### PR TITLE
Use slim docker image + only print >warning on npm i

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:4.4.2
+FROM node:argon-slim
+ENV NPM_CONFIG_LOGLEVEL error
 WORKDIR /src
 ADD . /src
 RUN cd /src \


### PR DESCRIPTION
Specifying the image as argon-slim has two benefits:

 - Reduce overall size of image
 - Keep up to date with regards to node 4.x

We also want to set the npm log level from info to error so that it doesn't spew output while building.