### PR TITLE
Fix sidebar in narrow browser windows

### DIFF
--- a/components/Sidebar/AppsSelector.react.js
+++ b/components/Sidebar/AppsSelector.react.js
@@ -67,11 +67,19 @@ export default class AppsSelector extends React.Component {
   }
 
   render() {
+    let position = this.state.position;
+    try {
+      //Workaround for an issue where the apps selector appears in the wrong place when the
+      //window is narrower than the sidebar break when opened.
+      position = Position.inWindow(ReactDOM.findDOMNode(this));
+    } catch (e) {
+      //Use the one from the state
+    }
     let popover = null;
     if (this.state.open) {
-      let height = window.innerHeight - this.state.position.y;
+      let height = window.innerHeight - position.y;
       popover = (
-        <Popover fixed={true} position={this.state.position} onExternalClick={this.close.bind(this)}>
+        <Popover fixed={true} position={position} onExternalClick={this.close.bind(this)}>
           <AppsMenu
             apps={this.props.apps}
             current={this.context.currentApp}


### PR DESCRIPTION
There was a bug causing the apps selector to appear off the screen. This is a terrible workaround, but the whole sidebar implementation was terrible from the start anyway.
