### PR TITLE
Fix dashboard not applying mounting point when linking or redirecting to another page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2377,7 +2377,6 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -3659,8 +3658,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -3681,14 +3679,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3703,20 +3699,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -3833,8 +3826,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -3846,7 +3838,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -3861,7 +3852,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -3869,14 +3859,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3895,7 +3883,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3976,8 +3963,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3989,7 +3975,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -4075,8 +4060,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -4112,7 +4096,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -4132,7 +4115,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -4176,14 +4158,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -6530,7 +6510,6 @@
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6551,7 +6530,6 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6751,8 +6729,7 @@
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6872,8 +6849,7 @@
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -9520,8 +9496,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "loose-envify": {
       "version": "1.3.1",

--- a/src/components/Sidebar/AppsMenu.react.js
+++ b/src/components/Sidebar/AppsMenu.react.js
@@ -5,12 +5,13 @@
  * This source code is licensed under the license found in the LICENSE file in
  * the root directory of this source tree.
  */
-import AppBadge         from 'components/AppBadge/AppBadge.react';
-import html             from 'lib/htmlString';
-import { Link }         from 'react-router-dom';
-import React            from 'react';
-import styles           from 'components/Sidebar/Sidebar.scss';
-import { unselectable } from 'stylesheets/base.scss';
+import AppBadge           from 'components/AppBadge/AppBadge.react';
+import html               from 'lib/htmlString';
+import { Link }           from 'react-router-dom';
+import React              from 'react';
+import styles             from 'components/Sidebar/Sidebar.scss';
+import { unselectable }   from 'stylesheets/base.scss';
+import { applyMountPath } from "lib/path";
 
 let AppsMenu = ({ apps, current, height, onSelect }) => (
   <div style={{ height }} className={[styles.appsMenu, unselectable].join(' ')}>
@@ -23,7 +24,7 @@ let AppsMenu = ({ apps, current, height, onSelect }) => (
         return null;
       }
       return (
-        <Link to={{ pathname: html`/apps/${app.slug}/browser` }} key={app.slug} className={styles.menuRow}>
+        <Link to={{ pathname: applyMountPath(`apps/${app.slug}/browser`) }} key={app.slug} className={styles.menuRow}>
           {app.name}
           <AppBadge production={app.production} />
         </Link>

--- a/src/components/Sidebar/AppsSelector.react.js
+++ b/src/components/Sidebar/AppsSelector.react.js
@@ -5,15 +5,16 @@
  * This source code is licensed under the license found in the LICENSE file in
  * the root directory of this source tree.
  */
-import PropTypes   from 'lib/PropTypes'; 
-import AppsMenu       from 'components/Sidebar/AppsMenu.react';
-import Popover        from 'components/Popover/Popover.react';
-import history        from 'dashboard/history';
-import ParseApp       from 'lib/ParseApp';
-import Position       from 'lib/Position';
-import React          from 'react';
-import ReactDOM       from 'react-dom';
-import styles         from 'components/Sidebar/Sidebar.scss';
+import PropTypes          from 'lib/PropTypes'; 
+import AppsMenu           from 'components/Sidebar/AppsMenu.react';
+import Popover            from 'components/Popover/Popover.react';
+import history            from 'dashboard/history';
+import ParseApp           from 'lib/ParseApp';
+import Position           from 'lib/Position';
+import React              from 'react';
+import ReactDOM           from 'react-dom';
+import styles             from 'components/Sidebar/Sidebar.scss';
+import { applyMountPath } from "lib/path";
 
 export default class AppsSelector extends React.Component {
   constructor() {
@@ -58,7 +59,7 @@ export default class AppsSelector extends React.Component {
         if (sections[0] === '') {
           sections.shift();
         }
-        history.push(`/apps/${value}/${sections[2]}`);
+        history.push(applyMountPath(`apps/${value}/${sections[2]}`));
       }
     });
   }

--- a/src/components/Sidebar/FooterMenu.react.js
+++ b/src/components/Sidebar/FooterMenu.react.js
@@ -5,13 +5,12 @@
  * This source code is licensed under the license found in the LICENSE file in
  * the root directory of this source tree.
  */
-import Icon     from 'components/Icon/Icon.react';
-import Popover  from 'components/Popover/Popover.react';
-import Position from 'lib/Position';
-import React    from 'react';
-import styles   from 'components/Sidebar/Sidebar.scss';
-
-let mountPath = window.PARSE_DASHBOARD_PATH;
+import Icon               from 'components/Icon/Icon.react';
+import Popover            from 'components/Popover/Popover.react';
+import Position           from 'lib/Position';
+import React              from 'react';
+import styles             from 'components/Sidebar/Sidebar.scss';
+import { applyMountPath } from 'lib/path';
 
 export default class FooterMenu extends React.Component {
   constructor() {
@@ -41,7 +40,7 @@ export default class FooterMenu extends React.Component {
           position={this.state.position}
           onExternalClick={() => this.setState({ show: false })}>
           <div className={styles.popup}>
-            <a href={`${mountPath}logout`}>Log Out <span className={styles.emoji}>👋</span></a>
+            <a href={applyMountPath('logout')}>Log Out <span className={styles.emoji}>👋</span></a>
             <a target='_blank' href='http://docs.parseplatform.org/parse-server/guide/'>Server Guide <span className={styles.emoji}>📚</span></a>
             <a target='_blank' href='http://stackoverflow.com/questions/tagged/parse.com'>Code-level Questions <span className={styles.emoji}>❓</span></a>
             <a target='_blank' href='http://stackoverflow.com/questions/tagged/parse-server'>Server Questions <span className={styles.emoji}>❓</span></a>

--- a/src/components/Sidebar/SidebarHeader.react.js
+++ b/src/components/Sidebar/SidebarHeader.react.js
@@ -5,10 +5,11 @@
  * This source code is licensed under the license found in the LICENSE file in
  * the root directory of this source tree.
  */
-import Icon     from 'components/Icon/Icon.react';
-import { Link } from 'react-router-dom';
-import React    from 'react';
-import styles   from 'components/Sidebar/Sidebar.scss';
+import Icon                          from 'components/Icon/Icon.react';
+import { Link }                      from 'react-router-dom';
+import React                         from 'react';
+import styles                        from 'components/Sidebar/Sidebar.scss';
+import { mountPath, applyMountPath } from 'lib/path';
 // get the package.json environment variable
 const version = process.env.version;
 
@@ -18,7 +19,6 @@ export default class SidebarHeader extends React.Component {
     this.state = { };
   }
   componentWillMount() {
-    let mountPath = window.PARSE_DASHBOARD_PATH;
     fetch(mountPath).then(response => {
       this.setState({ dashboardUser: response.headers.get('username') });
     });
@@ -26,10 +26,10 @@ export default class SidebarHeader extends React.Component {
   render() {
     return (
       <div className={styles.header}>
-        <Link className={styles.logo} to={{ pathname: '/apps' }}>
+        <Link className={styles.logo} to={{ pathname: applyMountPath('apps') }}>
           <Icon width={28} height={28} name='infinity' fill={'#ffffff'} />
         </Link>
-        <Link to='/apps'>
+        <Link to={applyMountPath('apps')}>
           <div className={styles.version}>
             <div>
               Parse Dashboard {version}

--- a/src/dashboard/AppData.react.js
+++ b/src/dashboard/AppData.react.js
@@ -5,13 +5,14 @@
  * This source code is licensed under the license found in the LICENSE file in
  * the root directory of this source tree.
  */
-import React       from 'react';
-import PropTypes   from 'lib/PropTypes';
-import AppSelector from 'dashboard/AppSelector.react';
-import AppsManager from 'lib/AppsManager';
-import history     from 'dashboard/history';
-import ParseApp    from 'lib/ParseApp';
-import createClass from 'create-react-class';
+import React              from 'react';
+import PropTypes          from 'lib/PropTypes';
+import AppSelector        from 'dashboard/AppSelector.react';
+import AppsManager        from 'lib/AppsManager';
+import history            from 'dashboard/history';
+import ParseApp           from 'lib/ParseApp';
+import createClass        from 'create-react-class';
+import { applyMountPath } from 'lib/path';
 
 let AppData = createClass({
   childContextTypes: {
@@ -27,7 +28,7 @@ let AppData = createClass({
   },
 
   generatePath(path) {
-    return '/apps/' + this.props.params.appId + '/' + path;
+    return applyMountPath('apps/' + this.props.params.appId + '/' + path);
   },
 
   render() {
@@ -39,7 +40,7 @@ let AppData = createClass({
     if (current) {
       current.setParseKeys();
     } else {
-      history.replace('/apps');
+      history.replace(applyMountPath('apps'));
       return <div />;
     }
     return (

--- a/src/dashboard/AppSelector.react.js
+++ b/src/dashboard/AppSelector.react.js
@@ -5,14 +5,15 @@
  * This source code is licensed under the license found in the LICENSE file in
  * the root directory of this source tree.
  */
-import AppsManager from 'lib/AppsManager';
-import Dropdown    from 'components/Dropdown/Dropdown.react';
-import Field       from 'components/Field/Field.react';
-import history     from 'dashboard/history';
-import Label       from 'components/Label/Label.react';
-import Modal       from 'components/Modal/Modal.react';
-import Option      from 'components/Dropdown/Option.react';
-import React       from 'react';
+import AppsManager        from 'lib/AppsManager';
+import Dropdown           from 'components/Dropdown/Dropdown.react';
+import Field              from 'components/Field/Field.react';
+import history            from 'dashboard/history';
+import Label              from 'components/Label/Label.react';
+import Modal              from 'components/Modal/Modal.react';
+import Option             from 'components/Dropdown/Option.react';
+import React              from 'react';
+import { applyMountPath } from 'lib/path'
 
 export default class AppSelector extends React.Component {
   constructor(props, context) {
@@ -30,7 +31,7 @@ export default class AppSelector extends React.Component {
   }
 
   handleCancel() {
-    history.push('/apps');
+    history.push(applyMountPath('apps'));
   }
 
   render() {

--- a/src/dashboard/Apps/AppsIndex.react.js
+++ b/src/dashboard/Apps/AppsIndex.react.js
@@ -5,18 +5,19 @@
  * This source code is licensed under the license found in the LICENSE file in
  * the root directory of this source tree.
  */
-import AppsManager   from 'lib/AppsManager';
-import FlowFooter    from 'components/FlowFooter/FlowFooter.react';
-import history       from 'dashboard/history';
-import html          from 'lib/htmlString';
-import Icon          from 'components/Icon/Icon.react';
-import joinWithFinal from 'lib/joinWithFinal';
-import LiveReload    from 'components/LiveReload/LiveReload.react';
-import prettyNumber  from 'lib/prettyNumber';
-import React         from 'react';
-import styles        from 'dashboard/Apps/AppsIndex.scss';
-import { center }    from 'stylesheets/base.scss';
-import AppBadge      from 'components/AppBadge/AppBadge.react';
+import AppsManager        from 'lib/AppsManager';
+import FlowFooter         from 'components/FlowFooter/FlowFooter.react';
+import history            from 'dashboard/history';
+import html               from 'lib/htmlString';
+import Icon               from 'components/Icon/Icon.react';
+import joinWithFinal      from 'lib/joinWithFinal';
+import LiveReload         from 'components/LiveReload/LiveReload.react';
+import prettyNumber       from 'lib/prettyNumber';
+import React              from 'react';
+import styles             from 'dashboard/Apps/AppsIndex.scss';
+import { center }         from 'stylesheets/base.scss';
+import AppBadge           from 'components/AppBadge/AppBadge.react';
+import { applyMountPath } from 'lib/path';
 
 function dash(value, content) {
   if (value === undefined) {
@@ -36,7 +37,7 @@ let CloningNote = ({ app, clone_status, clone_progress }) => {
   }
   let progress = <LiveReload
     initialData={[{appId: app.applicationId, progress: clone_progress}]}
-    source='/apps/cloning_progress'
+    source={applyMountPath('apps/cloning_progress')}
     render={data => {
       let currentAppProgress = data.find(({ appId }) => appId === app.applicationId);
       let progressStr = currentAppProgress ? currentAppProgress.progress.toString() : '0';
@@ -64,7 +65,7 @@ let AppCard = ({
   app,
   icon,
 }) => {
-  let canBrowse = app.serverInfo.error ? null : () => history.push(html`/apps/${app.slug}/browser`);
+  let canBrowse = app.serverInfo.error ? null : () => history.push(applyMountPath(`apps/${app.slug}/browser`));
   let versionMessage = app.serverInfo.error ?
     <div className={styles.serverVersion}>Server not reachable: <span className={styles.ago}>{app.serverInfo.error.toString()}</span></div>:
     <div className={styles.serverVersion}>
@@ -98,7 +99,7 @@ export default class AppsIndex extends React.Component {
   componentWillMount() {
     if (AppsManager.apps().length === 1) {
       const [app] = AppsManager.apps();
-      history.push(`/apps/${app.slug}/browser`);
+      history.push(applyMountPath(`apps/${app.slug}/browser`));
       return;
     }
     document.body.addEventListener('keydown', this.focusField);

--- a/src/dashboard/Dashboard.js
+++ b/src/dashboard/Dashboard.js
@@ -5,48 +5,49 @@
  * This source code is licensed under the license found in the LICENSE file in
  * the root directory of this source tree.
  */
-import AccountOverview    from './Account/AccountOverview.react';
-import AccountView        from './AccountView.react';
-import AnalyticsOverview  from './Analytics/Overview/Overview.react';
-import ApiConsole         from './Data/ApiConsole/ApiConsole.react';
-import AppData            from './AppData.react';
-import AppsIndex          from './Apps/AppsIndex.react';
-import AppsManager        from 'lib/AppsManager';
-import Browser            from './Data/Browser/Browser.react';
-import CloudCode          from './Data/CloudCode/CloudCode.react';
-import Config             from './Data/Config/Config.react';
-import Explorer           from './Analytics/Explorer/Explorer.react';
-import FourOhFour         from 'components/FourOhFour/FourOhFour.react';
-import GeneralSettings    from './Settings/GeneralSettings.react';
-import history            from 'dashboard/history';
-import HostingSettings    from './Settings/HostingSettings.react';
-import Icon               from 'components/Icon/Icon.react';
-import JobEdit            from 'dashboard/Data/Jobs/JobEdit.react';
-import Jobs               from './Data/Jobs/Jobs.react';
-import JobsData           from 'dashboard/Data/Jobs/JobsData.react';
-import Loader             from 'components/Loader/Loader.react';
-import Logs               from './Data/Logs/Logs.react';
-import Migration          from './Data/Migration/Migration.react';
-import ParseApp           from 'lib/ParseApp';
-import Performance        from './Analytics/Performance/Performance.react';
-import PushAudiencesIndex from './Push/PushAudiencesIndex.react';
-import PushDetails        from './Push/PushDetails.react';
-import PushIndex          from './Push/PushIndex.react';
-import PushNew            from './Push/PushNew.react';
-import PushSettings       from './Settings/PushSettings.react';
-import React              from 'react';
-import Retention          from './Analytics/Retention/Retention.react';
-import SchemaOverview     from './Data/Browser/SchemaOverview.react';
-import SecuritySettings   from './Settings/SecuritySettings.react';
-import SettingsData       from './Settings/SettingsData.react';
-import SlowQueries        from './Analytics/SlowQueries/SlowQueries.react';
-import styles             from 'dashboard/Apps/AppsIndex.scss';
-import UsersSettings      from './Settings/UsersSettings.react';
-import Webhooks           from './Data/Webhooks/Webhooks.react';
-import { AsyncStatus }    from 'lib/Constants';
-import { center }         from 'stylesheets/base.scss';
-import { get }            from 'lib/AJAX';
-import { setBasePath }    from 'lib/AJAX';
+import AccountOverview               from './Account/AccountOverview.react';
+import AccountView                   from './AccountView.react';
+import AnalyticsOverview             from './Analytics/Overview/Overview.react';
+import ApiConsole                    from './Data/ApiConsole/ApiConsole.react';
+import AppData                       from './AppData.react';
+import AppsIndex                     from './Apps/AppsIndex.react';
+import AppsManager                   from 'lib/AppsManager';
+import Browser                       from './Data/Browser/Browser.react';
+import CloudCode                     from './Data/CloudCode/CloudCode.react';
+import Config                        from './Data/Config/Config.react';
+import Explorer                      from './Analytics/Explorer/Explorer.react';
+import FourOhFour                    from 'components/FourOhFour/FourOhFour.react';
+import GeneralSettings               from './Settings/GeneralSettings.react';
+import history                       from 'dashboard/history';
+import HostingSettings               from './Settings/HostingSettings.react';
+import Icon                          from 'components/Icon/Icon.react';
+import JobEdit                       from 'dashboard/Data/Jobs/JobEdit.react';
+import Jobs                          from './Data/Jobs/Jobs.react';
+import JobsData                      from 'dashboard/Data/Jobs/JobsData.react';
+import Loader                        from 'components/Loader/Loader.react';
+import Logs                          from './Data/Logs/Logs.react';
+import Migration                     from './Data/Migration/Migration.react';
+import ParseApp                      from 'lib/ParseApp';
+import Performance                   from './Analytics/Performance/Performance.react';
+import PushAudiencesIndex            from './Push/PushAudiencesIndex.react';
+import PushDetails                   from './Push/PushDetails.react';
+import PushIndex                     from './Push/PushIndex.react';
+import PushNew                       from './Push/PushNew.react';
+import PushSettings                  from './Settings/PushSettings.react';
+import React                         from 'react';
+import Retention                     from './Analytics/Retention/Retention.react';
+import SchemaOverview                from './Data/Browser/SchemaOverview.react';
+import SecuritySettings              from './Settings/SecuritySettings.react';
+import SettingsData                  from './Settings/SettingsData.react';
+import SlowQueries                   from './Analytics/SlowQueries/SlowQueries.react';
+import styles                        from 'dashboard/Apps/AppsIndex.scss';
+import UsersSettings                 from './Settings/UsersSettings.react';
+import Webhooks                      from './Data/Webhooks/Webhooks.react';
+import { AsyncStatus }               from 'lib/Constants';
+import { center }                    from 'stylesheets/base.scss';
+import { get }                       from 'lib/AJAX';
+import { setBasePath }               from 'lib/AJAX';
+import { mountPath, applyMountPath } from 'lib/path';
 import {
   Router,
   Switch,
@@ -173,6 +174,7 @@ export default class Dashboard extends React.Component {
   }
 
   render() {
+
     if (this.state.configLoadingState === AsyncStatus.PROGRESS) {
       return <div className={center}><Loader/></div>;
     }
@@ -205,7 +207,7 @@ export default class Dashboard extends React.Component {
           <Route path={ match.url + '/hosting' } component={HostingSettings} />
         </Switch>
       </SettingsData>
-    )
+    );
 
     const JobsRoute = (props) => (
       <Switch>
@@ -224,14 +226,14 @@ export default class Dashboard extends React.Component {
             <Jobs {...props} params={props.match.params}/>
           </JobsData>
         )} />
-        <Redirect from={ props.match.path } to='/apps/:appId/jobs/all' />
+        <Redirect from={ props.match.path } to={applyMountPath('apps/:appId/jobs/all')} />
       </Switch>
-    )
+    );
 
     const AnalyticsRoute = ({ match }) => (
       <Switch>
         <Route path={ match.path + '/overview' } component={AnalyticsOverview} />
-        <Redirect exact from={ match.path + '/explorer' } to='/apps/:appId/analytics/explorer/chart' />
+        <Redirect exact from={ match.path + '/explorer' } to={applyMountPath('apps/:appId/analytics/explorer/chart')} />
         <Route path={ match.path + '/explorer/:displayType' } component={Explorer} />
         <Route path={ match.path + '/retention' } component={Retention} />
         <Route path={ match.path + '/performance' } component={Performance} />
@@ -262,15 +264,15 @@ export default class Dashboard extends React.Component {
           <Route path={ match.path + '/logs/:type' } render={(props) => (
             <Logs {...props} params={props.match.params} />
           )} />
-          <Redirect from={ match.path + '/logs' } to='/apps/:appId/logs/info' />
+          <Redirect from={ match.path + '/logs' } to={applyMountPath('apps/:appId/logs/info')} />
 
           <Route path={ match.path + '/config' } component={Config} />
           <Route path={ match.path + '/api_console' } component={ApiConsole} />
           <Route path={ match.path + '/migration' } component={Migration} />/>
 
 
-          <Redirect exact from={ match.path + '/push' } to='/apps/:appId/push/new' />
-          <Redirect exact from={ match.path + '/push/activity' } to='/apps/:appId/push/activity/all'  />
+          <Redirect exact from={ match.path + '/push' } to={applyMountPath('apps/:appId/push/new')} />
+          <Redirect exact from={ match.path + '/push/activity' } to={applyMountPath('apps/:appId/push/activity/all')} />
 
           <Route path={ match.path + '/push/activity/:category' } render={(props) => (
             <PushIndex {...props} params={props.match.params} />
@@ -282,9 +284,9 @@ export default class Dashboard extends React.Component {
           )} />
 
           {/* Unused routes... */}
-          <Redirect exact from={ match.path + '/analytics' } to='/apps/:appId/analytics/overview' />
+          <Redirect exact from={ match.path + '/analytics' } to={applyMountPath('apps/:appId/analytics/overview')} />
           <Route path={ match.path + '/analytics' } component={AnalyticsRoute}/>
-          <Redirect exact from={ match.path + '/settings' } to='/apps/:appId/settings/general' />
+          <Redirect exact from={ match.path + '/settings' } to={applyMountPath('apps/:appId/settings/general')} />
           <Route path={ match.path + '/settings' } component={SettingsRoute}/>
         </Switch>
       </AppData>
@@ -293,9 +295,9 @@ export default class Dashboard extends React.Component {
     const Index = () => (
       <div>
         <Switch>
-          <Redirect exact from='/apps/:appId' to='/apps/:appId/browser' />
-          <Route exact path='/apps' component={AppsIndexPage} />
-          <Route path='/apps/:appId' component={AppRoute} />
+          <Redirect exact from={applyMountPath('apps/:appId')} to={applyMountPath('apps/:appId/browser')} />
+          <Route exact path={applyMountPath('apps')} component={AppsIndexPage} />
+          <Route path={applyMountPath('apps/:appId')} component={AppRoute} />
         </Switch>
       </div>
     )
@@ -306,10 +308,10 @@ export default class Dashboard extends React.Component {
             <title>Parse Dashboard</title>
           </Helmet>
           <Switch>
-            <Route path='/apps' component={Index} />
-            <Route path='/account/overview' component={AccountSettingsPage} />
-            <Redirect from='/account' to='/account/overview' />
-            <Redirect from='/' to='/apps' />
+            <Route path={applyMountPath('apps')} component={Index} />
+            <Route path={applyMountPath('account/overview')} component={AccountSettingsPage} />
+            <Redirect from={applyMountPath('account')} to={applyMountPath('account/overview')} />
+            <Redirect from={mountPath} to={applyMountPath('apps')} />
             <Route path='*' component={FourOhFour} />
           </Switch>
         </div>

--- a/src/dashboard/DashboardView.react.js
+++ b/src/dashboard/DashboardView.react.js
@@ -5,12 +5,13 @@
  * This source code is licensed under the license found in the LICENSE file in
  * the root directory of this source tree.
  */
-import PropTypes     from 'lib/PropTypes';
-import ParseApp      from 'lib/ParseApp';
-import React         from 'react';
-import Sidebar       from 'components/Sidebar/Sidebar.react';
-import SidebarToggle from 'components/Sidebar/SidebarToggle.react';
-import styles        from 'dashboard/Dashboard.scss';
+import PropTypes          from 'lib/PropTypes';
+import ParseApp           from 'lib/ParseApp';
+import React              from 'react';
+import Sidebar            from 'components/Sidebar/Sidebar.react';
+import SidebarToggle      from 'components/Sidebar/SidebarToggle.react';
+import styles             from 'dashboard/Dashboard.scss';
+import { applyMountPath } from 'lib/path';
 
 export default class DashboardView extends React.Component {
 
@@ -241,7 +242,7 @@ export default class DashboardView extends React.Component {
       appSelector={true}
       section={this.section}
       subsection={this.subsection}
-      prefix={'/apps/' + appSlug}
+      prefix={applyMountPath('apps/' + appSlug)}
       action={this.action}
       primaryBackgroundColor={this.context.currentApp.primaryBackgroundColor}
       secondaryBackgroundColor={this.context.currentApp.secondaryBackgroundColor}

--- a/src/dashboard/Push/PushDetails.react.js
+++ b/src/dashboard/Push/PushDetails.react.js
@@ -32,6 +32,7 @@ import Toolbar                from 'components/Toolbar/Toolbar.react';
 import { Directions }         from 'lib/Constants';
 import { Link }               from 'react-router-dom';
 import { tableInfoBuilder }   from 'lib/PushUtils';
+import { applyMountPath }     from "lib/path";
 
 const EXP_STATS_URL = 'http://docs.parseplatform.org/ios/guide/#push-experiments';
 
@@ -178,7 +179,7 @@ let getExperimentPartial = (pushDetails, type, isMessageType, style) => {
 }
 
 let getPushDetailUrl = (context, pushId) => {
-  return `/apps/${context.currentApp.slug}/push/${pushId}`;
+  return applyMountPath(`apps/${context.currentApp.slug}/push/${pushId}`);
 }
 
 let formatAnalyticsData = (data) => {

--- a/src/dashboard/Settings/GeneralSettings.react.js
+++ b/src/dashboard/Settings/GeneralSettings.react.js
@@ -38,6 +38,7 @@ import unique                            from 'lib/unique';
 import validateAndSubmitConnectionString from 'lib/validateAndSubmitConnectionString';
 import { cost, features }                from 'dashboard/Settings/GeneralSettings.scss';
 import { Link }                          from 'react-router-dom';
+import { applyMountPath }                from "lib/path";
 
 const DEFAULT_SETTINGS_LABEL_WIDTH = 62;
 
@@ -225,7 +226,7 @@ let ManageAppFields = ({
         description='View your migration progress.' />}
       input={<FormButton
         color='blue'
-        onClick={() => history.push(`/apps/${appSlug}/migration`)}
+        onClick={() => history.push(applyMountPath(`apps/${appSlug}/migration`))}
         value='View progress' />} />
   } else {
     migrateAppField = [<Field
@@ -305,7 +306,7 @@ let ManageAppFields = ({
     {cloneAppMessage ? <FormNote
       show={true}
       color='green'>
-      <div>{cloneAppMessage} Check out the progress on your <Link to={{ pathname: '/apps' }}>apps page</Link>!</div>
+      <div>{cloneAppMessage} Check out the progress on your <Link to={{ pathname: applyMountPath('apps') }}>apps page</Link>!</div>
     </FormNote> : null}
     {!isCollaborator ? <Field
       labelWidth={DEFAULT_SETTINGS_LABEL_WIDTH}
@@ -424,7 +425,7 @@ export default class GeneralSettings extends DashboardView {
         return promise;
       }}
       onClose={closeModalWithConnectionString}
-      onSuccess={() => history.push(`/apps/${this.context.currentApp.slug}/migration`)}
+      onSuccess={() => history.push(applyMountPath(`apps/${this.context.currentApp.slug}/migration`))}
       clearFields={() => this.setState({
         migrationMongoURL: '',
         migrationWarnings: [],
@@ -535,7 +536,7 @@ export default class GeneralSettings extends DashboardView {
       inProgressText={'Deleting\u2026'}
       enabled={this.state.password.length > 0}
       onSubmit={() => AppsManager.deleteApp(this.context.currentApp.slug, this.state.password)}
-      onSuccess={() => history.push('/apps')}
+      onSuccess={() => history.push(applyMountPath('apps'))}
       onClose={() => this.setState({showDeleteAppModal: false})}
       clearFields={() => this.setState({password: ''})}>
       {passwordField}

--- a/src/dashboard/Settings/HostingSettings.react.js
+++ b/src/dashboard/Settings/HostingSettings.react.js
@@ -20,6 +20,7 @@ import TextInput               from 'components/TextInput/TextInput.react';
 import Toggle                  from 'components/Toggle/Toggle.react';
 import Toolbar                 from 'components/Toolbar/Toolbar.react';
 import unique                  from 'lib/unique';
+import { applyMountPath }      from 'lib/path';
 
 export default class HostingSettings extends DashboardView {
 	constructor() {
@@ -220,7 +221,7 @@ export default class HostingSettings extends DashboardView {
 				label={<Label
 					text={"Custom “choose a new password” page"}
 					//getSiteDomain() is required here and not for the other templates because this template is an erb file, as opposed to the others which are html.
-					description={<span>This page will be loaded when users click on a reset password link. <a href={getSiteDomain() + '/apps/choose_password'} download="choose_password.html">Download the template</a>.</span>} />
+					description={<span>This page will be loaded when users click on a reset password link. <a href={getSiteDomain() + applyMountPath('apps/choose_password')} download="choose_password.html">Download the template</a>.</span>} />
 				}
 				input={<TextInput
 					value={fields.choose_password_link}

--- a/src/dashboard/SidebarBuilder.js
+++ b/src/dashboard/SidebarBuilder.js
@@ -5,14 +5,15 @@
  * This source code is licensed under the license found in the LICENSE file in
  * the root directory of this source tree.
  */
-import React          from 'react';
-import Sidebar        from 'components/Sidebar/Sidebar.react';
+import React              from 'react';
+import Sidebar            from 'components/Sidebar/Sidebar.react';
+import { applyMountPath } from 'lib/path';
 
 let accountSidebarSections = [
   {
     name: 'Your Apps',
     icon: 'blank-app-outline',
-    link: '/apps'
+    link: applyMountPath('apps')
   }, /*{
     name: 'Account Settings',
     icon: 'users-solid',

--- a/src/dashboard/index.js
+++ b/src/dashboard/index.js
@@ -10,10 +10,10 @@ import installDevTools from 'immutable-devtools';
 import React           from 'react';
 import ReactDOM        from 'react-dom';
 import Dashboard       from './Dashboard';
+import { mountPath}    from 'lib/path';
 import '@babel/polyfill';
 
 require('stylesheets/fonts.scss');
 installDevTools(Immutable);
 
-var path = window.PARSE_DASHBOARD_PATH || '/';
-ReactDOM.render(<Dashboard path={path}/>, document.getElementById('browser_mount'));
+ReactDOM.render(<Dashboard path={mountPath}/>, document.getElementById('browser_mount'));

--- a/src/lib/AppsManager.js
+++ b/src/lib/AppsManager.js
@@ -7,6 +7,7 @@
  */
 import ParseApp           from 'lib/ParseApp';
 import { post, del } from 'lib/AJAX';
+import { applyMountPath } from "lib/path";
 
 let appsStore = [];
 
@@ -39,7 +40,7 @@ const AppsManager = {
     if (connectionURL) {
       payload.parse_app.connectionString = connectionURL;
     }
-    return post('/apps', payload).then((response) => {
+    return post(applyMountPath('apps'), payload).then((response) => {
       let newApp = new ParseApp(response.app);
       appsStore.push(newApp);
       return newApp;
@@ -47,7 +48,7 @@ const AppsManager = {
   },
 
   deleteApp(slug, password) {
-    return del('/apps/' + slug + '?password_confirm_delete=' + password).then(() => {
+    return del(applyMountPath('apps/' + slug + '?password_confirm_delete=' + password)).then(() => {
       for (let i = 0; i < appsStore.length; i++) {
         if (appsStore[i].slug == slug) {
           appsStore.splice(i, 1);
@@ -90,7 +91,7 @@ const AppsManager = {
         optionsForRuby[option] = true;
       }
     });
-    let path = '/apps/' + slug + '/clone_app';
+    let path = applyMountPath('apps/' + slug + '/clone_app');
     let request = post(path, {
       app_name: name,
       options: optionsForRuby,
@@ -114,7 +115,7 @@ const AppsManager = {
       payload.password_confirm_transfer = password;
     }
 
-    let promise = post('/apps/' + slug + '/transfer', payload);
+    let promise = post(applyMountPath('apps/' + slug + '/transfer'), payload);
     promise.then(() => {
       //TODO modify appsStore to reflect transfer
     });

--- a/src/lib/ParseApp.js
+++ b/src/lib/ParseApp.js
@@ -5,12 +5,13 @@
  * This source code is licensed under the license found in the LICENSE file in
  * the root directory of this source tree.
  */
-import * as AJAX      from 'lib/AJAX';
-import encodeFormData from 'lib/encodeFormData';
-import Parse          from 'parse';
+import * as AJAX          from 'lib/AJAX';
+import encodeFormData     from 'lib/encodeFormData';
+import Parse              from 'parse';
+import { applyMountPath } from "lib/path";
 
 function setEnablePushSource(setting, enable) {
-  let path = `/apps/${this.slug}/update_push_notifications`;
+  let path = applyMountPath(`apps/${this.slug}/update_push_notifications`);
   let attr = `parse_app[${setting}]`;
   let body = {};
   body[attr] = enable ? 'true' : 'false';
@@ -218,7 +219,7 @@ export default class ParseApp {
 
   getAnalyticsRetention(time) {
     time = Math.round(time.getTime() / 1000);
-    return AJAX.abortableGet('/apps/' + this.slug + '/analytics_retention?at=' + time);
+    return AJAX.abortableGet(applyMountPath('apps/' + this.slug + '/analytics_retention?at=' + time));
   }
 
   getAnalyticsOverview(time) {
@@ -233,7 +234,7 @@ export default class ParseApp {
       'monthly_installations',
       'total_installations'
     ].map((activity) => {
-      let { xhr, promise } = AJAX.abortableGet('/apps/' + this.slug + '/analytics_content_audience?at=' + time + '&audienceType=' + activity);
+      let { xhr, promise } = AJAX.abortableGet(applyMountPath('apps/' + this.slug + '/analytics_content_audience?at=' + time + '&audienceType=' + activity));
       promise = promise.then((result) => (
         result.total === undefined ? result.content : result.total
       ));
@@ -245,7 +246,7 @@ export default class ParseApp {
       'billing_database_storage',
       'billing_data_transfer'
     ].map((billing) => (
-      AJAX.abortableGet('/apps/' + this.slug + '/' + billing)
+      AJAX.abortableGet(applyMountPath('apps/' + this.slug + '/' + billing))
     ));
 
     let allPromises = audiencePromises.concat(billingPromises);
@@ -266,20 +267,20 @@ export default class ParseApp {
   }
 
   getAnalyticsTimeSeries(query) {
-    let path = '/apps/' + this.slug + '/analytics?' + encodeFormData(null, query);
+    let path = applyMountPath('apps/' + this.slug + '/analytics?' + encodeFormData(null, query));
     let { promise, xhr } = AJAX.abortableGet(path);
     promise = promise.then(({ requested_data }) => requested_data);
     return { promise, xhr };
   }
 
   getAnalyticsSlowQueries(className, os, version, from, to) {
-    let path = '/apps/' + this.slug + '/slow_queries?' + encodeFormData(null, {
+    let path = applyMountPath('apps/' + this.slug + '/slow_queries?' + encodeFormData(null, {
       className: className || '',
       os: os || '',
       version: version || '',
       from: from.getTime() / 1000,
       to: to.getTime() / 1000
-    });
+    }));
     let { promise, xhr } = AJAX.abortableGet(path);
     promise = promise.then(({ result }) => result);
 
@@ -287,38 +288,38 @@ export default class ParseApp {
   }
 
   getAppleCerts() {
-    let path = '/apps/' + this.slug + '/apple_certificates';
+    let path = applyMountPath('apps/' + this.slug + '/apple_certificates');
     return AJAX.get(path).then(({ certs }) => certs);
   }
 
   uploadAppleCert(file) {
-    let path = '/apps/' + this.slug + '/dashboard_ajax/push_certificate';
+    let path = applyMountPath('apps/' + this.slug + '/dashboard_ajax/push_certificate');
     let data = new FormData();
     data.append('new_apple_certificate', file);
     return AJAX.post(path, data).then(({ cert }) => cert);
   }
 
   deleteAppleCert(id) {
-    let path = '/apps/' + this.slug + '/apple_certificates/' + id;
+    let path = applyMountPath('apps/' + this.slug + '/apple_certificates/' + id);
     return AJAX.del(path);
   }
 
   uploadSSLPublicCertificate(file) {
-    let path = '/apps/' + this.slug + '/update_hosting_certificates';
+    let path = applyMountPath('apps/' + this.slug + '/update_hosting_certificates');
     let data= new FormData();
     data.append('new_hosting_certificate[certificate_data]', file);
     return AJAX.put(path, data);
   }
 
   uploadSSLPrivateKey(file) {
-    let path = '/apps/' + this.slug + '/update_hosting_certificates';
+    let path = applyMountPath('apps/' + this.slug + '/update_hosting_certificates');
     let data= new FormData();
     data.append('new_hosting_certificate[key_data]', file);
     return AJAX.put(path, data);
   }
 
   saveSettingsFields(fields) {
-    let path = '/apps/' + this.slug;
+    let path = applyMountPath('apps/' + this.slug);
     let appFields = {};
     for (let f in fields) {
       appFields['parse_app[' + f + ']'] = fields[f];
@@ -337,7 +338,7 @@ export default class ParseApp {
     if (new Date() - this.settings.lastFetched < 60000) {
       return Promise.resolve(this.settings.fields);
     }
-    let path = '/apps/' + this.slug + '/dashboard_ajax/settings';
+    let path = applyMountPath('apps/' + this.slug + '/dashboard_ajax/settings');
     return AJAX.get(path).then((fields) => {
       for (let f in fields) {
         this.settings.fields[f] = fields[f];
@@ -348,17 +349,17 @@ export default class ParseApp {
   }
 
   cleanUpFiles() {
-    let path = '/apps/' + this.slug + '/cleanup_files';
+    let path = applyMountPath('apps/' + this.slug + '/cleanup_files');
     return AJAX.put(path);
   }
 
   exportData() {
-    let path = '/apps/' + this.slug + '/export_data';
+    let path = applyMountPath('apps/' + this.slug + '/export_data');
     return AJAX.put(path);
   }
 
   resetMasterKey(password) {
-    let path = '/apps/' + this.slug + '/reset_master_key';
+    let path = applyMountPath('apps/' + this.slug + '/reset_master_key');
     return AJAX.post(
       path,
       { password_confirm_reset_master_key: password }
@@ -370,7 +371,7 @@ export default class ParseApp {
 
   clearCollection(className) {
     if (this.serverInfo.parseServerVersion == 'Parse.com') {
-      let path = `/apps/${this.slug}/collections/${className}/clear`;
+      let path = applyMountPath(`apps/${this.slug}/collections/${className}/clear`);
       return AJAX.del(path);
     } else {
       let path = `purge/${className}`;
@@ -379,7 +380,7 @@ export default class ParseApp {
   }
 
   validateCollaborator(email) {
-    let path = '/apps/' + this.slug + '/collaborations/validate?email=' + encodeURIComponent(email);
+    let path = applyMountPath('apps/' + this.slug + '/collaborations/validate?email=' + encodeURIComponent(email));
     return AJAX.get(path);
   }
 
@@ -412,7 +413,7 @@ export default class ParseApp {
   }
 
   fetchPushAudienceSizeSuggestion() {
-    let path = '/apps/' + this.slug + '/push_notifications/audience_size_suggestion';
+    let path = applyMountPath('apps/' + this.slug + '/push_notifications/audience_size_suggestion');
     return AJAX.get(path);
   }
 
@@ -431,7 +432,7 @@ export default class ParseApp {
   }
 
   fetchPushLocaleDeviceCount(audienceId, where, locales) {
-    let path = '/apps/' + this.slug + '/push_subscriber_translation_count';
+    let path = applyMountPath('apps/' + this.slug + '/push_subscriber_translation_count');
     let urlsSeparator = '?';
     path += `?where=${encodeURI(JSON.stringify(where || {}))}`;
     path += `&locales=${encodeURI(JSON.stringify(locales))}`
@@ -440,12 +441,12 @@ export default class ParseApp {
   }
 
   fetchAvailableDevices() {
-    let path = '/apps/' + this.slug + '/dashboard_ajax/available_devices';
+    let path = applyMountPath('apps/' + this.slug + '/dashboard_ajax/available_devices');
     return AJAX.get(path);
   }
 
   removeCollaboratorById(id) {
-    let path = '/apps/' + this.slug + '/collaborations/' + id.toString();
+    let path = applyMountPath('apps/' + this.slug + '/collaborations/' + id.toString());
     let promise = AJAX.del(path)
     promise.then(() => {
       //TODO: this currently works because everything that uses collaborators
@@ -457,7 +458,7 @@ export default class ParseApp {
   }
 
   addCollaborator(email) {
-    let path = '/apps/' + this.slug + '/collaborations';
+    let path = applyMountPath('apps/' + this.slug + '/collaborations');
     let promise = AJAX.post(path, {'collaboration[email]': email});
     promise.then(({ data }) => {
       //TODO: this currently works because everything that uses collaborators
@@ -478,7 +479,7 @@ export default class ParseApp {
   }
 
   setAppName(name) {
-    let path = '/apps/' + this.slug;
+    let path = applyMountPath('apps/' + this.slug);
     let promise = AJAX.put(path, {'parse_app[name]': name});
     promise.then(() => {
       this.name = name;
@@ -487,7 +488,7 @@ export default class ParseApp {
   }
 
   setAppStoreURL(type, url) {
-    let path = '/apps/' + this.slug;
+    let path = applyMountPath('apps/' + this.slug);
     let promise = AJAX.put(path, {['parse_app[parse_app_metadata][url][' + type + ']']: url});
     promise.then(() => {
       this.settings.fields.fields.urls.unshift({platform: type, url: url});
@@ -496,7 +497,7 @@ export default class ParseApp {
   }
 
   setInProduction(inProduction) {
-    let path = '/apps/' + this.slug;
+    let path = applyMountPath('apps/' + this.slug);
     let promise = AJAX.put(path, {'parse_app[parse_app_metadata][production]': inProduction ? 'true' : 'false'});
     promise.then(() => {
       this.production = inProduction;
@@ -505,7 +506,7 @@ export default class ParseApp {
   }
 
   launchExperiment(objectId, formData) {
-    let path = `/apps/${this.slug}/push_notifications/${objectId}/launch_experiment`;
+    let path = applyMountPath(`apps/${this.slug}/push_notifications/${objectId}/launch_experiment`);
     return AJAX.post(path, formData);
   }
 
@@ -513,12 +514,12 @@ export default class ParseApp {
     if (!where) {
       where = {};
     }
-    let path = '/apps/' + this.slug + '/export_data';
+    let path = applyMountPath('apps/' + this.slug + '/export_data');
     return AJAX.put(path, { name: className, where: where });
   }
 
   getExportProgress() {
-    let path = '/apps/' + this.slug + '/export_progress';
+    let path = applyMountPath('apps/' + this.slug + '/export_progress');
     return AJAX.get(path);
   }
 
@@ -561,7 +562,7 @@ export default class ParseApp {
   }
 
   getMigrations() {
-    let path = '/apps/' + this.slug + '/migrations';
+    let path = applyMountPath('apps/' + this.slug + '/migrations');
     let obj = AJAX.abortableGet(path);
     this.hasCheckedForMigraton = true
     obj.promise.then(({ migration }) => {
@@ -572,12 +573,12 @@ export default class ParseApp {
 
   beginMigration(connectionString) {
     this.hasCheckedForMigraton = false;
-    let path = '/apps/' + this.slug + '/migrations';
+    let path = applyMountPath('apps/' + this.slug + '/migrations');
     return AJAX.post(path, {connection_string: connectionString});
   }
 
   changeConnectionString(newConnectionString) {
-    let path = '/apps/' + this.slug + '/change_connection_string';
+    let path = applyMountPath('apps/' + this.slug + '/change_connection_string');
     let promise = AJAX.post(path, {connection_string: newConnectionString});
     promise.then(() => {
       this.settings.fields.fields.opendb_connection_string = newConnectionString;
@@ -587,19 +588,19 @@ export default class ParseApp {
 
   stopMigration() {
     //We will need to pass the real ID here if we decide to have migrations deletable by id. For now, from the users point of view, there is only one migration per app.
-    let path = '/apps/' + this.slug + '/migrations/0';
+    let path = applyMountPath('apps/' + this.slug + '/migrations/0');
     return AJAX.del(path);
   }
 
   commitMigration() {
     //Migration IDs are not to be exposed, so pass 0 as ID and let rails fetch the correct ID
-    let path = '/apps/' + this.slug + '/migrations/0/commit';
+    let path = applyMountPath('apps/' + this.slug + '/migrations/0/commit');
     //No need to update anything, UI will autorefresh once request goes through and mowgli enters FINISH/DONE state
     return AJAX.post(path);
   }
 
   setRequireRevocableSessions(require) {
-    let path = '/apps/' + this.slug;
+    let path = applyMountPath('apps/' + this.slug);
     let promise = AJAX.put(path, {'parse_app[require_revocable_session]': require ? 'true' : 'false'});
     promise.then(() => {
       //TODO: this currently works because everything that uses this
@@ -611,7 +612,7 @@ export default class ParseApp {
   }
 
   setExpireInactiveSessions(require) {
-    let path = '/apps/' + this.slug;
+    let path = applyMountPath('apps/' + this.slug);
     let promise = AJAX.put(path, {'parse_app[expire_revocable_session]': require ? 'true' : 'false'});
     promise.then(() => {
       //TODO: this currently works because everything that uses this
@@ -623,7 +624,7 @@ export default class ParseApp {
   }
 
   setRevokeSessionOnPasswordChange(require) {
-    let path = '/apps/' + this.slug;
+    let path = applyMountPath('apps/' + this.slug);
     let promise = AJAX.put(path, {'parse_app[revoke_on_password_reset]': require ? 'true' : 'false'});
     promise.then(() => {
       //TODO: this currently works because everything that uses this
@@ -635,7 +636,7 @@ export default class ParseApp {
   }
 
   setEnableNewMethodsByDefault(require) {
-    let path = '/apps/' + this.slug;
+    let path = applyMountPath('apps/' + this.slug);
     let promise = AJAX.put(path, {'parse_app[auth_options_attributes][_enable_by_default_as_bool]': require ? 'true' : 'false'});
     promise.then(() => {
       //TODO: this currently works because everything that uses this
@@ -647,7 +648,7 @@ export default class ParseApp {
   }
 
   setAllowUsernameAndPassword(require) {
-    let path = '/apps/' + this.slug;
+    let path = applyMountPath('apps/' + this.slug);
     let promise = AJAX.put(path, {'parse_app[auth_options_attributes][username_attributes][enabled_as_bool]': require ? 'true' : 'false'});
     promise.then(() => {
       //TODO: this currently works because everything that uses this
@@ -659,7 +660,7 @@ export default class ParseApp {
   }
 
   setAllowAnonymousUsers(require) {
-    let path = '/apps/' + this.slug;
+    let path = applyMountPath('apps/' + this.slug);
     let promise = AJAX.put(path, {'parse_app[auth_options_attributes][anonymous_attributes][enabled_as_bool]': require ? 'true' : 'false'});
     promise.then(() => {
       //TODO: this currently works because everything that uses this
@@ -671,7 +672,7 @@ export default class ParseApp {
   }
 
   setAllowCustomAuthentication(require) {
-    let path = '/apps/' + this.slug;
+    let path = applyMountPath('apps/' + this.slug);
     let promise = AJAX.put(path, {'parse_app[auth_options_attributes][custom_attributes][enabled_as_bool]': require ? 'true' : 'false'});
     promise.then(() => {
       //TODO: this currently works because everything that uses this
@@ -683,7 +684,7 @@ export default class ParseApp {
   }
 
   setConnectedFacebookApps(idList, secretList) {
-    let path = '/apps/' + this.slug;
+    let path = applyMountPath('apps/' + this.slug);
     let promise = AJAX.put(path, {
       'parse_app[auth_options_attributes][facebook_attributes][app_ids_as_list]': idList.join(','),
       'parse_app[auth_options_attributes][facebook_attributes][app_secrets_as_list]': secretList.join(','),
@@ -702,7 +703,7 @@ export default class ParseApp {
   }
 
   setAllowFacebookAuth(enable) {
-    let path = '/apps/' + this.slug;
+    let path = applyMountPath('apps/' + this.slug);
     let promise = AJAX.put(path, {
       'parse_app[auth_options_attributes][facebook_attributes][enabled_as_bool]': enable ? 'true' : 'false',
     });
@@ -713,7 +714,7 @@ export default class ParseApp {
   }
 
   setConnectedTwitterApps(consumerKeyList) {
-    let path = '/apps/' + this.slug;
+    let path = applyMountPath('apps/' + this.slug);
     let promise = AJAX.put(path, {
       'parse_app[auth_options_attributes][twitter_attributes][consumer_keys_as_list]': consumerKeyList.join(','),
     });
@@ -729,7 +730,7 @@ export default class ParseApp {
   }
 
   setAllowTwitterAuth(allow) {
-    let path = '/apps/' + this.slug;
+    let path = applyMountPath('apps/' + this.slug);
     let promise = AJAX.put(path, {
       'parse_app[auth_options_attributes][twitter_attributes][enabled_as_bool]': allow ? 'true' : 'false',
     });
@@ -748,7 +749,7 @@ export default class ParseApp {
   }
 
   addGCMCredentials(sender_id, api_key) {
-    let path = '/apps/' + this.slug + '/update_push_notifications'
+    let path = applyMountPath('apps/' + this.slug + '/update_push_notifications');
     let promise = AJAX.post(path, {
       gcm_sender_id: sender_id,
       gcm_api_key: api_key
@@ -760,7 +761,7 @@ export default class ParseApp {
   }
 
   deleteGCMPushCredentials(GCMSenderID) {
-    let path = '/apps/' + this.slug + '/delete_gcm_push_credential?gcm_sender_id='+GCMSenderID;
+    let path = applyMountPath('apps/' + this.slug + '/delete_gcm_push_credential?gcm_sender_id='+GCMSenderID);
     let promise = AJAX.get(path);
     promise.then(() => {
       this.settings.fields.fields.gcm_credentials = this.settings.fields.fields.gcm_credentials.filter(cred =>

--- a/src/lib/path.js
+++ b/src/lib/path.js
@@ -1,0 +1,5 @@
+export const mountPath = window.PARSE_DASHBOARD_PATH;
+
+export function applyMountPath(path) {
+  return `${mountPath}${path}`
+}

--- a/src/lib/stores/AnalyticsQueryStore.js
+++ b/src/lib/stores/AnalyticsQueryStore.js
@@ -9,6 +9,7 @@ import { get, post, put } from 'lib/AJAX';
 import keyMirror          from 'lib/keyMirror';
 import { Map }            from 'immutable';
 import { registerStore }  from 'lib/stores/StoreManager';
+import { applyMountPath } from "lib/path";
 
 const LABEL_TO_KEY_MAPPING = {
   // Display Type
@@ -167,7 +168,7 @@ export const ActionTypes = keyMirror([
 
 function AnalyticsQueryStore(state, action) {
   action.app.setParseKeys();
-  let urlPrefix = `/apps/${action.app.slug}/explorer`;
+  let urlPrefix = applyMountPath(`apps/${action.app.slug}/explorer`);
 
   switch (action.type) {
     case ActionTypes.LIST:

--- a/src/login/index.js
+++ b/src/login/index.js
@@ -5,13 +5,13 @@
  * This source code is licensed under the license found in the LICENSE file in
  * the root directory of this source tree.
  */
-import Login    from './Login';
-import React    from 'react';
-import ReactDOM from 'react-dom';
+import Login        from './Login';
+import React        from 'react';
+import ReactDOM     from 'react-dom';
+import { mountPath} from 'lib/path';
 
 require('stylesheets/fonts.scss');
 
 // App entry point
 
-var path = window.PARSE_DASHBOARD_PATH || '/';
-ReactDOM.render(<Login path={path}/>, document.getElementById('login_mount'));
+ReactDOM.render(<Login path={mountPath}/>, document.getElementById('login_mount'));


### PR DESCRIPTION
TL;DR: single app redirection is not the root of our issue here, all mounted dashboards seem broken when using 1.3.0.

When upgrading to the latest version of the dashboard, I encountered the same issue as folks in #1054: app redirects and doesn't keep the mounting point.

Since I made the single app redirection changes in the first place (#958) and it was just a couple lines of code, I started investigating and I'm now 100% confident the problem was misattributed to the single app redirection in the first place.

Unless I'm missing something, something changed between 1.2.0 and 1.3.0. Commenting the code I wrote in #958 didn't fix the issue. I tracked the bad redirection to the following line:
```
// Dashboard.js#312
<Redirect from='/' to='/apps' />`
```

But that's not it! Basically, it looks like the mounting point is lost and the navigation is totally broken when the mountPath is not `/`. I've no idea how it was even working before since the whole app is referring/redirecting to `/apps` everywhere, without referencing the eventual mount path.

This PR is the result of a painful work trying to add the mountPath everywhere I found it was needed, but to be honest, I had no idea was I was doing the whole time, there might be a simple solution.

@flovilmart: I would love your assistance and opinion on this, thanks!