### PR TITLE
Fix display bug on safari when table has empty cells ('')

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### NEXT RELEASE
 
 * _Contributing to this repo? Add info about your change here to be included in next release_
+* Fix: Display bug on safari when table has empty cells ('')
 
 ### 1.0.28
 * Feature: Add ability to search Object columns (#727), thanks to [Samuli Siivinen](https://github.com/ssamuli)

--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -29,6 +29,9 @@ let BrowserCell = ({ type, value, hidden, width, current, onSelect, onEditChange
   } else if (value === null) {
     content = '(null)';
     classes.push(styles.empty);
+  } else if (value === '') {
+    content = <span>&nbsp;</span>;
+    classes.push(styles.empty);
   } else if (type === 'Pointer') {
     content = (
       <a href='javascript:;' onClick={onPointerClick.bind(undefined, value)}>


### PR DESCRIPTION
The tables look broken on Safari when there are empty cells:

<img width="1553" alt="screen shot 2017-06-14 at 18 06 36" src="https://user-images.githubusercontent.com/1568063/27142813-92144440-512c-11e7-9c13-abe45811edd5.png">

And after this patch:

<img width="1555" alt="screen shot 2017-06-14 at 18 07 00" src="https://user-images.githubusercontent.com/1568063/27142844-a8de6264-512c-11e7-8ce7-da0ca6bdbebe.png">
