### PR TITLE
Fix: Data Browser is not updating accordingly

### DIFF
--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -44,23 +44,6 @@ export default class DataBrowser extends React.Component {
     this.saveOrderTimeout = null;
   }
 
-  shouldComponentUpdate(nextProps, nextState) {
-    const shallowVerifyStates = [...new Set(Object.keys(this.state).concat(Object.keys(nextState)))]
-      .filter(stateName => stateName !== 'order');
-    if (shallowVerifyStates.some(stateName => this.state[stateName] !== nextState[stateName])) {
-      return true;
-    }
-    if (JSON.stringify(this.state.order) !== JSON.stringify(nextState.order)) {
-      return true;
-    }
-    const shallowVerifyProps = [...new Set(Object.keys(this.props).concat(Object.keys(nextProps)))]
-      .filter(propName => propName !== 'columns');
-    if (shallowVerifyProps.some(propName => this.props[propName] !== nextProps[propName])) {
-      return true;
-    }
-    return JSON.stringify(this.props.columns) !== JSON.stringify(nextProps.columns);
-  }
-
   componentWillReceiveProps(props, context) {
     if (props.className !== this.props.className) {
       let order = ColumnPreferences.getOrder(


### PR DESCRIPTION
@douglasmuraoka Unfortunately `shouldComponentUpdate` is not working accordingly in `DataBrowser.react.js` and it is causing many bugs in the last release:
- Columns are not resizing
- Menu is not updating when there is a row selection
- Select all stopped working

So I think it would be better remove it for now, and then work to optimize it later.

Close https://github.com/parse-community/parse-dashboard/issues/1270