### PR TITLE
Fix Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:argon-slim
+FROM node:8-slim
 ENV NPM_CONFIG_LOGLEVEL error
 WORKDIR /src
 ADD . /src
 RUN cd /src \
  && npm install \
  && npm run build \
- && npm cache clear \
+ && npm cache clear --force \
  && rm -rf ~/.npm \
  && rm -rf /var/lib/apt/lists/*
 ENTRYPOINT ["npm", "run", "dashboard"]


### PR DESCRIPTION
Version 1.2.0 no build in https://hub.docker.com/r/parseplatform/parse-dashboard/builds/.