### PR TITLE
feat: Add required and default value options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -119,6 +119,12 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
         }
       }
     },
@@ -1094,6 +1100,14 @@
         "@babel/helper-plugin-utils": "^7.0.0",
         "resolve": "^1.8.1",
         "semver": "^5.5.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
@@ -1232,6 +1246,12 @@
             "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           }
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
         }
       }
     },
@@ -4074,6 +4094,14 @@
         "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
       }
     },
     "cryptiles": {
@@ -4641,6 +4669,13 @@
         "lru-cache": "^4.1.5",
         "semver": "^5.6.0",
         "sigmund": "^1.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+        }
       }
     },
     "ee-first": {
@@ -5739,12 +5774,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5759,17 +5796,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5886,7 +5926,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5898,6 +5939,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5912,6 +5954,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5919,12 +5962,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5943,6 +5988,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6023,7 +6069,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6035,6 +6082,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6156,6 +6204,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8124,6 +8173,14 @@
         "natural-compare": "^1.4.0",
         "pretty-format": "^24.8.0",
         "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
       }
     },
     "jest-util": {
@@ -8390,6 +8447,12 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true
         }
       }
@@ -8782,6 +8845,12 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true
         }
       }
@@ -9557,6 +9626,14 @@
         "semver": "^5.5.0",
         "shellwords": "^0.1.1",
         "which": "^1.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
       }
     },
     "node-pre-gyp": {
@@ -9582,6 +9659,13 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
           "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+          "dev": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true,
           "optional": true
         },
@@ -9617,6 +9701,14 @@
       "dev": true,
       "requires": {
         "semver": "^5.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
       }
     },
     "node-rsa": {
@@ -9805,6 +9897,14 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
       }
     },
     "normalize-path": {
@@ -10340,10 +10440,10 @@
       "requires": {
         "@apollographql/graphql-playground-html": "1.6.24",
         "@parse/fs-files-adapter": "1.0.1",
-        "@parse/push-adapter": "3.0.0",
+        "@parse/push-adapter": "3.0.8",
         "@parse/s3-files-adapter": "1.2.3",
         "@parse/simple-mailgun-adapter": "1.1.0",
-        "apollo-server-express": "2.7.0",
+        "apollo-server-express": "2.8.0",
         "bcrypt": "3.0.6",
         "bcryptjs": "2.4.3",
         "body-parser": "1.19.0",
@@ -10363,14 +10463,13 @@
         "mime": "2.4.4",
         "mongodb": "3.2.7",
         "node-rsa": "1.0.5",
-        "parse": "2.5.1",
-        "pg-promise": "8.7.5",
+        "parse": "2.6.0",
+        "pg-promise": "9.0.0",
         "redis": "2.8.0",
         "semver": "6.3.0",
         "subscriptions-transport-ws": "0.9.16",
         "tv4": "1.3.0",
         "uuid": "3.3.2",
-        "uws": "10.148.1",
         "winston": "3.2.1",
         "winston-daily-rotate-file": "3.10.0",
         "ws": "7.1.1"
@@ -10602,9 +10701,9 @@
           }
         },
         "semver": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
-          "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==",
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         },
         "ws": {
@@ -12091,6 +12190,12 @@
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
           "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
           "dev": true
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
         }
       }
     },
@@ -12550,6 +12655,14 @@
         "neo-async": "^2.5.0",
         "pify": "^3.0.0",
         "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
       }
     },
     "sax": {
@@ -12611,9 +12724,9 @@
       "optional": true
     },
     "semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
     },
     "send": {
       "version": "0.17.1",
@@ -14040,13 +14153,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-    },
-    "uws": {
-      "version": "10.148.1",
-      "resolved": "https://registry.npmjs.org/uws/-/uws-10.148.1.tgz",
-      "integrity": "sha1-/Rp5z2EYo4jgob7YoTlwMNLE/Sw=",
-      "dev": true,
-      "optional": true
     },
     "v8-compile-cache": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "react-helmet": "5.2.1",
     "react-redux": "5.1.1",
     "react-router": "5.0.1",
-    "react-router-dom": "5.0.1"
+    "react-router-dom": "5.0.1",
+    "semver": "^6.3.0"
   },
   "devDependencies": {
     "@babel/core": "7.5.5",

--- a/src/components/Toggle/Toggle.react.js
+++ b/src/components/Toggle/Toggle.react.js
@@ -100,7 +100,7 @@ export default class Toggle extends React.Component {
       toggleClasses.push(styles.darkBg);
     }
     return (
-      <div className={toggleClasses.join(' ')}>
+      <div className={toggleClasses.join(' ')} style={this.props.additionalStyles || {}}>
         <span className={styles.label} onClick={this.toLeft.bind(this)}>{labelLeft}</span>
         <span className={switchClasses.join(' ')} onClick={this.toggle.bind(this)}></span>
         <span className={styles.label} onClick={this.toRight.bind(this)}>{labelRight}</span>
@@ -122,6 +122,7 @@ Toggle.propTypes = {
   labelRight: PropTypes.string.describe('Custom right toggle label, case when label does not equal content. [For Toggle.Type.CUSTOM]'),
   colored: PropTypes.bool.describe('Flag describing is toggle is colored. [For Toggle.Type.CUSTOM]'),
   darkBg: PropTypes.bool,
+  additionalStyles: PropTypes.object.describe('Additional styles for Toggle component.'),
 };
 
 Toggle.Types = {

--- a/src/dashboard/Data/Browser/AddColumnDialog.react.js
+++ b/src/dashboard/Data/Browser/AddColumnDialog.react.js
@@ -115,7 +115,7 @@ export default class AddColumnDialog extends React.Component {
           formattedValue = new Parse.Polygon(JSON.parse(defaultValue))
           break
         case 'GeoPoint':
-          formattedValue = new Parse.GeoPoint(defaultValue)
+          formattedValue = new Parse.GeoPoint(JSON.parse(defaultValue))
           break;
         case 'Pointer':
           formattedValue = await this.handlePointer(defaultValue, target)

--- a/src/dashboard/Data/Browser/AddColumnDialog.react.js
+++ b/src/dashboard/Data/Browser/AddColumnDialog.react.js
@@ -5,19 +5,21 @@
  * This source code is licensed under the license found in the LICENSE file in
  * the root directory of this source tree.
  */
+
+import Parse              from 'parse'
+import React              from 'react';
+import semver             from 'semver';
 import Dropdown           from 'components/Dropdown/Dropdown.react';
 import Field              from 'components/Field/Field.react';
 import Label              from 'components/Label/Label.react';
 import Modal              from 'components/Modal/Modal.react';
 import Option             from 'components/Dropdown/Option.react';
-import React              from 'react';
 import TextInput          from 'components/TextInput/TextInput.react';
 import Toggle             from 'components/Toggle/Toggle.react';
 import DateTimeInput      from 'components/DateTimeInput/DateTimeInput.react';
 import SegmentSelect      from 'components/SegmentSelect/SegmentSelect.react';
 import FileInput          from 'components/FileInput/FileInput.react';
 import styles             from 'dashboard/Data/Browser/Browser.scss';
-import Parse              from 'parse'
 import validateNumeric    from 'lib/validateNumeric';
 import {
   DataTypes,
@@ -39,6 +41,8 @@ export default class AddColumnDialog extends React.Component {
       defaultValue: undefined,
       isDefaultValueValid: true
     };
+
+    this.parseServerVersion = this.props.parseServerVersion
     this.renderDefaultValueInput = this.renderDefaultValueInput.bind(this)
     this.handleDefaultValueChange = this.handleDefaultValueChange.bind(this)
   }
@@ -204,6 +208,13 @@ export default class AddColumnDialog extends React.Component {
           label={<Label text='What should we call it?' description={'Don\u2019t use any special characters, and start your name with a letter.'} />}
           input={<TextInput placeholder='Give it a good name...' value={this.state.name} onChange={(name) => this.setState({ name })} />} />
         {
+          /*
+            Allow include require fields and default values if the parse-server
+            version is greater than or equal 3.7.0, that is the minimum version
+            support this feature and check if the field is not a relation
+          */
+          semver.valid(this.parseServerVersion) &&
+          semver.gte(this.parseServerVersion, '3.7.0') &&
           this.state.type !== 'Relation' ?
             <>
               <Field

--- a/src/dashboard/Data/Browser/AddColumnDialog.react.js
+++ b/src/dashboard/Data/Browser/AddColumnDialog.react.js
@@ -41,8 +41,6 @@ export default class AddColumnDialog extends React.Component {
       defaultValue: undefined,
       isDefaultValueValid: true
     };
-
-    this.parseServerVersion = this.props.parseServerVersion
     this.renderDefaultValueInput = this.renderDefaultValueInput.bind(this)
     this.handleDefaultValueChange = this.handleDefaultValueChange.bind(this)
   }
@@ -109,7 +107,11 @@ export default class AddColumnDialog extends React.Component {
           formattedValue = +defaultValue
           break
         case 'Array':
+          if (!Array.isArray(JSON.parse(defaultValue))) throw 'Invalid array'
+          formattedValue = JSON.parse(defaultValue)
+          break
         case 'Object':
+          if (typeof JSON.parse(defaultValue) !== 'object' || Array.isArray(JSON.parse(defaultValue))) throw 'Invalid object'
           formattedValue = JSON.parse(defaultValue)
           break
         case 'Date':
@@ -191,7 +193,6 @@ export default class AddColumnDialog extends React.Component {
         cancelText={'Never mind, don\u2019t.'}
         onCancel={this.props.onCancel}
         onConfirm={() => {
-          console.log(this.state)
           this.props.onConfirm(this.state);
         }}>
         <Field
@@ -213,8 +214,8 @@ export default class AddColumnDialog extends React.Component {
             version is greater than or equal 3.7.0, that is the minimum version
             support this feature and check if the field is not a relation
           */
-          semver.valid(this.parseServerVersion) &&
-          semver.gte(this.parseServerVersion, '3.7.0') &&
+          semver.valid(this.props.parseServerVersion) &&
+          semver.gte(this.props.parseServerVersion, '3.7.0') &&
           this.state.type !== 'Relation' ?
             <>
               <Field

--- a/src/dashboard/Data/Browser/AddColumnDialog.react.js
+++ b/src/dashboard/Data/Browser/AddColumnDialog.react.js
@@ -154,7 +154,7 @@ export default class AddColumnDialog extends React.Component {
       case 'String':
       case 'Pointer':
         return <TextInput
-          placeholder={type === 'Pointer' ? 'Set here a valid object ID' : 'Set here a default value'}
+          placeholder={type === 'Pointer' ? 'Set a valid object ID here' : 'Set a default value here'}
           onChange={async (defaultValue) => await this.handleDefaultValueChange(defaultValue)} />
       case 'Date':
         return <DateTimeInput
@@ -219,11 +219,11 @@ export default class AddColumnDialog extends React.Component {
           this.state.type !== 'Relation' ?
             <>
               <Field
-                label={<Label text='What is the default value?' description='If no value is specified for this column, it will be filled with its default value' />}
+                label={<Label text='What is the default value?' description='If no value is specified for this column, it will be filled with its default value.' />}
                 input={this.renderDefaultValueInput()}
                 className={styles.addColumnToggleWrapper} />
               <Field
-                label={<Label text='Is it a required field?' description={'When true this field must be filled when a new object is created'} />}
+                label={<Label text='Is it a required field?' description={'When true this field must be filled when a new object is created.'} />}
                 input={<Toggle value={this.state.required} type={Toggle.Types.YES_NO} onChange={(required) => this.setState({ required })} additionalStyles={{ margin: '0px' }} />}
                 className={styles.addColumnToggleWrapper} />
             </>

--- a/src/dashboard/Data/Browser/AddColumnDialog.react.js
+++ b/src/dashboard/Data/Browser/AddColumnDialog.react.js
@@ -12,6 +12,8 @@ import Modal              from 'components/Modal/Modal.react';
 import Option             from 'components/Dropdown/Option.react';
 import React              from 'react';
 import TextInput          from 'components/TextInput/TextInput.react';
+import Toggle             from 'components/Toggle/Toggle.react';
+import styles             from 'dashboard/Data/Browser/Browser.scss';
 import {
   DataTypes,
   SpecialClasses
@@ -27,7 +29,8 @@ export default class AddColumnDialog extends React.Component {
     this.state = {
       type: 'String',
       target: props.classes[0],
-      name: ''
+      name: '',
+      required: false
     };
   }
 
@@ -74,13 +77,13 @@ export default class AddColumnDialog extends React.Component {
         cancelText={'Never mind, don\u2019t.'}
         onCancel={this.props.onCancel}
         onConfirm={() => {
-          this.props.onConfirm(this.state.type, this.state.name, this.state.target);
+          this.props.onConfirm(this.state);
         }}>
         <Field
           label={
             <Label
               text='What type of data do you want to store?' />
-            }
+          }
           input={typeDropdown} />
         {this.state.type === 'Pointer' || this.state.type === 'Relation' ?
           <Field
@@ -89,6 +92,10 @@ export default class AddColumnDialog extends React.Component {
         <Field
           label={<Label text='What should we call it?' description={'Don\u2019t use any special characters, and start your name with a letter.'} />}
           input={<TextInput placeholder='Give it a good name...' value={this.state.name} onChange={(name) => this.setState({ name })} />}/>
+        <Field
+          label={<Label text='Is it a required field?' description={'When true this field must be filled when a new object is created'} />}
+          input={<Toggle value={this.state.required} type={Toggle.Types.YES_NO} onChange={(required) => this.setState({ required })}  additionalStyles={{ margin: '0px' }}/>}
+          className={styles.addColumnToggleWrapper}/>
       </Modal>
     );
   }

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -258,12 +258,13 @@ class Browser extends DashboardView {
     });
   }
 
-  addColumn(type, name, target) {
+  addColumn({ type, name, target, required }) {
     let payload = {
       className: this.props.params.className,
       columnType: type,
       name: name,
-      targetClass: target
+      targetClass: target,
+      required
     };
     this.props.schema.dispatch(ActionTypes.ADD_COLUMN, payload).finally(() => {
       this.setState({ showAddColumnDialog: false });

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -993,6 +993,7 @@ class Browser extends DashboardView {
           onConfirm={this.createClass} />
       );
     } else if (this.state.showAddColumnDialog) {
+      const { currentApp = {} } = this.context;
       let currentColumns = [];
       classes.get(className).forEach((field, name) => {
         currentColumns.push(name);
@@ -1002,7 +1003,8 @@ class Browser extends DashboardView {
           currentColumns={currentColumns}
           classes={this.props.schema.data.get('classes').keySeq().toArray()}
           onCancel={() => this.setState({ showAddColumnDialog: false })}
-          onConfirm={this.addColumn} />
+          onConfirm={this.addColumn}
+          parseServerVersion={currentApp.serverInfo && currentApp.serverInfo.parseServerVersion} />
       );
     } else if (this.state.showRemoveColumnDialog) {
       let currentColumns = this.getClassColumns(className).map(column => column.name);

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -258,13 +258,14 @@ class Browser extends DashboardView {
     });
   }
 
-  addColumn({ type, name, target, required }) {
+  addColumn({ type, name, target, required, defaultValue }) {
     let payload = {
       className: this.props.params.className,
       columnType: type,
       name: name,
       targetClass: target,
-      required
+      required,
+      defaultValue
     };
     this.props.schema.dispatch(ActionTypes.ADD_COLUMN, payload).finally(() => {
       this.setState({ showAddColumnDialog: false });

--- a/src/dashboard/Data/Browser/Browser.scss
+++ b/src/dashboard/Data/Browser/Browser.scss
@@ -138,6 +138,16 @@
   }
 }
 
+.addColumnToggleWrapper {
+  >:nth-child(2) {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 50%;
+    background: #f6fafb;
+  }
+}
+
 .notificationMessage, .notificationError {
   @include animation('fade-in 0.2s ease-out');
   position: absolute;

--- a/src/lib/stores/SchemaStore.js
+++ b/src/lib/stores/SchemaStore.js
@@ -75,7 +75,8 @@ function SchemaStore(state, action) {
       let newField = {
         [action.name]: {
           type: action.columnType,
-          required: action.required
+          required: action.required,
+          defaultValue: action.defaultValue
         }
       };
       if (action.columnType === 'Pointer' || action.columnType === 'Relation') {

--- a/src/lib/stores/SchemaStore.js
+++ b/src/lib/stores/SchemaStore.js
@@ -74,7 +74,8 @@ function SchemaStore(state, action) {
     case ActionTypes.ADD_COLUMN:
       let newField = {
         [action.name]: {
-          type: action.columnType
+          type: action.columnType,
+          required: action.required
         }
       };
       if (action.columnType === 'Pointer' || action.columnType === 'Relation') {

--- a/src/parse-interface-guide/routes.js
+++ b/src/parse-interface-guide/routes.js
@@ -11,7 +11,7 @@ import { Router, Route } from 'react-router';
 import { createBrowserHistory } from 'history';
 const history = createBrowserHistory({});
 
-module.exports = (
+const routes = (
 <Router history={history}>
   <div>
     <Route path='/:component?' render={(props) => {
@@ -20,3 +20,5 @@ module.exports = (
   </div>
 </Router>
 );
+
+export default routes


### PR DESCRIPTION
This PR means to add the feature developed in [#5835](https://github.com/parse-community/parse-server/pull/5835) to Parse-Dashboard, that includes the option to set required fields and default values to the schema. This feature is available for Parse-Server version >= 3.7.0 and all field types, except Relation.

Some screenshots:

- String
![image](https://user-images.githubusercontent.com/14318858/62139221-55d48700-b2bf-11e9-9604-6ede40f881f1.png)

- Boolean
![image](https://user-images.githubusercontent.com/14318858/62139348-8ae0d980-b2bf-11e9-98ec-77e34975c040.png)

- Field creating with an invalid default value
![image](https://user-images.githubusercontent.com/14318858/62140092-c039f700-b2c0-11e9-9100-0b1b42e7e8a3.png)

- Handle error on object creation
![image](https://user-images.githubusercontent.com/14318858/62139608-093d7b80-b2c0-11e9-8855-461d93fb343d.png)

