### PR TITLE
[CLP Dialog] allow granular Pointer Permissions + fixes

### DIFF
--- a/src/components/PermissionsDialog/PermissionsDialog.example.js
+++ b/src/components/PermissionsDialog/PermissionsDialog.example.js
@@ -74,8 +74,8 @@ class DialogDemo extends React.Component {
             confirmText='Save ACL'
             details={<a href='#'>Learn more about ACLs and app security</a>}
             permissions={{
-              read: {'*': true},
-              write: {'*': true},
+              read: {'*': true, 'role:admin': true, 'role:user': true, 's0meU5er1d':true},
+              write: {'*': true, 'role:admin':true },
             }}
             validateEntry={validateSimple}
             onCancel={() => {
@@ -93,14 +93,15 @@ class DialogDemo extends React.Component {
             confirmText='Save CLP'
             details={<a href='#'>Learn more about CLPs and app security</a>}
             permissions={{
-              get: {'*': false, '1234asdf': true, 'role:admin': true},
-              find: {'*': true, '1234asdf': true, 'role:admin': true},
-              create: {'*': true},
-              update: {'*': true},
-              delete: {'*': true},
-              addField: {'*': true},
-              readUserFields: ['owner'],
-              writeUserFields: ['owner']
+              get: {'*': false, '1234asdf': true, 'role:admin': true,},
+              find: {'*': true, '1234asdf': true, 'role:admin': true, },
+              create: {'*': true,  },
+              update: {'*': true, pointerFields: ['user']},
+              delete: {'*': true, },
+              addField: {'*': true, 'requiresAuthentication': true},
+              readUserFields: ['owner', 'user'],
+              writeUserFields: ['owner'],
+              protectedFields: {'*': ['password', 'email'], 'userField:owner': []}
             }}
             validateEntry={validateAdvanced}
             onCancel={() => {

--- a/src/components/PermissionsDialog/PermissionsDialog.react.js
+++ b/src/components/PermissionsDialog/PermissionsDialog.react.js
@@ -702,7 +702,6 @@ export default class PermissionsDialog extends React.Component {
           } else {
             nextPerms = nextPerms.setIn(['read', id], true);
             nextPerms = nextPerms.setIn(['write', id], true);
-            nextPerms = nextPerms.setIn(['addField', id], true);
           }
 
           let nextKeys = this.state.newKeys.concat([id]);

--- a/src/components/PermissionsDialog/PermissionsDialog.scss
+++ b/src/components/PermissionsDialog/PermissionsDialog.scss
@@ -19,6 +19,11 @@ $sumWriteColsWidth: calc(3 * #{$writeColWidth});
 $permissionsDialogWidth: calc(#{$labelWidth} + (2 * #{$colWidth}) + #{$deleteColWidth});
 $permissionsDialogMaxWidth: calc(#{$labelWidth} + #{$sumReadColsWidth} + #{$sumWriteColsWidth} + #{$addFieldColWidth} + #{$deleteColWidth});
 
+$simplePointerWriteWidth: calc( #{$colWidth} + #{$addFieldColWidth});
+$pointerWriteWidth: calc( #{$sumWriteColsWidth} + #{$addFieldColWidth});
+
+$clpDialogWidth: calc(#{$permissionsDialogWidth} + #{$addFieldColWidth});
+
 .dialog {
   @include modalAnimation();
   position: absolute;
@@ -29,6 +34,24 @@ $permissionsDialogMaxWidth: calc(#{$labelWidth} + #{$sumReadColsWidth} + #{$sumW
   border-radius: 5px;
   overflow: hidden;
   transition: width 0.3s 0.15s ease-out;
+}
+
+.clp{
+  width: $clpDialogWidth;
+  
+  .level{
+    width: $clpDialogWidth;
+  }
+  // 118px for add field in CLP only
+  .fourth {
+    width: $addFieldColWidth;
+  }
+}
+
+.clp.advanced{
+  .fourth {
+    width: $colWidth;
+  }
 }
 
 .header {
@@ -64,9 +87,10 @@ $permissionsDialogMaxWidth: calc(#{$labelWidth} + #{$sumReadColsWidth} + #{$sumW
   }
 }
 
+
 .level {
   height: 50px;
-  width: $permissionsDialogWidth;
+  width: $permissionsDialogWidth; //   width: 658px;
   background: #0E69A1;
   position: relative;
   color: white;
@@ -239,10 +263,11 @@ $permissionsDialogMaxWidth: calc(#{$labelWidth} + #{$sumReadColsWidth} + #{$sumW
   width: $sumReadColsWidth;
   padding: 5px 10px;
 }
+
 .pointerWrite {
+  width: $simplePointerWriteWidth;
+  padding: 0px 10px;
   display: inline-block;
-  width: calc(#{$sumWriteColsWidth} + #{$addFieldColWidth});
-  padding: 5px 10px;
 }
 
 .checkboxWrap {

--- a/src/dashboard/Data/Browser/BrowserToolbar.react.js
+++ b/src/dashboard/Data/Browser/BrowserToolbar.react.js
@@ -156,7 +156,7 @@ let BrowserToolbar = ({
       if (col === 'objectId' || isUnique && col !== uniqueField) {
         return;
       }
-      if (targetClass === '_User') {
+      if ((type !=='Relation' && targetClass === '_User') || type === 'Array' ) {
         userPointers.push(col);
       }
     });


### PR DESCRIPTION
- Allows to set Pointer Permissions (PP) per-operation in advanced mode. Previously it was only possible to set write/read groups ( `readUserFields` / `writeUserFields` in schema).  Upon saving the field name will go under corresponding `operation` into `pointerFields` array.   If all (read or write) operations  are checked  - saves into corresponding `readUserFields`/`writeUserFields` array instead. 
parse-community/parse-server#6351 parse-community/parse-server#6352 #1391
- Fixes incorrect behavior when it was possible to add Relation field as PP (not supported server-side).
- Allowed adding Array field as PP.
- Added an Authenticated row - represents `requiresAuthentication` from schema.
- Now saving CLP from dashboard does not clear the `protectedFields`.