### PR TITLE
Updating array of Dates no longer converts it to array of strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### NEXT RELEASE
 
 * _Contributing to this repo? Add info about your change here to be included in next release_
+* Fix: Updating array of Dates now keeps it's type (was changing to array of ISO strings, issue #590), thanks to [David Riha](https://github.com/rihadavid)
 * Fix: NaN displayed when filter input is empty or negative number (#749), thanks to [Miguel Serrrano](https://github.com/miguel-s)
 * Fix: Addresses issue related to displaying iOS alert object containing title and body keys (#539), thanks to [Robert Martin del Campo](https://github.com/repertus)
 

--- a/src/dashboard/Data/Browser/BrowserTable.react.js
+++ b/src/dashboard/Data/Browser/BrowserTable.react.js
@@ -201,7 +201,15 @@ export default class BrowserTable extends React.Component {
             value = '';
           } else if (type === 'Array') {
             if (value) {
-              value = value.map(val => val instanceof Parse.Object ? val.toPointer() : (typeof val.getMonth === 'function' ? { __type: "Date", iso: val.toISOString() } : val));
+              value = value.map(val => {
+                  if (val instanceof Parse.Object) {
+                      return val.toPointer();
+                  } else if (typeof val.getMonth === 'function') {
+                      return { __type: "Date", iso: val.toISOString() };
+                  }
+
+                  return val;
+              });
             }
           }
           let wrapTop = Math.max(0, this.props.current.row * ROW_HEIGHT);

--- a/src/dashboard/Data/Browser/BrowserTable.react.js
+++ b/src/dashboard/Data/Browser/BrowserTable.react.js
@@ -201,7 +201,7 @@ export default class BrowserTable extends React.Component {
             value = '';
           } else if (type === 'Array') {
             if (value) {
-              value = value.map(val => val instanceof Parse.Object ? val.toPointer() : val);
+              value = value.map(val => val instanceof Parse.Object ? val.toPointer() : (typeof val.getMonth === 'function' ? { __type: "Date", iso: val.toISOString() } : val));
             }
           }
           let wrapTop = Math.max(0, this.props.current.row * ROW_HEIGHT);


### PR DESCRIPTION
This PR fixes issue #590  (but does not fix issue #756 )

It might not be the best solution (the problem might be deeper in the system), but it is a 
one-line workaround that just does what is needed and prevents dashboard users from creating fatal damage to their Date arrays just by opening the field and losing focus thus saving changes.

![datearray](https://user-images.githubusercontent.com/15065185/30102063-b6ecd562-92ee-11e7-8752-238cfa728412.png)

BTW: I had troubles running the jest tests on windows, spend a few hours figuring out how to do it but I was not able to. It really drives me crazy. Could someone please try it on windows and update CONTRIBUTING.md with info how to do it? First I was getting `'NODE_PATH' is not recognized as an internal or external command`, then I found out I need to do some changes in package.json:
```
"build": "SET NODE_ENV=production && webpack --config webpack/production.config.js && webpack --config webpack/PIG.config.js",
    "test": "SET NODE_PATH=./node_modules && jest",
```
..and maybe also setting windows NODE_PATH environment variable and running `npm install jest` was needed, I don't know what exactly was needed, tried a lot of things. But then I ended up on 
```
Using Jest CLI v12.1.1, jasmine2
No tests found for "".
```
and I was not able to solve this issue. So the PR is not tested, can someone please do it?

