### PR TITLE
Correct inappropriate error message when no target audience is selected.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Parse Dashboard Changelog
-* _Contributing to this repo? Add info about your change here to be included in next release_
+* Fix: Correct inappropriate error message when no target audience is selected.
 
 ### master
 [Full Changelog](https://github.com/parse-community/parse-dashboard/compare/1.3.0...master)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## Parse Dashboard Changelog
-* Fix: Correct inappropriate error message when no target audience is selected.
 
 ### master
 [Full Changelog](https://github.com/parse-community/parse-dashboard/compare/1.3.0...master)
+
+* _Contributing to this repo? Add info about your change here to be included in next release_
+* Fix: Correct inappropriate error message when no target audience is selected (#1052), thanks to [Bouimadaghene](https://github.com/starbassma)
 
 ### 1.3.0
 [Full Changelog](https://github.com/parse-community/parse-dashboard/compare/1.2.0...1.3.0)

--- a/src/dashboard/Push/PushNew.react.js
+++ b/src/dashboard/Push/PushNew.react.js
@@ -729,7 +729,7 @@ class PushNew extends DashboardView {
     let invalidInputMessages = [];
 
     if (!this.state.audienceId) {
-      emptyInputMessages.push('you need select an audience');
+      emptyInputMessages.push('target audience');
     }
 
     // when number audience size is 0


### PR DESCRIPTION
Hello,
Because of the use of a generic method  _formatErrorMessage_ (src/dashboard/Push/PushNew.react.js) an inappropriate message is shown when no target audience is selected .

Before
<img src="http://oi68.tinypic.com/2r5wyme.jpg" width="800" heigth="600" />
After
<img src="http://oi65.tinypic.com/210hz4k.jpg" width="800" heigth="600" />

Wassime.