### PR TITLE
Prevent the duplicate last entry when sorting by _createdAt

### DIFF
--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -405,7 +405,7 @@ class Browser extends DashboardView {
     let className = this.props.params.className;
     let source = this.state.relation || className;
     let query = queryFromFilters(source, this.state.filters);
-    if (this.state.ordering !== '-createdAt') {
+    if (this.state.ordering !== 'createdAt') {
       // Construct complex pagination query
       let equalityQuery = queryFromFilters(source, this.state.filters);
       let field = this.state.ordering;


### PR DESCRIPTION
Only do a complex query for `createdAt` instead of `-createdAt`

This should resolve this issue: https://github.com/parse-community/parse-dashboard/issues/1309