### PR TITLE
Fix pointer CLPs

### DIFF
--- a/src/components/PermissionsDialog/PermissionsDialog.react.js
+++ b/src/components/PermissionsDialog/PermissionsDialog.react.js
@@ -936,6 +936,7 @@ export default class PermissionsDialog extends React.Component {
         }
       });
     });
+
     let readUserFields = [];
     let writeUserFields = [];
     this.state.pointerPerms.forEach((perms, key) => {
@@ -945,6 +946,7 @@ export default class PermissionsDialog extends React.Component {
       if (perms.get('write')) {
         writeUserFields.push(key);
       }
+
       fields.forEach(op => {
         if (perms.get(op)) {
           if (!output[op].pointerFields) {
@@ -1168,6 +1170,7 @@ export default class PermissionsDialog extends React.Component {
     } else {
       placeholderText = 'Role or User\u2026';
     }
+
     return (
       <Popover
         fadeIn={true}
@@ -1244,6 +1247,7 @@ export default class PermissionsDialog extends React.Component {
                   {this.renderAuthenticatedCheckboxes()}
                 </div>
               ) : null}
+
               {this.state.keys
                 .slice(this.props.advanced ? 2 : 1)
                 .map(key =>

--- a/src/components/PermissionsDialog/PermissionsDialog.react.js
+++ b/src/components/PermissionsDialog/PermissionsDialog.react.js
@@ -589,13 +589,15 @@ export default class PermissionsDialog extends React.Component {
       perms.delete = perms.delete || Map();
       perms.addField = perms.addField || Map();
 
-      (pointerPermsSubset.get = permissions.get.pointerFields || []),
-        (pointerPermsSubset.find = permissions.find.pointerFields || []),
-        (pointerPermsSubset.count = permissions.count.pointerFields || []),
-        (pointerPermsSubset.create = permissions.create.pointerFields || []),
-        (pointerPermsSubset.update = permissions.update.pointerFields || []),
-        (pointerPermsSubset.delete = permissions.delete.pointerFields || []),
-        (pointerPermsSubset.addField = permissions.addField.pointerFields || []);
+      // The double check is necessary because the permissions object seems to be empty when accessing the CLP section
+      // if the class was recently created.
+      (pointerPermsSubset.get = permissions.get && permissions.get.pointerFields || []),
+        (pointerPermsSubset.find = permissions.find && permissions.find.pointerFields || []),
+        (pointerPermsSubset.count = permissions.count && permissions.count.pointerFields || []),
+        (pointerPermsSubset.create = permissions.create && permissions.create.pointerFields || []),
+        (pointerPermsSubset.update = permissions.update && permissions.update.pointerFields || []),
+        (pointerPermsSubset.delete = permissions.delete && permissions.delete.pointerFields || []),
+        (pointerPermsSubset.addField = permissions.addField && permissions.addField.pointerFields || []);
     }
 
     let pointerPerms = {};


### PR DESCRIPTION
As discussed here https://community.parseplatform.org/t/permission-denied-for-action-find-on-class/365/9, it seems that the latest version of the dashboard is not setting pointer CLPs correctly. The details can be found in the thread.

This change fixes it. For instance, if I set the following CLPs

![image](https://user-images.githubusercontent.com/1514814/85408486-95890a80-b532-11ea-8c6c-be254ae1400e.png)

I get the following CLP object

```
  "classLevelPermissions": {
    "find": {
      "pointerFields": [
        "user",
        "users"
      ]
    },
    "count": {
      "pointerFields": [
        "user",
        "users"
      ]
    },
    "get": {
      "pointerFields": [
        "user",
        "users"
      ]
    },
    "create": {},
    "update": {},
    "delete": {},
    "addField": {},
    "protectedFields": {
      "*": []
    }
  }
```

I believe that the most important change in behavior that this PR fixes is that now if I `find` as an user (with session token) with exactly the same CLP settings shown in the screenshot above (with public and authenticated permissions turned off), it returns me 0 rows if there are none, 1 row if there are 1 associated row to the user, etc. As you can read from the forum thread referenced above, by not setting the pointer CLPs correctly I could not execute the `find` action as an user.

Something weird I found along the way is that when I added the minor change in line 982, it added the pointer information like this:

![image](https://user-images.githubusercontent.com/1514814/85408703-db45d300-b532-11ea-9b6e-4db46793aa09.png)

But it also  had the effect of grouping **Write and Add fields**... let me know if it should be like that or if it should be changed. This behavior is new to me.

![image](https://user-images.githubusercontent.com/1514814/85409703-20b6d000-b534-11ea-98d3-65646a7c2dc3.png)

Please feel free to share any questions or concerns.