### PR TITLE
Update middleware sample code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,15 +184,15 @@ var express = require('express');
 var ParseServer = require('parse-server').ParseServer;
 var ParseDashboard = require('parse-dashboard');
 
-var allowInsecureHTTP = false
-
 var api = new ParseServer({
 	// Parse Server settings
 });
 
+var options = { allowInsecureHTTP: false };
+
 var dashboard = new ParseDashboard({
 	// Parse Dashboard settings
-}, allowInsecureHTTP);
+}, options);
 
 var app = express();
 


### PR DESCRIPTION
Since [1.1.1](https://github.com/parse-community/parse-dashboard/compare/1.1.0...1.1.1#diff-6e7f8f893e54e5b6f584a6f7f5d4bf69R49) options to the middleware are passed as an object. This is not reflected in the main README file where for instance `allowInsecureHTTP` is still passed as an standalone `boolean`:

```javascript
var allowInsecureHTTP = false
var dashboard = new ParseDashboard({
	// Parse Dashboard settings
}, allowInsecureHTTP);
```

Where the sample code should be in the form:

```javascript
var options = { allowInsecureHTTP: false };
var dashboard = new ParseDashboard({
	// Parse Dashboard settings
}, options);
```

The lack of this update was driving me crazy for a couple of hours. Hope this help others.
