### PR TITLE
Redirect to the first app browser when only a single app is registered

### DIFF
--- a/src/dashboard/Apps/AppsIndex.react.js
+++ b/src/dashboard/Apps/AppsIndex.react.js
@@ -96,6 +96,11 @@ export default class AppsIndex extends React.Component {
   }
 
   componentWillMount() {
+    if (AppsManager.apps().length === 1) {
+      const singleApp = AppsManager.apps()[0];
+      history.push(`/apps/${singleApp.slug}/browser`);
+      return;
+    }
     document.body.addEventListener('keydown', this.focusField);
     AppsManager.getAllAppsIndexStats().then(() => {
       this.forceUpdate();

--- a/src/dashboard/Apps/AppsIndex.react.js
+++ b/src/dashboard/Apps/AppsIndex.react.js
@@ -97,8 +97,8 @@ export default class AppsIndex extends React.Component {
 
   componentWillMount() {
     if (AppsManager.apps().length === 1) {
-      const singleApp = AppsManager.apps()[0];
-      history.push(`/apps/${singleApp.slug}/browser`);
+      const [app] = AppsManager.apps();
+      history.push(`/apps/${app.slug}/browser`);
       return;
     }
     document.body.addEventListener('keydown', this.focusField);


### PR DESCRIPTION
Hi, in a project using Parse Server, I'm trying to connect the Parse Dashboard as a middleware and don't need multiple apps.

Since I don't need multiple apps, I don't want to be redirected to the apps screen, which is only an extra step to the content.

This PR is simply to open the conversation, I browsed the code and found that it would be difficult to build my use case properly and decided to find the easiest way to achieve my goal. For now it's simply redirecting to the browser every time you reach the `AppsIndex` page and the `AppsManager` only knows one app.

More ideas would be to:
- prevent the Apps selectors toggle
- remove the caret when in "single app mode"

Any feedback welcome, I'd especially like pointers on how to plug this feature properly.