### PR TITLE
fix: AppsMenu broken layout when app name is too long

### DIFF
--- a/src/components/Sidebar/AppsMenu.react.js
+++ b/src/components/Sidebar/AppsMenu.react.js
@@ -24,7 +24,7 @@ let AppsMenu = ({ apps, current, height, onSelect }) => (
         }
         return (
           <Link to={{ pathname: html`/apps/${app.slug}/browser` }} key={app.slug} className={styles.menuRow} onClick={onSelect.bind(null, current.slug)}>
-            {app.name}
+            <span>{app.name}</span>
             <AppBadge production={app.production} />
           </Link>
         );


### PR DESCRIPTION
This PR fixes the layout issue that occurs when an app name is too long.

The screenshot of the issue:
![image](https://user-images.githubusercontent.com/14318858/61550110-1046cd00-aa28-11e9-8d19-a3ad2c457c3f.png)

and after this PR:
![image](https://user-images.githubusercontent.com/14318858/61550372-a4b12f80-aa28-11e9-8344-4ed22b442ea3.png)
