### PR TITLE
fix: Fonts on AppsIndex

### DIFF
--- a/src/components/Sidebar/Sidebar.scss
+++ b/src/components/Sidebar/Sidebar.scss
@@ -70,7 +70,7 @@ $footerHeight: 36px;
 }
 
 .footer {
-  @include NotoSansFont;
+  @include DosisFont;
   position: absolute;
   background: #05283c;
   height: $footerHeight;
@@ -255,6 +255,7 @@ $footerHeight: 36px;
 
   > span {
     vertical-align: top;
+    @include DosisFont;
   }
 
   > svg {

--- a/src/dashboard/Apps/AppsIndex.scss
+++ b/src/dashboard/Apps/AppsIndex.scss
@@ -129,6 +129,7 @@
 }
 
 .appname {
+  @include DosisFont;
   @include ellipsis();
   width: 100%;
   display: inline-block;


### PR DESCRIPTION
Fix #1194. I Reverted the changes applied [here](https://github.com/parse-community/parse-dashboard/commit/51ab46d569c9da55fa30aefc3bf9c872bd17695b) and standardized the font-family for Dosis

Screenshot:
![image](https://user-images.githubusercontent.com/14318858/62327614-7f400f00-b487-11e9-88d2-4c4017e44eb2.png)

@davimacedo and @natanrolnik let me know your feedback.