### PR TITLE
Added support for reverse proxy

### DIFF
--- a/Parse-Dashboard/app.js
+++ b/Parse-Dashboard/app.js
@@ -88,8 +88,10 @@ module.exports = function(config, options) {
         req.connection.remoteAddress === '127.0.0.1' ||
         req.connection.remoteAddress === '::ffff:127.0.0.1' ||
         req.connection.remoteAddress === '::1';
+      // To support reverse-proxy:
+      const isForwardedFromHttps = req.headers['x-forwarded-proto'] === 'https';
       if (!options.dev && !requestIsLocal) {
-        if (!req.secure && !options.allowInsecureHTTP) {
+        if (!req.secure && !isForwardedFromHttps && !options.allowInsecureHTTP) {
           //Disallow HTTP requests except on localhost, to prevent the master key from being transmitted in cleartext
           return res.send({ success: false, error: 'Parse Dashboard can only be remotely accessed via HTTPS' });
         }


### PR DESCRIPTION
Currently the app.js assumes that all "non-127.0.0.1" requests are insecure if they are not HTTPS. 

However, this is an incorrect assumption as the app could be behind a reverse proxy. This is specially important when you use Docker to deploy an nginx that manages HTTPS and routes the request to Parse. In that case, the remote IP is in private range of 172.17.0.1 or 192.168.0.1.