### PR TITLE
feat(Database Browser): Copy cell value using CTRL+C

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "commander": "3.0.1",
     "connect-flash": "0.1.1",
     "cookie-session": "2.0.0-beta.3",
+    "copy-to-clipboard": "^3.2.0",
     "create-react-class": "15.6.3",
     "csurf": "1.10.0",
     "express": "4.17.1",

--- a/src/components/BrowserRow/BrowserRow.react.js
+++ b/src/components/BrowserRow/BrowserRow.react.js
@@ -18,7 +18,7 @@ export default class BrowserRow extends Component {
   }
 
   render() {
-    const { className, columns, currentCol, isUnique, obj, onPointerClick, order, readOnlyFields, row, rowWidth, selection, selectRow, setCurrent, setEditing, setRelation } = this.props;
+    const { className, columns, currentCol, isUnique, obj, onPointerClick, order, readOnlyFields, row, rowWidth, selection, selectRow, setCopyableValue, setCurrent, setEditing, setRelation } = this.props;
     let attributes = obj.attributes;
     return (
       <div className={styles.tableRow} style={{ minWidth: rowWidth }}>
@@ -71,7 +71,8 @@ export default class BrowserRow extends Component {
               onPointerClick={onPointerClick}
               setRelation={setRelation}
               value={attr}
-              hidden={hidden} />
+              hidden={hidden}
+              setCopyableValue={setCopyableValue} />
           );
         })}
       </div>

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -113,6 +113,7 @@ class Browser extends DashboardView {
     this.createClass = this.createClass.bind(this);
     this.addColumn = this.addColumn.bind(this);
     this.removeColumn = this.removeColumn.bind(this);
+    this.showNote = this.showNote.bind(this);
   }
 
   componentWillMount() {
@@ -974,7 +975,8 @@ class Browser extends DashboardView {
             setRelation={this.setRelation}
             onAddColumn={this.showAddColumn}
             onAddRow={this.addRow}
-            onAddClass={this.showCreateClass} />
+            onAddClass={this.showCreateClass}
+            showNote={this.showNote} />
         );
       }
     }

--- a/src/dashboard/Data/Browser/BrowserTable.react.js
+++ b/src/dashboard/Data/Browser/BrowserTable.react.js
@@ -135,7 +135,8 @@ export default class BrowserTable extends React.Component {
               selectRow={this.props.selectRow}
               setCurrent={this.props.setCurrent}
               setEditing={this.props.setEditing}
-              setRelation={this.props.setRelation} />
+              setRelation={this.props.setRelation}
+              setCopyableValue={this.props.setCopyableValue} />
           </div>
         );
       }
@@ -167,7 +168,8 @@ export default class BrowserTable extends React.Component {
           selectRow={this.props.selectRow}
           setCurrent={this.props.setCurrent}
           setEditing={this.props.setEditing}
-          setRelation={this.props.setRelation} />
+          setRelation={this.props.setRelation}
+          setCopyableValue={this.props.setCopyableValue} />
       }
 
       if (this.props.editing) {

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -5,6 +5,7 @@
  * This source code is licensed under the license found in the LICENSE file in
  * the root directory of this source tree.
  */
+import copy                   from 'copy-to-clipboard';
 import BrowserTable           from 'dashboard/Data/Browser/BrowserTable.react';
 import BrowserToolbar         from 'dashboard/Data/Browser/BrowserToolbar.react';
 import * as ColumnPreferences from 'lib/ColumnPreferences';
@@ -32,6 +33,7 @@ export default class DataBrowser extends React.Component {
       order: order,
       current: null,
       editing: false,
+      copyableValue: undefined
     };
 
     this.handleKey = this.handleKey.bind(this);
@@ -40,13 +42,14 @@ export default class DataBrowser extends React.Component {
     this.setCurrent = this.setCurrent.bind(this);
     this.setEditing = this.setEditing.bind(this);
     this.handleColumnsOrder = this.handleColumnsOrder.bind(this);
+    this.setCopyableValue = this.setCopyableValue.bind(this);
 
     this.saveOrderTimeout = null;
   }
 
   shouldComponentUpdate(nextProps, nextState) {
     const shallowVerifyStates = [...new Set(Object.keys(this.state).concat(Object.keys(nextState)))]
-      .filter(stateName => stateName !== 'order');
+      .filter(stateName => stateName !== 'order' && stateName !== 'copyableValue');
     if (shallowVerifyStates.some(stateName => this.state[stateName] !== nextState[stateName])) {
       return true;
     }
@@ -195,6 +198,13 @@ export default class DataBrowser extends React.Component {
         });
         e.preventDefault();
         break;
+      case 67: // C
+        if ((e.ctrlKey || e.metaKey) && this.state.copyableValue !== undefined) {
+          copy(this.state.copyableValue); // Copies current cell value to clipboard
+          this.props.showNote('Value copied to clipboard', false)
+          e.preventDefault()
+        }
+        break;
     }
   }
 
@@ -207,6 +217,12 @@ export default class DataBrowser extends React.Component {
   setCurrent(current) {
     if (JSON.stringify(this.state.current) !== JSON.stringify(current)) {
       this.setState({ current });
+    }
+  }
+  
+  setCopyableValue(copyableValue) {
+    if (this.state.copyableValue !== copyableValue) {
+      this.setState({ copyableValue });
     }
   }
 
@@ -230,6 +246,7 @@ export default class DataBrowser extends React.Component {
           handleResize={this.handleResize}
           setEditing={this.setEditing}
           setCurrent={this.setCurrent}
+          setCopyableValue={this.setCopyableValue}
           {...other} />
         <BrowserToolbar
           count={count}


### PR DESCRIPTION
Currently, in order to copy cell content, users need to edit the cell, select all content manually and copy. This PR allows users to copy the entire cell content just by selecting the cell and pressing CTRL+C (or CMD+C).
When a value is copied to the clipboard, a message will appear on the bottom right of the screen.
Also, it is not possible to copy sensitive data such as `_User` password and sessionToken.