### PR TITLE
Update parse SDK to 1.9.1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "js-beautify": "~1.5.0",
     "marked": "^0.3.5",
     "node-sass": "^3.7.0",
-    "parse": "1.6.14",
+    "parse": "1.9.1",
     "prismjs": "~1.2.0",
     "react": "^15.0.1",
     "react-addons-test-utils": "^15.0.1",

--- a/src/dashboard/Dashboard.js
+++ b/src/dashboard/Dashboard.js
@@ -163,8 +163,8 @@ class Dashboard extends React.Component {
         }
       });
       return Parse.Promise.when(appInfoPromises);
-    }).then(function() {
-      Array.prototype.slice.call(arguments).forEach(app => {
+    }).then(function(resolvedApps) {
+      resolvedApps.forEach(app => {
         AppsManager.addApp(app);
       });
       this.setState({ configLoadingState: AsyncStatus.SUCCESS });


### PR DESCRIPTION
The specific issue this fixes for us is https://github.com/ParsePlatform/Parse-SDK-JS/issues/311.

I've only done smoke testing of this fix, but will be deploying it to our staging instance today and will update if I run into any issues.