### PR TITLE
Added/fixed a filtering option "contains string" for String fields.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### NEXT RELEASE
 
 * _Contributing to this repo? Add info about your change here to be included in next release_
+* Improvement: Added/fixed a filtering option "contains string" for String fields. Case insensitive for now.
 
 ### 1.0.27
 * Improvement: Show notifications upon success or failure of save and delete objects (#718), thanks to [Natan Rolnik](https://github.com/natanrolnik)

--- a/src/lib/Filters.js
+++ b/src/lib/Filters.js
@@ -48,6 +48,11 @@ export const Constraints = {
   ends: {
     name: 'ends with',
   },
+  stringContainsString: {
+    name: 'string contains string',
+    field: 'String',
+    composable: true,
+  },
   before: {
     name: 'is before',
     field: 'Date',
@@ -92,7 +97,7 @@ export const FieldConstraints = {
   'Pointer': [ 'exists', 'dne', 'eq', 'neq'],
   'Boolean': [ 'exists', 'dne', 'eq' ],
   'Number': [ 'exists', 'dne', 'eq', 'neq', 'lt', 'lte', 'gt', 'gte' ],
-  'String': [ 'exists', 'dne', 'eq', 'neq', 'starts', 'ends', 'containsString' ],
+  'String': [ 'exists', 'dne', 'eq', 'neq', 'starts', 'ends', 'stringContainsString' ],
   'Date': [ 'exists', 'dne', 'before', 'after' ],
   'Array': [
     'exists',

--- a/src/lib/Filters.js
+++ b/src/lib/Filters.js
@@ -92,7 +92,7 @@ export const FieldConstraints = {
   'Pointer': [ 'exists', 'dne', 'eq', 'neq'],
   'Boolean': [ 'exists', 'dne', 'eq' ],
   'Number': [ 'exists', 'dne', 'eq', 'neq', 'lt', 'lte', 'gt', 'gte' ],
-  'String': [ 'exists', 'dne', 'eq', 'neq', 'starts', 'ends' ],
+  'String': [ 'exists', 'dne', 'eq', 'neq', 'starts', 'ends', 'containsString' ],
   'Date': [ 'exists', 'dne', 'before', 'after' ],
   'Array': [
     'exists',

--- a/src/lib/queryFromFilters.js
+++ b/src/lib/queryFromFilters.js
@@ -60,6 +60,8 @@ function addConstraint(query, filter) {
       query.greaterThan(filter.get('field'), filter.get('compareTo'));
       break;
     case 'containsString':
+      query.matches(filter.get('field'), filter.get('compareTo'), 'i');
+      break;
     case 'containsNumber':
       query.equalTo(filter.get('field'), filter.get('compareTo'));
       break;

--- a/src/lib/queryFromFilters.js
+++ b/src/lib/queryFromFilters.js
@@ -60,8 +60,6 @@ function addConstraint(query, filter) {
       query.greaterThan(filter.get('field'), filter.get('compareTo'));
       break;
     case 'containsString':
-      query.matches(filter.get('field'), filter.get('compareTo'), 'i');
-      break;
     case 'containsNumber':
       query.equalTo(filter.get('field'), filter.get('compareTo'));
       break;
@@ -71,6 +69,9 @@ function addConstraint(query, filter) {
       break;
     case 'containedIn':
       query.containedIn(filter.get('field'), filter.get('array'));
+      break;
+    case 'stringContainsString':
+      query.matches(filter.get('field'), filter.get('compareTo'), 'i');
       break;
   }
   return query;


### PR DESCRIPTION
There are options "startsWith" and "endsWith" in the filter input for string fields, but "contains string" option is for some reason missing, so I made this change. In my opinion it is pretty important feature for people who use dashboard to browse their parse data.

It does filtering case insensitively for now. Could maybe add later a checkbox for selecting case sensitivity.

<img width="599" alt="screen shot 2017-06-12 at 14 13 34" src="https://user-images.githubusercontent.com/1568063/27034159-a3a0ad0e-4f7c-11e7-9a90-7bd46ba58bc0.png">
