### PR TITLE
fix: Update base config to work with sass-loader 8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "parse-dashboard": "./bin/parse-dashboard"
   },
   "engines": {
-    "node": ">=4.3"
+    "node": ">=8.9"
   },
   "main": "Parse-Dashboard/app.js",
   "jest": {

--- a/webpack/base.config.js
+++ b/webpack/base.config.js
@@ -53,7 +53,14 @@ module.exports = {
               importLoaders: 2
             },
           },
-          "sass-loader?includePaths[]=" + encodeURIComponent(path.resolve(__dirname, '../src'))
+          {
+            loader: 'sass-loader',
+            options: {
+              sassOptions: {
+                includePaths: [path.resolve(__dirname, '../src')]
+              }
+            }
+          }
         ]
       }, {
         test: /\.css$/,


### PR DESCRIPTION
[Source](https://github.com/webpack-contrib/sass-loader/blob/master/CHANGELOG.md#800-2019-08-29)