### PR TITLE
add background color in AppCard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Fix: Databrowser shows correct count of filtered objects, thanks to [Tom Engelbrecht](https://github.com/engel)
 
 ### 1.1.3
-* Feature: Add background color in AppCard, thanks to [AreyouHappy](https://github.com/AreyouHappy)
+* Feature: Add primaryBackgroundColor and secondaryBackgroundColor in AppCard, thanks to [AreyouHappy](https://github.com/AreyouHappy)
 
 ### 1.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * Fix: Filtering with a 1-digit number (#831), thanks to [Pascal Giguère](https://github.com/pgiguere1)
 * Fix: Databrowser shows correct count of filtered objects, thanks to [Tom Engelbrecht](https://github.com/engel)
 
+### 1.1.3
+* Feature: Add background color in AppCard, thanks to [AreyouHappy](https://github.com/AreyouHappy)
+
 ### 1.1.2
 
 * Fix: An issue introduced when using readOnlyMasterKey would make all users readOnly after one has logged in.

--- a/Parse-Dashboard/parse-dashboard-config.json
+++ b/Parse-Dashboard/parse-dashboard-config.json
@@ -4,7 +4,8 @@
     "appId": "",
     "masterKey": "",
     "appName": "",
-    "iconName": ""
+    "iconName": "",
+    "backgroundColor":"#000000"
   }],
   "iconsFolder": "icons"
 }

--- a/Parse-Dashboard/parse-dashboard-config.json
+++ b/Parse-Dashboard/parse-dashboard-config.json
@@ -5,7 +5,8 @@
     "masterKey": "",
     "appName": "",
     "iconName": "",
-    "backgroundColor":"#000000"
+    "primaryBackgroundColor": "",
+    "secondaryBackgroundColor": ""
   }],
   "iconsFolder": "icons"
 }

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Parse Dashboard supports adding an optional icon for each app, so you can identi
 
 ## App Background Color Configuration
 
-Parse Dashboard supports adding an optional background color for each app, so you can identify them easier in the list. To do so, you *must* use the configuration file, define an `backgroundColor` in it, parameter for each app. It is `CSS style`. To visualize what it means, in the following example `backgroundColor` is a configuration file:
+Parse Dashboard supports adding an optional background color for each app, so you can identify them easier in the list. To do so, you *must* use the configuration file, define an `primaryBackgroundColor` and `secondaryBackgroundColor` in it, parameter for each app. It is `CSS style`. To visualize what it means, in the following example `backgroundColor` is a configuration file:
 
 ```json
 {
@@ -166,14 +166,16 @@ Parse Dashboard supports adding an optional background color for each app, so yo
       "appId": "myAppId",
       "masterKey": "myMasterKey",
       "appName": "My Parse Server App",
-      "backgroundColor": "#FFA500" // Orange
+      "primaryBackgroundColor": "#FFA500", // Orange
+      "secondaryBackgroundColor": "#FF4500" // OrangeRed
     },
     {
       "serverURL": "http://localhost:1337/parse",
       "appId": "myAppId",
       "masterKey": "myMasterKey",
       "appName": "My Parse Server App [2]",
-      "backgroundColor": "rgb(255, 0, 0)" // Red
+      "primaryBackgroundColor": "rgb(255, 0, 0)", // Red
+      "secondaryBackgroundColor": "rgb(204, 0, 0)" // DarkRed
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Parse Dashboard is a standalone dashboard for managing your Parse apps. You can 
       * [Single app](#single-app)
   * [Managing Multiple Apps](#managing-multiple-apps)
   * [App Icon Configuration](#app-icon-configuration)
+  * [App Background Color Configuration](#app-background-color-configuration)
   * [Other Configuration Options](#other-configuration-options)
 * [Running as Express Middleware](#running-as-express-middleware)
 * [Deploying Parse Dashboard](#deploying-parse-dashboard)
@@ -150,6 +151,31 @@ Parse Dashboard supports adding an optional icon for each app, so you can identi
     }
   ],
   "iconsFolder": "icons"
+}
+```
+
+## App Background Color Configuration
+
+Parse Dashboard supports adding an optional background color for each app, so you can identify them easier in the list. To do so, you *must* use the configuration file, define an `backgroundColor` in it, parameter for each app. It is `CSS style`. To visualize what it means, in the following example `backgroundColor` is a configuration file:
+
+```json
+{
+  "apps": [
+    {
+      "serverURL": "http://localhost:1337/parse",
+      "appId": "myAppId",
+      "masterKey": "myMasterKey",
+      "appName": "My Parse Server App",
+      "backgroundColor": "#FFA500" // Orange
+    },
+    {
+      "serverURL": "http://localhost:1337/parse",
+      "appId": "myAppId",
+      "masterKey": "myMasterKey",
+      "appName": "My Parse Server App [2]",
+      "backgroundColor": "rgb(255, 0, 0)" // Red
+    }
+  ]
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "homepage": "https://github.com/ParsePlatform/parse-dashboard",
   "bugs": "https://github.com/ParsePlatform/parse-dashboard/issues",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/ParsePlatform/parse-dashboard"

--- a/src/components/Sidebar/Sidebar.react.js
+++ b/src/components/Sidebar/Sidebar.react.js
@@ -23,6 +23,8 @@ const Sidebar = ({
   sections,
   section,
   appSelector,
+  primaryBackgroundColor,
+  secondaryBackgroundColor
 }) => {
   const _subMenu = subsections => {
     if (!subsections) {
@@ -70,7 +72,10 @@ const Sidebar = ({
             icon={icon}
             style={style}
             link={prefix + link}
-            active={active}>
+            active={active}
+            primaryBackgroundColor={primaryBackgroundColor}
+            secondaryBackgroundColor={secondaryBackgroundColor}
+            >
             {active ? _subMenu(subsections) : null}
           </SidebarSection>
         );

--- a/src/components/Sidebar/SidebarSection.react.js
+++ b/src/components/Sidebar/SidebarSection.react.js
@@ -10,7 +10,7 @@ import { Link } from 'react-router';
 import React    from 'react';
 import styles   from 'components/Sidebar/Sidebar.scss';
 
-let SidebarSection = ({ active, children, name, link, icon, style }) => {
+let SidebarSection = ({ active, children, name, link, icon, style, primaryBackgroundColor, secondaryBackgroundColor  }) => {
   let classes = [styles.section];
   if (active) {
     classes.push(styles.active);
@@ -22,10 +22,10 @@ let SidebarSection = ({ active, children, name, link, icon, style }) => {
   return (
     <div className={classes.join(' ')}>
       {active ?
-        <div style={style} className={styles.section_header}>{iconContent}<span>{name}</span></div> :
+        <div style={style} className={styles.section_header} style={{ background: primaryBackgroundColor }}>{iconContent}<span>{name}</span></div> :
         <Link style={style} className={styles.section_header} to={{ pathname: link || '' }}>{iconContent}<span>{name}</span></Link>}
 
-      {children ? <div className={styles.section_contents}>{children}</div> : null}
+      {children ? <div className={styles.section_contents} style={{ background: secondaryBackgroundColor }}>{children}</div> : null}
     </div>
   );
 };

--- a/src/dashboard/Apps/AppsIndex.react.js
+++ b/src/dashboard/Apps/AppsIndex.react.js
@@ -72,8 +72,8 @@ let AppCard = ({
     Server version: <span className={styles.ago}>{app.serverInfo.parseServerVersion || 'unknown'}</span>
     </div>;
 
-  return <li onClick={canBrowse}>
-    <a className={styles.icon}>
+  return <li onClick={canBrowse} style={{ background: app.backgroundColor }}>
+    <a className={styles.icon} >
       {icon ? <img src={'appicons/' + icon} width={56} height={56}/> : <Icon width={56} height={56} name='blank-app-outline' fill='#1E384D' />}
     </a>
     <div className={styles.details}>

--- a/src/dashboard/Apps/AppsIndex.react.js
+++ b/src/dashboard/Apps/AppsIndex.react.js
@@ -72,7 +72,7 @@ let AppCard = ({
     Server version: <span className={styles.ago}>{app.serverInfo.parseServerVersion || 'unknown'}</span>
     </div>;
 
-  return <li onClick={canBrowse} style={{ background: app.backgroundColor }}>
+  return <li onClick={canBrowse} style={{ background: app.primaryBackgroundColor }}>
     <a className={styles.icon}>
       {icon ? <img src={'appicons/' + icon} width={56} height={56}/> : <Icon width={56} height={56} name='blank-app-outline' fill='#1E384D' />}
     </a>

--- a/src/dashboard/Apps/AppsIndex.react.js
+++ b/src/dashboard/Apps/AppsIndex.react.js
@@ -73,7 +73,7 @@ let AppCard = ({
     </div>;
 
   return <li onClick={canBrowse} style={{ background: app.backgroundColor }}>
-    <a className={styles.icon} >
+    <a className={styles.icon}>
       {icon ? <img src={'appicons/' + icon} width={56} height={56}/> : <Icon width={56} height={56} name='blank-app-outline' fill='#1E384D' />}
     </a>
     <div className={styles.details}>

--- a/src/dashboard/DashboardView.react.js
+++ b/src/dashboard/DashboardView.react.js
@@ -240,7 +240,10 @@ export default class DashboardView extends React.Component {
       section={this.section}
       subsection={this.subsection}
       prefix={'/apps/' + appSlug}
-      action={this.action}>
+      action={this.action}
+      primaryBackgroundColor={this.context.currentApp.primaryBackgroundColor}
+      secondaryBackgroundColor={this.context.currentApp.secondaryBackgroundColor}
+      >
       {sidebarChildren}
     </Sidebar>);
 

--- a/src/lib/ParseApp.js
+++ b/src/lib/ParseApp.js
@@ -39,6 +39,7 @@ export default class ParseApp {
     serverInfo,
     production,
     iconName,
+    backgroundColor,
     supportedPushLocales,
   }) {
     this.name = appName;
@@ -60,6 +61,7 @@ export default class ParseApp {
     this.serverURL = serverURL;
     this.serverInfo = serverInfo;
     this.icon = iconName;
+    this.backgroundColor=backgroundColor;
     this.supportedPushLocales = supportedPushLocales ? supportedPushLocales : [];
 
     if(!supportedPushLocales) {

--- a/src/lib/ParseApp.js
+++ b/src/lib/ParseApp.js
@@ -39,7 +39,8 @@ export default class ParseApp {
     serverInfo,
     production,
     iconName,
-    backgroundColor,
+    primaryBackgroundColor,
+    secondaryBackgroundColor,
     supportedPushLocales,
   }) {
     this.name = appName;
@@ -61,7 +62,8 @@ export default class ParseApp {
     this.serverURL = serverURL;
     this.serverInfo = serverInfo;
     this.icon = iconName;
-    this.backgroundColor=backgroundColor;
+    this.primaryBackgroundColor=primaryBackgroundColor;
+    this.secondaryBackgroundColor=secondaryBackgroundColor;
     this.supportedPushLocales = supportedPushLocales ? supportedPushLocales : [];
 
     if(!supportedPushLocales) {


### PR DESCRIPTION
### add background color
Easily distinguish your app cards.

```
{
  "apps": [{
    "serverURL": "",
    "appId": "",
    "masterKey": "",
    "appName": "",
    "iconName": "",
    "backgroundColor":"#000000"
  }],
  "iconsFolder": "icons"
}
```
