### PR TITLE
Support push time, expiration time, and expiration interval

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "webpack": "~1.12.0"
   },
   "scripts": {
-    "dev": "node ./Parse-Dashboard/index.js --config=config.json & webpack --config webpack/build.config.js --devtool eval-source-map --progress --watch",
+    "dev": "node ./Parse-Dashboard/index.js & webpack --config webpack/build.config.js --devtool eval-source-map --progress --watch",
     "dashboard": "node ./Parse-Dashboard/index.js & webpack --config webpack/build.config.js --progress --watch",
     "pig": "http-server ./PIG -p 4041 -s & webpack --config webpack/PIG.config.js --progress --watch",
     "build": "NODE_ENV=production webpack --config webpack/production.config.js && webpack --config webpack/PIG.config.js",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "webpack": "~1.12.0"
   },
   "scripts": {
-    "dev": "node ./Parse-Dashboard/index.js & webpack --config webpack/build.config.js --devtool eval-source-map --progress --watch",
+    "dev": "node ./Parse-Dashboard/index.js --config=config.json & webpack --config webpack/build.config.js --devtool eval-source-map --progress --watch",
     "dashboard": "node ./Parse-Dashboard/index.js & webpack --config webpack/build.config.js --progress --watch",
     "pig": "http-server ./PIG -p 4041 -s & webpack --config webpack/PIG.config.js --progress --watch",
     "build": "NODE_ENV=production webpack --config webpack/production.config.js && webpack --config webpack/PIG.config.js",

--- a/src/dashboard/Push/PushNew.react.js
+++ b/src/dashboard/Push/PushNew.react.js
@@ -39,7 +39,6 @@ import { Directions }          from 'lib/Constants';
 import { Promise }             from 'parse';
 
 const PARSE_SERVER_SUPPORTS_AB_TESTING = false;
-const PARSE_SERVER_SUPPORTS_SCHEDULE_PUSH = false;
 
 let formatErrorMessage = (emptyInputMessages, key) => {
   let boldMessages = emptyInputMessages.map((message) => {
@@ -677,18 +676,21 @@ export default class PushNew extends DashboardView {
       {this.renderExperimentContent(fields, setField)}
     </Fieldset> : null;
 
-    const timeFieldsLegend = PARSE_SERVER_SUPPORTS_SCHEDULE_PUSH ?
-      'Choose a delivery time' :
-      'Choose exiry';
+    const {push} = this.context.currentApp.serverInfo.features;
+    const hasScheduledPushSupport = push && push.scheduledPush;
 
-    const timeFieldsDescription = PARSE_SERVER_SUPPORTS_SCHEDULE_PUSH ?
+    const timeFieldsLegend = hasScheduledPushSupport ?
+      'Choose a delivery time' :
+      'Choose expiry';
+
+    const timeFieldsDescription = hasScheduledPushSupport ?
       'We can send the campaign immediately, or any time in the next 2 weeks.' :
       "If your push hasn't been send by this time, it won't get sent.";
 
-    const deliveryTimeFields = PARSE_SERVER_SUPPORTS_SCHEDULE_PUSH ? <Fieldset
+    const deliveryTimeFields = hasScheduledPushSupport ? <Fieldset
       legend={timeFieldsLegend}
       description={timeFieldsDescription}>
-      {PARSE_SERVER_SUPPORTS_SCHEDULE_PUSH ? this.renderDeliveryContent(fields, setField) : null}
+      {hasScheduledPushSupport ? this.renderDeliveryContent(fields, setField) : null}
       <Field
         label={<Label text='Should this notification expire?' />}
         input={<Toggle value={fields.push_expires} onChange={setField.bind(null, 'push_expires')} />} />

--- a/src/dashboard/Push/PushNew.react.js
+++ b/src/dashboard/Push/PushNew.react.js
@@ -37,7 +37,7 @@ import Toggle                  from 'components/Toggle/Toggle.react';
 import Toolbar                 from 'components/Toolbar/Toolbar.react';
 import { Directions }          from 'lib/Constants';
 import { Promise }             from 'parse';
-import { extractExpirationTime, extractPushTime } from 'lib/extractTime';
+import { extractExpiration, extractPushTime } from 'lib/extractTime';
 
 const PARSE_SERVER_SUPPORTS_AB_TESTING = false;
 
@@ -207,8 +207,8 @@ export default class PushNew extends DashboardView {
       data: payload,
       where: changes.target || new Parse.Query(Parse.Installation),
       push_time,
-      expiration_time: extractExpirationTime(changes, push_time),
     };
+    Object.assign(body, extractExpiration(changes));
 
     let audience_id = changes.audience_id;
     // Only set the audience ID if it is a saved audience.

--- a/src/dashboard/Push/PushNew.react.js
+++ b/src/dashboard/Push/PushNew.react.js
@@ -204,6 +204,7 @@ export default class PushNew extends DashboardView {
 
     const push_time = extractPushTime(changes);
     let body = {
+      data: payload,
       where: changes.target || new Parse.Query(Parse.Installation),
       push_time,
       expiration_time: extractExpirationTime(changes, push_time),

--- a/src/dashboard/Push/PushNew.react.js
+++ b/src/dashboard/Push/PushNew.react.js
@@ -37,7 +37,7 @@ import Toggle                  from 'components/Toggle/Toggle.react';
 import Toolbar                 from 'components/Toolbar/Toolbar.react';
 import { Directions }          from 'lib/Constants';
 import { Promise }             from 'parse';
-import {extractExpirationTime, extractPushTime} from "../../lib/extractTime";
+import { extractExpirationTime, extractPushTime } from 'lib/extractTime';
 
 const PARSE_SERVER_SUPPORTS_AB_TESTING = false;
 

--- a/src/dashboard/Push/PushNew.react.js
+++ b/src/dashboard/Push/PushNew.react.js
@@ -37,6 +37,7 @@ import Toggle                  from 'components/Toggle/Toggle.react';
 import Toolbar                 from 'components/Toolbar/Toolbar.react';
 import { Directions }          from 'lib/Constants';
 import { Promise }             from 'parse';
+import {extractExpirationTime, extractPushTime} from "../../lib/extractTime";
 
 const PARSE_SERVER_SUPPORTS_AB_TESTING = false;
 
@@ -201,10 +202,13 @@ export default class PushNew extends DashboardView {
       payload.badge = "Increment";
     }
 
+    const push_time = extractPushTime(changes);
     let body = {
       where: changes.target || new Parse.Query(Parse.Installation),
-      data: payload
-    }
+      push_time,
+      expiration_time: extractExpirationTime(changes, push_time),
+    };
+
     let audience_id = changes.audience_id;
     // Only set the audience ID if it is a saved audience.
     if (audience_id != PushConstants.NEW_SEGMENT_ID && audience_id != "everyone") {

--- a/src/dashboard/Push/PushNew.react.js
+++ b/src/dashboard/Push/PushNew.react.js
@@ -635,7 +635,7 @@ export default class PushNew extends DashboardView {
       legend='Choose your recipients.'
       description='Send to everyone, or use an audience to target the right users.'>
       <PushAudiencesData
-        loaded={true /* Parse Server doesn't support push audiences yet. once it does, pass: this.state.pushAudiencesFetched */}
+        loaded={this.state.pushAudiencesFetched}
         schema={schema}
         pushAudiencesStore={this.props.pushaudiences}
         current={fields.audience_id}

--- a/src/lib/extractTime.js
+++ b/src/lib/extractTime.js
@@ -1,0 +1,47 @@
+export function extractPushTime(changes) {
+  const {
+    local_time: isLocalTime,
+    push_time_type,
+    push_time,
+    push_time_iso,
+  } = changes;
+
+  if (push_time_type === 'time') {
+    if (isLocalTime) {
+      return push_time;
+    }
+    return push_time_iso;
+  }
+}
+
+export function extractExpirationTime(changes, extractedPushTime) {
+  const {
+    local_time: isLocalTime,
+    push_time_type,
+
+    push_expires,
+    expiration_time_type,
+    expiration_interval_unit,
+    expiration_interval_num,
+    expiration_time
+  } = changes;
+
+  let time;
+  if (push_expires) {
+    if (expiration_time_type === 'interval') {
+      time = parseInt(expiration_interval_num, 10);
+      if (expiration_interval_unit === 'hours') {
+        time *= 60 * 60;
+      } else if (expiration_interval_unit === 'days') {
+        time *= 60 * 60 * 24;
+      }
+
+      if (push_time_type === 'time' && !isLocalTime) {
+        time += Math.floor(Date.parse(extractedPushTime) / 1000);
+      }
+    } else if (expiration_time_type === 'time') {
+      time = expiration_time;
+    }
+  }
+  return time;
+}

--- a/src/lib/extractTime.js
+++ b/src/lib/extractTime.js
@@ -14,11 +14,8 @@ export function extractPushTime(changes) {
   }
 }
 
-export function extractExpirationTime(changes, extractedPushTime) {
+export function extractExpiration(changes) {
   const {
-    local_time: isLocalTime,
-    push_time_type,
-
     push_expires,
     expiration_time_type,
     expiration_interval_unit,
@@ -26,22 +23,20 @@ export function extractExpirationTime(changes, extractedPushTime) {
     expiration_time
   } = changes;
 
-  let time;
   if (push_expires) {
     if (expiration_time_type === 'interval') {
-      time = parseInt(expiration_interval_num, 10);
+      let time = parseInt(expiration_interval_num, 10);
       if (expiration_interval_unit === 'hours') {
         time *= 60 * 60;
       } else if (expiration_interval_unit === 'days') {
         time *= 60 * 60 * 24;
       }
 
-      if (push_time_type === 'time' && !isLocalTime) {
-        time += Math.floor(Date.parse(extractedPushTime) / 1000);
-      }
+      return { expiration_interval: time };
     } else if (expiration_time_type === 'time') {
-      time = expiration_time;
+      return { expiration_time };
     }
   }
-  return time;
+
+  return {};
 }

--- a/src/lib/extractTime.js
+++ b/src/lib/extractTime.js
@@ -16,6 +16,8 @@ export function extractPushTime(changes) {
 
 export function extractExpiration(changes) {
   const {
+    local_time: isLocalTime,
+    push_time,
     push_expires,
     expiration_time_type,
     expiration_interval_unit,
@@ -34,6 +36,13 @@ export function extractExpiration(changes) {
 
       return { expiration_interval: time };
     } else if (expiration_time_type === 'time') {
+      if (isLocalTime) {
+        const pushTime = new Date(push_time);
+        const expirationTime = new Date(expiration_time);
+        const diffSeconds = Math.floor((expirationTime - pushTime) / 1000);
+        return { expiration_interval: diffSeconds };
+      }
+
       return { expiration_time };
     }
   }

--- a/src/lib/tests/extractTime.test.js
+++ b/src/lib/tests/extractTime.test.js
@@ -277,9 +277,9 @@ describe('extractExpiration', () => {
         "expiration_time_iso": "2017-09-30T19:47:00.000Z"
       };
 
-      it('should return a relative date', () => {
-        const { expiration_time } = extractExpiration(changes);
-        expect(expiration_time).toBe('2017-09-30T15:47:00.000');
+      it('should return an expiration interval', () => {
+        const { expiration_interval } = extractExpiration(changes);
+        expect(expiration_interval).toBe(158820);
       });
     });
 

--- a/src/lib/tests/extractTime.test.js
+++ b/src/lib/tests/extractTime.test.js
@@ -1,0 +1,337 @@
+jest.dontMock('../extractTime');
+const {extractExpirationTime, extractPushTime} = require('../extractTime');
+
+describe('extractPushTime', () => {
+  describe('in user\'s timezone', () => {
+    it('should return without a timezone component', () => {
+      const push_time = extractPushTime({
+        "experiment_name": "",
+        "exp_size_in_percent": 50,
+        "push_time_type": "time",
+        "push_time": "2017-09-29T19:01:00.000",
+        "push_time_1": null,
+        "push_time_2": null,
+        "push_time_iso": "2017-09-29T23:01:00.000Z",
+        "push_time_1_iso": null,
+        "push_time_2_iso": null,
+        "deliveryTime": null,
+        "local_time": true,
+        "push_expires": false,
+        "expiration_time": null,
+        "expiration_time_type": "time",
+        "expiration_interval_num": "24",
+        "expiration_interval_unit": "hours",
+        "expirationInterval": null,
+        "exp_type": "message",
+        "exp_enable": null,
+        "increment_badge": null,
+        "audience_id": "new_segment",
+        "data": "adasdasd",
+        "data_type": "text",
+        "data1": "",
+        "data_type_1": "text",
+        "data2": "",
+        "data_type_2": "text",
+        "translation_enable": null,
+        "target": {
+          "where": {
+            "deviceType": {
+              "$in": [
+                "winrt"
+              ]
+            }
+          }
+        }
+      });
+
+      expect(push_time).toBe('2017-09-29T19:01:00.000');
+    });
+  });
+
+  describe('In absolute time', () => {
+    it('should return in UTC time', () => {
+      const push_time = extractPushTime({
+        "experiment_name": "",
+        "exp_size_in_percent": 50,
+        "push_time_type": "time",
+        "push_time": "2017-09-30T19:18:00.000Z",
+        "push_time_1": null,
+        "push_time_2": null,
+        "push_time_iso": "2017-09-30T19:18:00.000Z",
+        "push_time_1_iso": null,
+        "push_time_2_iso": null,
+        "deliveryTime": null,
+        "local_time": false,
+        "push_expires": false,
+        "expiration_time": null,
+        "expiration_time_type": "time",
+        "expiration_interval_num": "24",
+        "expiration_interval_unit": "hours",
+        "expirationInterval": null,
+        "exp_type": "message",
+        "exp_enable": null,
+        "increment_badge": null,
+        "audience_id": "everyone",
+        "data": "asdsadas",
+        "data_type": "text",
+        "data1": "",
+        "data_type_1": "text",
+        "data2": "",
+        "data_type_2": "text",
+        "translation_enable": null
+      });
+
+      expect(push_time).toBe('2017-09-30T19:18:00.000Z');
+    });
+  });
+});
+
+describe('extractExpirationTime', () => {
+  describe('With expiration interval', () => {
+    describe('In user\'s local timezone', () => {
+      const changes = {
+        "experiment_name": "",
+        "exp_size_in_percent": 50,
+        "push_time_type": "time",
+        "push_time": "2017-09-28T19:40:00.000",
+        "push_time_1": null,
+        "push_time_2": null,
+        "push_time_iso": "2017-09-28T23:40:00.000Z",
+        "push_time_1_iso": null,
+        "push_time_2_iso": null,
+        "deliveryTime": null,
+        "local_time": true,
+        "push_expires": true,
+        "expiration_time": null,
+        "expiration_time_type": "interval",
+        "expiration_interval_num": "3",
+        "expiration_interval_unit": "hours",
+        "expirationInterval": null,
+        "exp_type": "message",
+        "exp_enable": null,
+        "increment_badge": null,
+        "audience_id": "everyone",
+        "data": "asdsada",
+        "data_type": "text",
+        "data1": "",
+        "data_type_1": "text",
+        "data2": "",
+        "data_type_2": "text",
+        "translation_enable": null
+      };
+
+      it('should return a relative time in seconds', () => {
+        const push_time = extractPushTime(changes);
+        const expiration_time = extractExpirationTime(changes, push_time);
+
+        expect(expiration_time).toBe(3 * 60 * 60);
+      });
+    });
+
+    describe('In absolute time', () => {
+      const changes = {
+        "experiment_name": "",
+        "exp_size_in_percent": 50,
+        "push_time_type": "time",
+        "push_time": "2017-09-28T19:40:00.000Z",
+        "push_time_1": null,
+        "push_time_2": null,
+        "push_time_iso": "2017-09-28T19:40:00.000Z",
+        "push_time_1_iso": null,
+        "push_time_2_iso": null,
+        "deliveryTime": null,
+        "local_time": false,
+        "push_expires": true,
+        "expiration_time": null,
+        "expiration_time_type": "interval",
+        "expiration_interval_num": "3",
+        "expiration_interval_unit": "hours",
+        "expirationInterval": null,
+        "exp_type": "message",
+        "exp_enable": null,
+        "increment_badge": null,
+        "audience_id": "everyone",
+        "data": "asdsada",
+        "data_type": "text",
+        "data1": "",
+        "data_type_1": "text",
+        "data2": "",
+        "data_type_2": "text",
+        "translation_enable": null
+      };
+
+      it('should return a UTC time in seconds', () => {
+        const push_time = extractPushTime(changes);
+        const expiration_time = extractExpirationTime(changes, push_time);
+
+        expect(expiration_time).toBe(1506638400);
+        expect((new Date(expiration_time * 1000)).toISOString())
+          .toBe('2017-09-28T22:40:00.000Z');
+      });
+    });
+
+    describe('Sent immediately', () => {
+      const changes = {
+        "experiment_name": "",
+        "exp_size_in_percent": 50,
+        "push_time_type": "now",
+        "push_time": null,
+        "push_time_1": null,
+        "push_time_2": null,
+        "push_time_iso": null,
+        "push_time_1_iso": null,
+        "push_time_2_iso": null,
+        "deliveryTime": null,
+        "local_time": false,
+        "push_expires": true,
+        "expiration_time": null,
+        "expiration_time_type": "interval",
+        "expiration_interval_num": "24",
+        "expiration_interval_unit": "hours",
+        "expirationInterval": null,
+        "exp_type": "message",
+        "exp_enable": null,
+        "increment_badge": null,
+        "audience_id": "everyone",
+        "data": "asdsada",
+        "data_type": "text",
+        "data1": "",
+        "data_type_1": "text",
+        "data2": "",
+        "data_type_2": "text",
+        "translation_enable": null
+      };
+
+      it('should return 24 hours in seconds', () => {
+        const push_time = extractPushTime(changes);
+        const expiration_time = extractExpirationTime(changes, push_time);
+        expect(expiration_time).toBe(86400);
+      });
+    });
+  });
+
+  describe('With expiration date', () => {
+    describe('In user\'s local timezone', () => {
+      const changes = {
+        "experiment_name": "",
+        "exp_size_in_percent": 50,
+        "push_time_type": "time",
+        "push_time": "2017-09-28T19:40:00.000",
+        "push_time_1": null,
+        "push_time_2": null,
+        "push_time_iso": "2017-09-28T23:40:00.000Z",
+        "push_time_1_iso": null,
+        "push_time_2_iso": null,
+        "deliveryTime": null,
+        "local_time": true,
+        "push_expires": true,
+        "expiration_time": "2017-09-30T15:47:00.000",
+        "expiration_time_type": "time",
+        "expiration_interval_num": "3",
+        "expiration_interval_unit": "hours",
+        "expirationInterval": null,
+        "exp_type": "message",
+        "exp_enable": null,
+        "increment_badge": null,
+        "audience_id": "everyone",
+        "data": "asdsada",
+        "data_type": "text",
+        "data1": "",
+        "data_type_1": "text",
+        "data2": "",
+        "data_type_2": "text",
+        "translation_enable": null,
+        "expiration_time_iso": "2017-09-30T19:47:00.000Z"
+      };
+
+      it('should return a relative date', () => {
+        const push_time = extractPushTime(changes);
+        const expiration_time = extractExpirationTime(changes, push_time);
+
+        expect(expiration_time).toBe('2017-09-30T15:47:00.000');
+      });
+    });
+
+    describe('In absolute time', () => {
+      const changes = {
+        "experiment_name": "",
+        "exp_size_in_percent": 50,
+        "push_time_type": "time",
+        "push_time": "2017-09-28T19:40:00.000Z",
+        "push_time_1": null,
+        "push_time_2": null,
+        "push_time_iso": "2017-09-28T19:40:00.000Z",
+        "push_time_1_iso": null,
+        "push_time_2_iso": null,
+        "deliveryTime": null,
+        "local_time": false,
+        "push_expires": true,
+        "expiration_time": "2017-09-30T15:47:00.000Z",
+        "expiration_time_type": "time",
+        "expiration_interval_num": "3",
+        "expiration_interval_unit": "hours",
+        "expirationInterval": null,
+        "exp_type": "message",
+        "exp_enable": null,
+        "increment_badge": null,
+        "audience_id": "everyone",
+        "data": "asdsada",
+        "data_type": "text",
+        "data1": "",
+        "data_type_1": "text",
+        "data2": "",
+        "data_type_2": "text",
+        "translation_enable": null,
+        "expiration_time_iso": "2017-09-30T15:47:00.000Z"
+      };
+
+      it('should return a relative date', () => {
+        const push_time = extractPushTime(changes);
+        const expiration_time = extractExpirationTime(changes, push_time);
+
+        expect(expiration_time).toBe('2017-09-30T15:47:00.000Z');
+      });
+    });
+
+    describe('Sent immediately', () => {
+      const changes = {
+        "experiment_name": "",
+        "exp_size_in_percent": 50,
+        "push_time_type": "now",
+        "push_time": "2017-09-28T19:40:00.000Z",
+        "push_time_1": null,
+        "push_time_2": null,
+        "push_time_iso": "2017-09-28T19:40:00.000Z",
+        "push_time_1_iso": null,
+        "push_time_2_iso": null,
+        "deliveryTime": null,
+        "local_time": false,
+        "push_expires": true,
+        "expiration_time": "2017-09-30T15:47:00.000Z",
+        "expiration_time_type": "time",
+        "expiration_interval_num": "3",
+        "expiration_interval_unit": "hours",
+        "expirationInterval": null,
+        "exp_type": "message",
+        "exp_enable": null,
+        "increment_badge": null,
+        "audience_id": "everyone",
+        "data": "asdsada",
+        "data_type": "text",
+        "data1": "",
+        "data_type_1": "text",
+        "data2": "",
+        "data_type_2": "text",
+        "translation_enable": null,
+        "expiration_time_iso": "2017-09-30T15:47:00.000Z"
+      };
+
+      it('should return an absolute time', () => {
+        const push_time = extractPushTime(changes);
+        const expiration_time = extractExpirationTime(changes, push_time);
+
+        expect(expiration_time).toBe('2017-09-30T15:47:00.000Z');
+      });
+    });
+  });
+});

--- a/src/lib/tests/extractTime.test.js
+++ b/src/lib/tests/extractTime.test.js
@@ -1,5 +1,5 @@
 jest.dontMock('../extractTime');
-const {extractExpirationTime, extractPushTime} = require('../extractTime');
+const {extractExpiration, extractPushTime} = require('../extractTime');
 
 describe('extractPushTime', () => {
   describe('in user\'s timezone', () => {
@@ -86,7 +86,7 @@ describe('extractPushTime', () => {
   });
 });
 
-describe('extractExpirationTime', () => {
+describe('extractExpiration', () => {
   describe('With expiration interval', () => {
     describe('In user\'s local timezone', () => {
       describe('In hours', () => {
@@ -121,11 +121,9 @@ describe('extractExpirationTime', () => {
           "translation_enable": null
         };
 
-        it('should return a relative time in seconds', () => {
-          const push_time = extractPushTime(changes);
-          const expiration_time = extractExpirationTime(changes, push_time);
-
-          expect(expiration_time).toBe(3 * 60 * 60); // 3 hours in seconds
+        it('should return the interval in seconds', () => {
+          const { expiration_interval } = extractExpiration(changes);
+          expect(expiration_interval).toBe(3 * 60 * 60); // 3 hours in seconds
         });
       });
 
@@ -161,11 +159,9 @@ describe('extractExpirationTime', () => {
           "translation_enable": null
         };
 
-        it('should return a relative time in seconds', () => {
-          const push_time = extractPushTime(changes);
-          const expiration_time = extractExpirationTime(changes, push_time);
-
-          expect(expiration_time).toBe(2 * 24 * 3600); // 2 days in seconds
+        it('should return the interval in seconds', () => {
+          const { expiration_interval } = extractExpiration(changes);
+          expect(expiration_interval).toBe(2 * 24 * 3600); // 2 days in seconds
         });
       });
     });
@@ -203,12 +199,8 @@ describe('extractExpirationTime', () => {
       };
 
       it('should return a UTC time in seconds', () => {
-        const push_time = extractPushTime(changes);
-        const expiration_time = extractExpirationTime(changes, push_time);
-
-        expect(expiration_time).toBe(1506638400);
-        expect((new Date(expiration_time * 1000)).toISOString())
-          .toBe('2017-09-28T22:40:00.000Z');
+        const { expiration_interval } = extractExpiration(changes);
+        expect(expiration_interval).toBe(3 * 60 * 60);
       });
     });
 
@@ -245,9 +237,8 @@ describe('extractExpirationTime', () => {
       };
 
       it('should return 24 hours in seconds', () => {
-        const push_time = extractPushTime(changes);
-        const expiration_time = extractExpirationTime(changes, push_time);
-        expect(expiration_time).toBe(86400);
+        const { expiration_interval } = extractExpiration(changes);
+        expect(expiration_interval).toBe(60 * 60 * 24);
       });
     });
   });
@@ -287,9 +278,7 @@ describe('extractExpirationTime', () => {
       };
 
       it('should return a relative date', () => {
-        const push_time = extractPushTime(changes);
-        const expiration_time = extractExpirationTime(changes, push_time);
-
+        const { expiration_time } = extractExpiration(changes);
         expect(expiration_time).toBe('2017-09-30T15:47:00.000');
       });
     });
@@ -328,9 +317,7 @@ describe('extractExpirationTime', () => {
       };
 
       it('should return a relative date', () => {
-        const push_time = extractPushTime(changes);
-        const expiration_time = extractExpirationTime(changes, push_time);
-
+        const { expiration_time } = extractExpiration(changes);
         expect(expiration_time).toBe('2017-09-30T15:47:00.000Z');
       });
     });
@@ -369,9 +356,7 @@ describe('extractExpirationTime', () => {
       };
 
       it('should return an absolute time', () => {
-        const push_time = extractPushTime(changes);
-        const expiration_time = extractExpirationTime(changes, push_time);
-
+        const { expiration_time } = extractExpiration(changes);
         expect(expiration_time).toBe('2017-09-30T15:47:00.000Z');
       });
     });

--- a/src/lib/tests/extractTime.test.js
+++ b/src/lib/tests/extractTime.test.js
@@ -89,42 +89,84 @@ describe('extractPushTime', () => {
 describe('extractExpirationTime', () => {
   describe('With expiration interval', () => {
     describe('In user\'s local timezone', () => {
-      const changes = {
-        "experiment_name": "",
-        "exp_size_in_percent": 50,
-        "push_time_type": "time",
-        "push_time": "2017-09-28T19:40:00.000",
-        "push_time_1": null,
-        "push_time_2": null,
-        "push_time_iso": "2017-09-28T23:40:00.000Z",
-        "push_time_1_iso": null,
-        "push_time_2_iso": null,
-        "deliveryTime": null,
-        "local_time": true,
-        "push_expires": true,
-        "expiration_time": null,
-        "expiration_time_type": "interval",
-        "expiration_interval_num": "3",
-        "expiration_interval_unit": "hours",
-        "expirationInterval": null,
-        "exp_type": "message",
-        "exp_enable": null,
-        "increment_badge": null,
-        "audience_id": "everyone",
-        "data": "asdsada",
-        "data_type": "text",
-        "data1": "",
-        "data_type_1": "text",
-        "data2": "",
-        "data_type_2": "text",
-        "translation_enable": null
-      };
+      describe('In hours', () => {
+        const changes = {
+          "experiment_name": "",
+          "exp_size_in_percent": 50,
+          "push_time_type": "time",
+          "push_time": "2017-09-28T19:40:00.000",
+          "push_time_1": null,
+          "push_time_2": null,
+          "push_time_iso": "2017-09-28T23:40:00.000Z",
+          "push_time_1_iso": null,
+          "push_time_2_iso": null,
+          "deliveryTime": null,
+          "local_time": true,
+          "push_expires": true,
+          "expiration_time": null,
+          "expiration_time_type": "interval",
+          "expiration_interval_num": "3",
+          "expiration_interval_unit": "hours",
+          "expirationInterval": null,
+          "exp_type": "message",
+          "exp_enable": null,
+          "increment_badge": null,
+          "audience_id": "everyone",
+          "data": "asdsada",
+          "data_type": "text",
+          "data1": "",
+          "data_type_1": "text",
+          "data2": "",
+          "data_type_2": "text",
+          "translation_enable": null
+        };
 
-      it('should return a relative time in seconds', () => {
-        const push_time = extractPushTime(changes);
-        const expiration_time = extractExpirationTime(changes, push_time);
+        it('should return a relative time in seconds', () => {
+          const push_time = extractPushTime(changes);
+          const expiration_time = extractExpirationTime(changes, push_time);
 
-        expect(expiration_time).toBe(3 * 60 * 60);
+          expect(expiration_time).toBe(3 * 60 * 60); // 3 hours in seconds
+        });
+      });
+
+      describe('In days', () => {
+        const changes = {
+          "experiment_name": "",
+          "exp_size_in_percent": 50,
+          "push_time_type": "time",
+          "push_time": "2017-09-28T19:40:00.000",
+          "push_time_1": null,
+          "push_time_2": null,
+          "push_time_iso": "2017-09-28T23:40:00.000Z",
+          "push_time_1_iso": null,
+          "push_time_2_iso": null,
+          "deliveryTime": null,
+          "local_time": true,
+          "push_expires": true,
+          "expiration_time": null,
+          "expiration_time_type": "interval",
+          "expiration_interval_num": "2",
+          "expiration_interval_unit": "days",
+          "expirationInterval": null,
+          "exp_type": "message",
+          "exp_enable": null,
+          "increment_badge": null,
+          "audience_id": "everyone",
+          "data": "asdsada",
+          "data_type": "text",
+          "data1": "",
+          "data_type_1": "text",
+          "data2": "",
+          "data_type_2": "text",
+          "translation_enable": null
+        };
+
+        it('should return a relative time in seconds', () => {
+          const push_time = extractPushTime(changes);
+          const expiration_time = extractExpirationTime(changes, push_time);
+
+          expect(expiration_time).toBe(2 * 24 * 3600); // 2 days in seconds
+        });
       });
     });
 


### PR DESCRIPTION
## Overview
- Enable the push/expiration time fields if the server supports scheduled push

![screen shot 2017-09-20 at 9 40 20 am](https://user-images.githubusercontent.com/10149609/30646963-607640ec-9de8-11e7-9d37-1abaa7b87404.png)

[Related PR #4137](https://github.com/parse-community/parse-server/pull/4137)