### PR TITLE
feat(query): set read preference to SECONDARY by default

### DIFF
--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -341,6 +341,7 @@ class Browser extends DashboardView {
       query.ascending(field)
     }
 
+    query.readPreference(this.getReadPreference());
     query.limit(MAX_ROWS_FETCHED);
 
     let promise = query.find({ useMasterKey: true });
@@ -362,6 +363,7 @@ class Browser extends DashboardView {
 
   async fetchParseDataCount(source, filters) {
     const query = queryFromFilters(source, filters);
+    query.readPreference(this.getReadPreference());
     const count = await query.count({ useMasterKey: true });
     return count;
   }
@@ -438,7 +440,7 @@ class Browser extends DashboardView {
       query.addDescending('createdAt');
     }
     query.limit(MAX_ROWS_FETCHED);
-
+    query.readPreference(this.getReadPreference());
     query.find({ useMasterKey: true }).then((nextPage) => {
       if (className === this.props.params.className) {
         this.setState((state) => ({
@@ -844,6 +846,10 @@ class Browser extends DashboardView {
       columns = columns.filter((column) => untouchable.indexOf(column.name) === -1);
     }
     return columns;
+  }
+
+  getReadPreference() {
+    return this.context.currentApp.getReadPreference();
   }
 
   renderSidebar() {

--- a/src/lib/ParseApp.js
+++ b/src/lib/ParseApp.js
@@ -204,7 +204,9 @@ export default class ParseApp {
         return Promise.resolve(this.classCounts.counts[className]);
       }
     }
-    let p = new Parse.Query(className).count({ useMasterKey: true });
+    const query = new Parse.Query(className);
+    query.readPreference(this.getReadPreference());
+    let p = query.count({ useMasterKey: true });
     p.then(count => {
       this.classCounts.counts[className] = count;
       this.classCounts.lastFetched[className] = new Date();
@@ -214,7 +216,9 @@ export default class ParseApp {
 
   getRelationCount(relation) {
     this.setParseKeys();
-    let p = relation.query().count({ useMasterKey: true });
+    const query = relation.query();
+    query.readPreference(this.getReadPreference());
+    let p = query.count({ useMasterKey: true });
     return p;
   }
 
@@ -770,5 +774,9 @@ export default class ParseApp {
       );
     });
     return promise;
+  }
+
+  getReadPreference() {
+    return 'SECONDARY';
   }
 }


### PR DESCRIPTION
*Use-case*

We think it makes sense to keep the load off the primary where possible, but here is one scenario that has stung us many times:

Given how flexible the data-browser is, it's very easy to accidentally set the `sort` on a large collection on an unindexed field. Whilst there are multiple lines of defences that we can add (beforeFind in parse-server, no unindexed queries in MongoDB, etc), we think this is a good starting point for other developers.

*Implementation*
Right now, I've just set the common find and count queries to be `SECONDARY`. None of the critical flows such as writes, or even reads on Roles, ACLs etc are set to use this preference. For now, I've not added a configuration option to disable this. Happy to look into this if it's helpful?