### PR TITLE
Remove security editor from browser

### DIFF
--- a/dashboard/Data/Browser/BrowserToolbar.react.js
+++ b/dashboard/Data/Browser/BrowserToolbar.react.js
@@ -39,6 +39,7 @@ let BrowserToolbar = ({
 
   enableDeleteAllRows,
   enableExportClass,
+  enableSecurityDialog,
 }) => {
   let selectionLength = Object.keys(selection).length;
   let details = [];
@@ -108,14 +109,14 @@ let BrowserToolbar = ({
         filters={filters}
         onChange={onFilterChange} />
       <div className={styles.toolbarSeparator} />
-      <SecurityDialog
+      {enableSecurityDialog ? <SecurityDialog
         setCurrent={setCurrent}
         disabled={!!relation}
         perms={perms}
         className={classNameForPermissionsEditor}
         updateCLP={updateCLP}
-        userPointers={userPointers} />
-      <div className={styles.toolbarSeparator} />
+        userPointers={userPointers} /> : <noscript />}
+      {enableSecurityDialog ? <div className={styles.toolbarSeparator} /> : <noscript/>}
       {menu}
     </Toolbar>
   );

--- a/dashboard/Data/Browser/DataBrowser.react.js
+++ b/dashboard/Data/Browser/DataBrowser.react.js
@@ -198,6 +198,7 @@ export default class DataBrowser extends React.Component {
           setCurrent={this.setCurrent.bind(this)}
           enableDeleteAllRows={this.context.currentApp.enabledFeatures.schemas.clearAllDataFromClass}
           enableExportClass={this.context.currentApp.enabledFeatures.schemas.exportClass}
+          enableSecurityDialog={false /* this will eventually come from the enabledFeatures object, format TBD */}
           {...other}/>
       </div>
     );


### PR DESCRIPTION
I think we would want this to be part of the `schemas` part of the `enabledFeatures` object, but there is also CLPs vs Pointer Permissions so it's not as simple as the other cases. So punt on it for now, we can change this when we actually go to add stuff to the Parse Server schemas API.
