### PR TITLE
Fix filtering with a 1-digit number (#831)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### NEXT RELEASE
 
 * _Contributing to this repo? Add info about your change here to be included in next release_
+* Fix: Filtering with a 1-digit number (#831), thanks to [Pascal Giguère](https://github.com/pgiguere1)
 
 ### 1.1.2
 

--- a/src/components/BrowserFilter/FilterRow.react.js
+++ b/src/components/BrowserFilter/FilterRow.react.js
@@ -55,12 +55,10 @@ function compareValue(info, value, onChangeCompareTo, active) {
           value={value}
           onChange={(e) => {
             let val = value;
-            if (!e.target.value.length) {
-              val = '';
-            } else if (e.target.value.length === 1) {
-              val = validateNumeric(e.target.value) ? e.target.value : value;
-            } else {
-              val = validateNumeric(e.target.value) ? parseFloat(e.target.value) : value;
+            if (!e.target.value.length || e.target.value === '-') {
+              val = e.target.value;
+            } else if (validateNumeric(e.target.value)) {
+              val = parseFloat(e.target.value);
             }
             onChangeCompareTo(val);
           }} />


### PR DESCRIPTION
Fixes a bug introduced in 1.1.1 causing any 1-digit number filter to yield no results.

https://github.com/parse-community/parse-dashboard/issues/831