### PR TITLE
fix filter for negative and empty number input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### NEXT RELEASE
 
 * _Contributing to this repo? Add info about your change here to be included in next release_
+* Fix: NaN displayed when filter input is empty or negative number (#749), thanks to [Miguel Serrrano](https://github.com/miguel-s)
 
 ### 1.1.0
 

--- a/src/components/BrowserFilter/FilterRow.react.js
+++ b/src/components/BrowserFilter/FilterRow.react.js
@@ -49,7 +49,18 @@ function compareValue(info, value, onChangeCompareTo, active) {
     case 'Boolean':
       return <ChromeDropdown color={active ? 'blue' : 'purple'} value={value ? 'True' : 'False'} options={['True', 'False']} onChange={(val) => onChangeCompareTo(val === 'True')} />;
     case 'Number':
-      return <input type='text' value={value} onChange={(e) => onChangeCompareTo(validateNumeric(e.target.value) ? parseFloat(e.target.value) : (parseFloat(value) || ''))} />;
+      return (
+        <input
+          type='text'
+          value={value}
+          onChange={(e) => {
+            let val = value;
+            if (!e.target.value.length) val = '';
+            else if (e.target.value.length === 1) val = validateNumeric(e.target.value) ? e.target.value : value;
+            else val = validateNumeric(e.target.value) ? parseFloat(e.target.value) : value;
+            onChangeCompareTo(val);
+          }} />
+      );
     case 'Date':
       return (
         <DateTimeEntry

--- a/src/components/BrowserFilter/FilterRow.react.js
+++ b/src/components/BrowserFilter/FilterRow.react.js
@@ -55,9 +55,13 @@ function compareValue(info, value, onChangeCompareTo, active) {
           value={value}
           onChange={(e) => {
             let val = value;
-            if (!e.target.value.length) val = '';
-            else if (e.target.value.length === 1) val = validateNumeric(e.target.value) ? e.target.value : value;
-            else val = validateNumeric(e.target.value) ? parseFloat(e.target.value) : value;
+            if (!e.target.value.length) {
+              val = '';
+            } else if (e.target.value.length === 1) {
+              val = validateNumeric(e.target.value) ? e.target.value : value;
+            } else {
+              val = validateNumeric(e.target.value) ? parseFloat(e.target.value) : value;
+            }
             onChangeCompareTo(val);
           }} />
       );


### PR DESCRIPTION
Contributing to #557

Fixes two bugs with number input in filters:
- when input has a negative number (to reproduce in master: typing a "-" char will lead to "NaN" being displayed)
- when input is empty (to reproduce in master: typing a valid number and deleting with backspace will lead to "NaN" being displayed)