### PR TITLE
Push schedule

### DIFF
--- a/src/dashboard/Push/PushDetails.react.js
+++ b/src/dashboard/Push/PushDetails.react.js
@@ -30,6 +30,7 @@ import subscribeTo            from 'lib/subscribeTo';
 import tableStyles            from 'components/Table/Table.scss';
 import Toggle                 from 'components/Toggle/Toggle.react';
 import Toolbar                from 'components/Toolbar/Toolbar.react';
+import Button                 from 'components/Button/Button.react';
 import { Directions }         from 'lib/Constants';
 import { Link }               from 'react-router';
 import { Promise }            from 'parse';
@@ -45,12 +46,46 @@ let getMessage = (payload) => {
   return '';
 }
 
+let getScheduleStatus = (status) => {
+  return status == "scheduled";
+}
+
 let getFormattedTime = ({ time, is_local }) => {
   let formattedTime = DateUtils.yearMonthDayTimeFormatter(new Date(time), !is_local);
   if(is_local){
     formattedTime += ' Local Time'
   }
   return formattedTime;
+}
+
+let getScheduleInfo = (sendTime, expiration) => {
+  //expiration unit is in seconds :(
+  if (!sendTime){
+    return '';
+  }
+
+  let fmtSendTime = getFormattedTime({time: sendTime});
+  let fmtExpiration = expiration ? getFormattedTime({time: expiration * 1000}) : null;
+  if (expiration){
+    return `Sent ${fmtSendTime} and expires ${fmtExpiration}`;
+  } else {
+    return `Sent ${fmtSendTime}`;
+  }
+}
+
+let getSentScheduleInfo = (sendTime, expiration) => {
+  //expiration unit is in seconds :(
+  if (!sendTime){
+    return '';
+  }
+
+  let fmtSendTime = getFormattedTime({time: sendTime});
+  let fmtExpiration = expiration ? getFormattedTime({time: expiration * 1000}) : null;
+  if (expiration){
+    return `It will be sent ${fmtSendTime} and expires ${fmtExpiration}`;
+  } else {
+    return `It will be sent ${fmtSendTime}`;
+  }
 }
 
 let getSentInfo = (sendTime, expiration) => {
@@ -512,27 +547,53 @@ export default class PushDetails extends DashboardView {
         </div>
       );
     } else {
-      res = (
-        <div>
-          <div className={styles.groupHeader}>
-            <div className={styles.headerTitle}>MESSAGE SENT</div>
-            <div className={styles.headline}>{getMessage(pushDetails.get('payload'))}</div>
-            <div className={styles.subline}>
-              {getSentInfo(pushDetails.get('pushTime'), pushDetails.get('expiration'))}
+      if(getScheduleStatus(pushDetails.get('status'))) {
+        res = (<div className={styles.groupHeader}>
+                  <div className={styles.headerTitle}>MESSAGE SCHEDULED</div>
+                  <div className={styles.headline}>{getMessage(pushDetails.get('payload'))}</div>
+                  <div className={styles.subline}>
+                      {getSentScheduleInfo(pushDetails.get('pushTime'), pushDetails.get('expiration'))}
+                  </div>
+                  <div className={styles.headline}>
+                    <Button
+                      value='Cancel schedule'
+                      primary={true}
+                      onClick={() => {
+                          let promise = this.context.currentApp.cancelPushSchedule(this.state.pushDetails.id);
+                          promise.then((push) => {
+                            push.destroy({ useMasterKey: true }).then(() => {
+                              history.push(this.context.generatePath('push/activity'));
+                            });
+                          });
+                      }}>
+                    </Button>
+                  </div>
+              </div>
+          );
+      } else {
+        res = (
+          <div>
+            <div className={styles.groupHeader}>
+                <div className={styles.headerTitle}>MESSAGE SENT</div>
+                <div className={styles.headline}>{getMessage(pushDetails.get('payload'))}</div>
+                <div className={styles.subline}>
+                    {getSentInfo(pushDetails.get('pushTime'), pushDetails.get('expiration'))}
+                </div>
             </div>
+            {prevLaunchGroup}
+            {experimentInfo}
+            <PushOpenRate
+              numOpened={pushDetails.get('numOpened') || 0}
+              numSent={pushDetails.get('numSent')}
+              customColor={this.state.standardColor} />
           </div>
-          {prevLaunchGroup}
-          {experimentInfo}
-          <PushOpenRate
-            numOpened={pushDetails.get('numOpened') || 0}
-            numSent={pushDetails.get('numSent')}
-            customColor={this.state.standardColor} />
-        </div>
-      );
+        );
+      }
     }
 
     return res;
   }
+
 
   renderAnalytics() {
     if (Object.keys(this.state.chartData).length > 0) {

--- a/src/dashboard/Push/PushIndex.react.js
+++ b/src/dashboard/Push/PushIndex.react.js
@@ -49,6 +49,7 @@ const PUSH_STATUS_COLOR = {
   failed: 'red',
   pending: 'blue',
   running: 'blue',
+  scheduled: 'blue',
 };
 
 const PUSH_STATUS_CONTENT = {
@@ -56,6 +57,7 @@ const PUSH_STATUS_CONTENT = {
   failed: 'FAILED',
   pending: 'SENDING',
   running: 'SENDING',
+  scheduled: 'SCHEDULED',
 };
 
 const EXPERIMENT_GROUP = {

--- a/src/dashboard/Push/PushIndex.scss
+++ b/src/dashboard/Push/PushIndex.scss
@@ -20,7 +20,7 @@
 }
 
 .colName {
-  width: 30%;
+  width: 25%;
 }
 
 .colTime {
@@ -28,7 +28,7 @@
 }
 
 .colStatus {
-  width: 10%;
+  width: 15%;
 }
 
 .experimentLabel, .localTimeLabel, .translationLabel {

--- a/src/lib/ParseApp.js
+++ b/src/lib/ParseApp.js
@@ -403,6 +403,35 @@ export default class ParseApp {
     return query.first({ useMasterKey: true });
   }
 
+  cancelPushSchedule(objectId) {
+    var query = new Parse.Query("_PushStatus");
+    query.equalTo('objectId', objectId);
+    return query.first({ useMasterKey: true });
+  }
+
+  schedulePush(changes) {
+    var pushTime = changes.push_time_iso.toISOString();
+    var query = changes.target;
+    let payload = changes.data_type === 'json' ? JSON.parse(changes.data) : { alert: changes.data };
+    if(query == undefined) {
+      query = "{}";
+    } else {
+      query = JSON.stringify(query);
+    }
+
+    let PushStatus = Parse.Object.extend("_PushStatus");
+    let pushStatus = new PushStatus();
+    pushStatus.set("query", query);
+    pushStatus.set("payload", JSON.stringify(payload));
+    pushStatus.set("pushTime", pushTime);
+    pushStatus.set("numSent", 0);
+    pushStatus.set("numFailed", 0);
+    pushStatus.set("status", "scheduled");
+    pushStatus.set("source", "rest");
+    pushStatus.setACL(new Parse.ACL());
+    return pushStatus.save(null, { useMasterKey: true });
+  }
+
   isLocalizationAvailable() {
     let path = '/apps/' + this.slug + '/is_localization_available';
     return AJAX.abortableGet(path);


### PR DESCRIPTION
This is an attempt to introduce the concept of push schedule in Parse
Dashboard.

What's in there?

- Push schedule and cancelation

By default all scheduled messages will be saved in the _PushStatus
collection with a "scheduled" status. You will be able to cancel them
directly from the Dashboard.

NOTICE: You will need a new adapter or a cron to dispatch all scheduled
messages stored in _PushStatus collection.