### PR TITLE
Scheduled jobs message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### NEXT RELEASE
 
 * _Contributing to this repo? Add info about your change here to be included in next release_
+* Fix: Added on the empty Scheduled Jobs page a message that notifies about jobs not being run by parse-server but requires further setup
 * Feature: When editing Object or Array fields the data is displayed in a prettier format and the textarea is resizable
 * Fix: Display bug on safari when table has empty cells ('')
 * Feature: UI for managing push audiences, thanks to [Davi Macedo](https://github.com/davimacedo)

--- a/src/dashboard/Data/Jobs/Jobs.react.js
+++ b/src/dashboard/Data/Jobs/Jobs.react.js
@@ -192,7 +192,18 @@ export default class Jobs extends TableView {
       return (
         <EmptyState
           title='Cloud Jobs'
-          description='Scheduling jobs is not supported on parse-server'
+          description=
+            <div>
+              <p>{'On this page you can create JobSchedule objects.'}</p>
+              <br/>
+              <p>
+                {"Be noted that "}
+                <b>{"parse-server doesn't schedule or run them. "}</b>
+                {"Please take a look at the "}
+                <a href="http://docs.parseplatform.org/parse-server/guide/#jobs">{'docs'}</a>
+                {" on how to do that."}
+              </p>
+            </div>
           icon='cloud-happy' />
       );
     } else {


### PR DESCRIPTION
Added on the empty Scheduled Jobs page a message that notifies about jobs not being run by parse-server but requires further setup.

<img width="987" alt="screen shot 2017-07-04 at 09 32 10" src="https://user-images.githubusercontent.com/1568063/27819718-d3ccbdbc-609b-11e7-9d23-6fc503d1b0ef.png">
