### PR TITLE
Restore jobs scheduling interface and capabilities

### DIFF
--- a/src/dashboard/Data/Jobs/Jobs.react.js
+++ b/src/dashboard/Data/Jobs/Jobs.react.js
@@ -27,7 +27,7 @@ import Toolbar         from 'components/Toolbar/Toolbar.react';
 
 let subsections = {
   all: 'All Jobs',
-  /*scheduled: 'Scheduled Jobs',*/
+  scheduled: 'Scheduled Jobs',
   status: 'Job Status'
 };
 
@@ -109,8 +109,8 @@ export default class Jobs extends TableView {
     let current = this.props.params.section || '';
     return (
       <CategoryList current={current} linkPrefix={'jobs/'} categories={[
-       /* { name: 'Scheduled Jobs', id: 'scheduled' }, */
         { name: 'All Jobs', id: 'all' },
+        { name: 'Scheduled Jobs', id: 'scheduled' },
         { name: 'Job Status', id: 'status' }
       ]} />
     );
@@ -225,7 +225,23 @@ export default class Jobs extends TableView {
 
   tableData() {
     let data = undefined;
-    if (this.props.params.section === 'scheduled' || this.props.params.section === 'all' ) {
+    if (this.props.params.section === 'all') {
+      if (this.props.availableJobs) {
+        data = this.props.availableJobs;
+      }
+      if (this.props.jobsInUse) {
+        if (data) {
+          data = data.concat(this.props.jobsInUse);
+        } else {
+          data = this.props.jobsInUse;
+        }
+      }
+      if (data) {
+        data = data.map((jobName) => {
+          return { jobName };
+        });
+      }
+    } else if (this.props.params.section === 'scheduled' ) {
       if (this.props.jobs.data) {
         let jobs = this.props.jobs.data.get('jobs');
         if (jobs) {

--- a/src/dashboard/Data/Jobs/JobsData.react.js
+++ b/src/dashboard/Data/Jobs/JobsData.react.js
@@ -29,7 +29,7 @@ export default class JobsData extends React.Component {
       () => this.setState({ release: null })
     );
   }
-
+  */
   fetchJobs(app) {
     app.getAvailableJobs().then(
       ({ jobs, in_use }) => {
@@ -43,17 +43,15 @@ export default class JobsData extends React.Component {
       }, () => this.setState({ jobs: [], inUse: [] })
     );
   }
-  */
 
   componentDidMount() {
-    // this.fetchJobs(this.context.currentApp);
+    this.fetchJobs(this.context.currentApp);
     // this.fetchRelease(this.context.currentApp);
   }
 
   componentWillReceiveProps(props, context) {
     if (this.context !== context) {
-      this.setState({ release: undefined, jobs: undefined, inUse: undefined });
-      // this.fetchJobs(context.currentApp);
+      this.fetchJobs(context.currentApp);
       // this.fetchRelease(context.currentApp);
     }
   }

--- a/src/lib/ParseApp.js
+++ b/src/lib/ParseApp.js
@@ -506,22 +506,26 @@ export default class ParseApp {
   }
 
   getAvailableJobs() {
-    let path = '/apps/' + this.slug + '/cloud_code/jobs/data';
-    return Parse._request('GET', path);
+    let path = 'cloud_code/jobs/data';
+    return this.apiRequest('GET', path, {}, { useMasterKey: true });
   }
 
   getJobStatus() {
-    // Cache it for a minute
+    // Cache it for a 30s
+    if (new Date() - this.jobStatus.lastFetched < 30000) {
+      return Parse.Promise.as(this.jobStatus.status);
+    }
     let query = new Parse.Query('_JobStatus');
     query.descending('createdAt');
     return query.find({ useMasterKey: true }).then((status) => {
+      status = status.map((jobStatus) => {
+        return jobStatus.toJSON();
+      });
       this.jobStatus = {
         status: status || null,
         lastFetched: new Date()
       };
-      return status.map((jobStatus) => {
-        return jobStatus.toJSON();
-      });
+      return status;
     });
   }
 

--- a/src/lib/stores/JobsStore.js
+++ b/src/lib/stores/JobsStore.js
@@ -5,7 +5,6 @@
  * This source code is licensed under the license found in the LICENSE file in
  * the root directory of this source tree.
  */
-import * as AJAX         from 'lib/AJAX';
 import keyMirror         from 'lib/keyMirror';
 import Parse             from 'parse';
 import { Map, List }     from 'immutable';
@@ -34,16 +33,16 @@ function JobsStore(state, action) {
         return Map({ lastFetch: new Date(), jobs: List(results) });
       });
     case ActionTypes.CREATE:
-      path = `/apps/${action.app.slug}/cloud_code/jobs`;
-      return AJAX.post(path, action.schedule).then((result) => {
+      path = `cloud_code/jobs`;
+      return Parse._request('POST', path, action.schedule, {useMasterKey: true}).then((result) => {
         let { ...schedule } = action.schedule.job_schedule;
         schedule.objectId = result.objectId;
         schedule.startAfter = schedule.startAfter || new Date().toISOString();
         return state.set('jobs', state.get('jobs').push(schedule));
       });
     case ActionTypes.EDIT:
-      path = `/apps/${action.app.slug}/cloud_code/jobs/${action.jobId}`;
-      return AJAX.put(path, action.updates).then(() => {
+      path = `cloud_code/jobs/${action.jobId}`;
+      return Parse._request('PUT', path, action.updates, {useMasterKey: true}).then(() => {
         let index = state.get('jobs').findIndex((j) => j.objectId === action.jobId);
         let current = state.get('jobs').get(index);
         let { ...update } = action.updates.job_schedule;
@@ -52,8 +51,8 @@ function JobsStore(state, action) {
         return state.set('jobs', state.get('jobs').set(index, update));
       });
     case ActionTypes.DELETE:
-      path = `/apps/${action.app.slug}/cloud_code/jobs/${action.jobId}`;
-      return AJAX.del(path).then(() => {
+      path = `cloud_code/jobs/${action.jobId}`;
+      return Parse._request('DELETE', path, {}, {useMasterKey: true}).then(() => {
         let index = state.get('jobs').findIndex((j) => j.objectId === action.jobId);
         return state.set('jobs', state.get('jobs').delete(index));
       }, () => {


### PR DESCRIPTION
This goes side by side with https://github.com/parse-community/parse-server/pull/3927

This restores the `Scheduled Jobs` section, keeps the `All Jobs` to run them manually, modernizes the network calls by using Parse._request instead of AJAX.