### PR TITLE
Fixes missing supportedPushLocales in #811

### DIFF
--- a/src/lib/ParseApp.js
+++ b/src/lib/ParseApp.js
@@ -60,7 +60,7 @@ export default class ParseApp {
     this.serverURL = serverURL;
     this.serverInfo = serverInfo;
     this.icon = iconName;
-    this.supportedPushLocales = supportedPushLocales;
+    this.supportedPushLocales = supportedPushLocales ? supportedPushLocales : [];
 
     this.settings = {
       fields: {},

--- a/src/lib/ParseApp.js
+++ b/src/lib/ParseApp.js
@@ -62,6 +62,10 @@ export default class ParseApp {
     this.icon = iconName;
     this.supportedPushLocales = supportedPushLocales ? supportedPushLocales : [];
 
+    if(!supportedPushLocales) {
+      console.warn(`Missing push locales for '` + appName + `', see this link for details on setting localizations up. https://github.com/parse-community/parse-dashboard#configuring-localized-push-notifications`);
+    }
+
     this.settings = {
       fields: {},
       lastFetched: new Date(0)


### PR DESCRIPTION
The newly added `supportedPushLocales` causes the **Push** section of the dashboard to break if it is not present. This adds a one-line check to set an empty array if push locales are not set. This does not remove the option to set a push locale however, it just provides no options as can be seen below.

![localize](https://user-images.githubusercontent.com/5070304/32860376-48d820d2-ca06-11e7-8545-05f8ffbcbe11.jpg)
