### PR TITLE
 feat(Database Browser): Select all objects

### DIFF
--- a/src/components/DataBrowserHeaderBar/DataBrowserHeaderBar.react.js
+++ b/src/components/DataBrowserHeaderBar/DataBrowserHeaderBar.react.js
@@ -14,12 +14,12 @@ import { DndProvider }     from 'react-dnd'
 
 export default class DataBrowserHeaderBar extends React.Component {
   render() {
-    let { headers, onResize, selectAll, onAddColumn, updateOrdering, readonly, preventSchemaEdits } = this.props;
+    let { headers, onResize, selectAll, onAddColumn, updateOrdering, readonly, preventSchemaEdits, disableSelectAll, selected } = this.props;
     let elements = [
       // Note: bulk checkbox is disabled as all rows are selected (not just visible ones due to current lazy loading implementation)
       // TODO: add bulk checking only visible rows
       <div key='check' className={[styles.wrap, styles.check].join(' ')}>
-        {readonly ? null : <input className={styles.disabled} type='checkbox' disabled={true} checked={false} onChange={(e) => selectAll(e.target.checked)} />}
+        {readonly ? null : <input className={disableSelectAll ? styles.disabled : undefined} type='checkbox' disabled={disableSelectAll} checked={selected} onChange={(e) => selectAll(e.target.checked)} />}
       </div>
     ];
 

--- a/src/components/DataBrowserHeaderBar/DataBrowserHeaderBar.react.js
+++ b/src/components/DataBrowserHeaderBar/DataBrowserHeaderBar.react.js
@@ -14,16 +14,13 @@ import { DndProvider }     from 'react-dnd'
 
 export default class DataBrowserHeaderBar extends React.Component {
   render() {
-    let { headers, onResize, selectAll, onAddColumn, updateOrdering, readonly, preventSchemaEdits, disableSelectAll, selected } = this.props;
+    let { headers, onResize, selectAll, onAddColumn, updateOrdering, readonly, preventSchemaEdits, selected } = this.props;
     let elements = [
       <div key='check' className={[styles.wrap, styles.check].join(' ')}>
         {readonly
           ? null
           : <input
-              className={disableSelectAll ? styles.disabled : undefined}
               type='checkbox'
-              title={disableSelectAll ? 'This operation is only avaialble when lazy loading data is entirely fetched' : undefined}
-              disabled={disableSelectAll}
               checked={selected}
               onChange={(e) => selectAll(e.target.checked)} />
         }

--- a/src/components/DataBrowserHeaderBar/DataBrowserHeaderBar.react.js
+++ b/src/components/DataBrowserHeaderBar/DataBrowserHeaderBar.react.js
@@ -16,10 +16,17 @@ export default class DataBrowserHeaderBar extends React.Component {
   render() {
     let { headers, onResize, selectAll, onAddColumn, updateOrdering, readonly, preventSchemaEdits, disableSelectAll, selected } = this.props;
     let elements = [
-      // Note: bulk checkbox is disabled as all rows are selected (not just visible ones due to current lazy loading implementation)
-      // TODO: add bulk checking only visible rows
       <div key='check' className={[styles.wrap, styles.check].join(' ')}>
-        {readonly ? null : <input className={disableSelectAll ? styles.disabled : undefined} type='checkbox' disabled={disableSelectAll} checked={selected} onChange={(e) => selectAll(e.target.checked)} />}
+        {readonly
+          ? null
+          : <input
+              className={disableSelectAll ? styles.disabled : undefined}
+              type='checkbox'
+              title={disableSelectAll ? 'This operation is only avaialble when lazy loading data is entirely fetched' : undefined}
+              disabled={disableSelectAll}
+              checked={selected}
+              onChange={(e) => selectAll(e.target.checked)} />
+        }
       </div>
     ];
 

--- a/src/components/DataBrowserHeaderBar/DataBrowserHeaderBar.scss
+++ b/src/components/DataBrowserHeaderBar/DataBrowserHeaderBar.scss
@@ -64,7 +64,3 @@
   margin: 0 -4px;
   cursor: ew-resize;
 }
-
-.disabled {
-  cursor: not-allowed;
-}

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -67,7 +67,6 @@ class Browser extends DashboardView {
       selection: {},
 
       data: null,
-      hasMoreData: true,
       lastMax: -1,
       newObject: null,
 
@@ -438,8 +437,7 @@ class Browser extends DashboardView {
     query.find({ useMasterKey: true }).then((nextPage) => {
       if (className === this.props.params.className) {
         this.setState((state) => ({
-          data: state.data.concat(nextPage),
-          hasMoreData: nextPage.length === MAX_ROWS_FETCHED
+          data: state.data.concat(nextPage)
         }));
       }
     });
@@ -676,25 +674,10 @@ class Browser extends DashboardView {
 
   selectRow(id, checked) {
     this.setState(({ selection }) => {
-      if (id === '*') {
-        return { selection: checked ? { '*': true } : {} };
-      }
       if (checked) {
         selection[id] = true;
       } else {
-        // If all objects are selected (*), selects all, except the id given
-        if (selection['*']) {
-          return {
-            selection: this.state.data.reduce((selection, obj) => {
-              selection[obj.id] = obj.id !== id;
-              return selection;
-            }, {})
-          };
-        }
-        // Otherwise just remove the id from the selection
-        else {
-          delete selection[id];
-        }
+        delete selection[id];
       }
       return { selection };
     });
@@ -989,7 +972,6 @@ class Browser extends DashboardView {
             selectRow={this.selectRow}
             selection={this.state.selection}
             data={this.state.data}
-            hasMoreData={this.state.hasMoreData}
             ordering={this.state.ordering}
             newObject={this.state.newObject}
             relation={this.state.relation}

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -645,7 +645,14 @@ class Browser extends DashboardView {
               this.state.data.splice(indexes[i] - i, 1);
             }
             this.state.counts[className] -= indexes.length;
-            this.forceUpdate();
+
+            // If after deletion, the remaining elements on the table is lesser than the maximum allowed elements
+            // we fetch more data to fill the table
+            if (this.state.data.length < MAX_ROWS_FETCHED) {
+              this.prefetchData(this.props, this.context);
+            } else {
+              this.forceUpdate();
+            }
           }
         }, (error) => {
           let errorDeletingNote = null;

--- a/src/dashboard/Data/Browser/BrowserTable.react.js
+++ b/src/dashboard/Data/Browser/BrowserTable.react.js
@@ -23,8 +23,6 @@ const ROW_HEIGHT = 31;
 
 const READ_ONLY = [ 'objectId', 'createdAt', 'updatedAt' ];
 
-let scrolling = false;
-
 export default class BrowserTable extends React.Component {
   constructor() {
     super();
@@ -59,9 +57,6 @@ export default class BrowserTable extends React.Component {
   }
 
   handleScroll() {
-    if (scrolling) {
-      return;
-    }
     if (!this.props.data || this.props.data.length === 0) {
       return;
     }
@@ -337,7 +332,8 @@ export default class BrowserTable extends React.Component {
           handleDragDrop={this.props.handleHeaderDragDrop}
           onResize={this.props.handleResize}
           onAddColumn={this.props.onAddColumn}
-          preventSchemaEdits={this.context.currentApp.preventSchemaEdits} />
+          preventSchemaEdits={this.context.currentApp.preventSchemaEdits}
+          disableSelectAll={this.props.hasMoreData} />
       </div>
     );
   }

--- a/src/dashboard/Data/Browser/BrowserTable.react.js
+++ b/src/dashboard/Data/Browser/BrowserTable.react.js
@@ -324,16 +324,19 @@ export default class BrowserTable extends React.Component {
       <div className={[styles.browser, browserUtils.isSafari() ? styles.safari : ''].join(' ')}>
         {table}
         <DataBrowserHeaderBar
-          selected={this.props.selection['*']}
-          selectAll={this.props.selectRow.bind(null, '*')}
+          selected={
+            this.props.selection &&
+            this.props.data &&
+            Object.values(this.props.selection).filter(checked => checked).length === this.props.data.length
+          }
+          selectAll={checked => this.props.data.forEach(({ id }) => this.props.selectRow(id, checked))}
           headers={headers}
           updateOrdering={this.props.updateOrdering}
           readonly={!!this.props.relation || !!this.props.isUnique}
           handleDragDrop={this.props.handleHeaderDragDrop}
           onResize={this.props.handleResize}
           onAddColumn={this.props.onAddColumn}
-          preventSchemaEdits={this.context.currentApp.preventSchemaEdits}
-          disableSelectAll={this.props.hasMoreData} />
+          preventSchemaEdits={this.context.currentApp.preventSchemaEdits} />
       </div>
     );
   }


### PR DESCRIPTION
Allows users to select all visible objects. If lazy loading fetches more data, the select all checkbox is unset.