### PR TITLE
Updated iOS alert object to display title and body detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Feature: When editing Object or Array fields the data is displayed in a prettier format and the textarea is resizable
 * Fix: Display bug on safari when table has empty cells ('')
 * Feature: UI for managing push audiences, thanks to [Davi Macedo](https://github.com/davimacedo)
+* Fix: Addresses issue related to displaying iOS alert object containing title and body keys (#539), thanks to [Robert Martin del Campo](https://github.com/repertus)
 
 ### 1.0.28
 * Feature: Add ability to search Object columns (#727), thanks to [Samuli Siivinen](https://github.com/ssamuli)

--- a/src/dashboard/Push/PushDetails.react.js
+++ b/src/dashboard/Push/PushDetails.react.js
@@ -39,7 +39,13 @@ const EXP_STATS_URL = 'http://docs.parseplatform.org/ios/guide/#push-experiments
 let getMessage = (payload) => {
   if(payload) {
     let payloadJSON = JSON.parse(payload);
-    return payloadJSON.alert ? payloadJSON.alert : payload;
+		if (payloadJSON.alert.body) {
+			return payloadJSON.alert.body;
+		} else if (payloadJSON.alert) {
+			return payloadJSON.alert;
+		} else {
+			return payload;
+		}
   }
   return '';
 }

--- a/src/dashboard/Push/PushDetails.react.js
+++ b/src/dashboard/Push/PushDetails.react.js
@@ -522,7 +522,7 @@ export default class PushDetails extends DashboardView {
 							{
 								(typeof alert === 'object') ?
 									<div>
-								 		<div className={styles.headline}>{alert.title}</div>
+										<div className={styles.headline}>{alert.title}</div>
 										<div className={styles.headline}>{alert.body}</div>
 									</div>:
 									<div className={styles.headline}>{alert}</div>

--- a/src/dashboard/Push/PushDetails.react.js
+++ b/src/dashboard/Push/PushDetails.react.js
@@ -467,6 +467,7 @@ export default class PushDetails extends DashboardView {
     let isMessageType = pushDetails.exp_type === 'message';
     let res = null;
     let prevLaunchGroup = null;
+		let alert = getMessage(pushDetails.get('payload'));
 
     if (pushDetails && pushDetails.experiment_push_id) {
       prevLaunchGroup = (
@@ -518,7 +519,14 @@ export default class PushDetails extends DashboardView {
         <div>
           <div className={styles.groupHeader}>
             <div className={styles.headerTitle}>MESSAGE SENT</div>
-            <div className={styles.headline}>{getMessage(pushDetails.get('payload'))}</div>
+							{
+								(typeof alert === 'object') ?
+									<div>
+								 		<div className={styles.headline}>{alert.title}</div>
+										<div className={styles.headline}>{alert.body}</div>
+									</div>:
+									<div className={styles.headline}>{alert}</div>
+							}
             <div className={styles.subline}>
               {getSentInfo(pushDetails.get('pushTime'), pushDetails.get('expiration'))}
             </div>

--- a/src/dashboard/Push/PushIndex.react.js
+++ b/src/dashboard/Push/PushIndex.react.js
@@ -137,6 +137,8 @@ let getPushName = (pushData) => {
     if (typeof payload === 'object') {
       if (typeof payload.alert === 'string') {
         return payload.alert;
+			} else if (typeof payload.alert === 'object' && payload.alert.title !== undefined) {
+				return payload.alert.title;
       }
       return payload.alert ? JSON.stringify(payload.alert) : JSON.stringify(payload);
     } else {


### PR DESCRIPTION
This fix addresses the issue outlined in #539 by being able to now render the title and body keys from the alert object.