### PR TITLE
Fix getFileName lib to display correctly the filename

### DIFF
--- a/src/lib/getFileName.js
+++ b/src/lib/getFileName.js
@@ -11,9 +11,6 @@ export default function getFileName(name) {
   if (name instanceof Parse.File) {
     return getFileName(name.name());
   }
-  let offset = 37;
-  if (name.indexOf('tfss-') === 0) {
-    offset += 5;
-  }
+  const offset = name.indexOf('_') + 1;
   return name.substr(offset);
 }

--- a/src/lib/tests/getFileName.test.js
+++ b/src/lib/tests/getFileName.test.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2016-present, Parse, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+jest.dontMock('../getFileName');
+const getFileName = require('../getFileName').default;
+const Parse = require('parse');
+
+describe('getFileName', () => {
+  it('get filename prefixed with hex', () => {
+    const actualFilename = 'profile.jpg';
+    expect(getFileName(`7b16230f584b360f667665fcb7d7a98b_${actualFilename}`)).toBe(actualFilename);
+
+    const parseFile = new Parse.File(`7b16230f584b360f667665fcb7d7a98b_${actualFilename}`);
+    expect(getFileName(parseFile)).toBe(actualFilename);
+  });
+
+  it('get filename containing underscore and prefixed with hex', () => {
+    const actualFilename = 'bg_img.png';
+    expect(getFileName(`7b16230f584b360f667665fcb7d7a98b_${actualFilename}`)).toBe(actualFilename);
+
+    const parseFile = new Parse.File(`7b16230f584b360f667665fcb7d7a98b_${actualFilename}`);
+    expect(getFileName(parseFile)).toBe(actualFilename);
+  });
+});


### PR DESCRIPTION
Fixes #1121 

This PR fixes the removal of [hex prefix generated by parse server](https://github.com/parse-community/parse-server/blob/d83a0b680854f52ce30205d3558c0133d7f8cf19/src/Controllers/FilesController.js#L29) and add tests for this function.