### PR TITLE
Add tvOS support to push targeting

### DIFF
--- a/src/dashboard/Push/PushConstants.js
+++ b/src/dashboard/Push/PushConstants.js
@@ -26,12 +26,13 @@ export const SENT_FIELD = 'numSent';
 export const DEVICE_MAP = {
   ios: 'iOS',
   osx: 'OS X',
+  tvos: 'tvOS',
   android: 'Android',
   winrt: 'Win8',
   winphone: 'Windows Phone',
   embedded: 'Embedded',
 };
 
-export const DEFAULT_DEVICES = ['ios', 'osx', 'android', 'winrt', 'winphone', 'embedded'];
+export const DEFAULT_DEVICES = ['ios', 'osx', 'tvos', 'android', 'winrt', 'winphone', 'embedded'];
 
 export const NEW_SEGMENT_ID = 'new_segment';


### PR DESCRIPTION
This goes together with the update done here https://github.com/parse-community/Parse-SDK-iOS-OSX/pull/1375 to add support for tvOS to the iOS/OSX SDK. 

It basically just adds the `tvos` audience to the push UI. 