### PR TITLE
Clear state.data when setting relation to prevent column type mismatch.

### DIFF
--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -499,6 +499,7 @@ class Browser extends DashboardView {
   setRelation(relation, filters) {
     this.setState({
       relation: relation,
+      data: null,
     }, () => {
       let filterQueryString;
       if (filters && filters.size) {
@@ -937,7 +938,7 @@ class Browser extends DashboardView {
   onDialogToggle(opened){
     this.setState({showPermissionsDialog: opened});
   }
-  
+
   renderContent() {
     let browser = null;
     let className = this.props.params.className;


### PR DESCRIPTION
When clicking a relation column, data from the current class rows can cause a type mismatch in the targetClass.

## Example Problem:

Class "One" schema:
```
myfield: { type: 'Object' }
two: { type: 'Relation', targetClass: 'Two' }
```
Class "Two" schema:
```
myfield: { type: 'String' }
```
## Steps to Reproduce
1. Create at least 1 object of class "One" with an object saved in myfield column.
2. Viewing "One" in parse dashboard browser, click the "two" relation button.

## Cause
Because the Browser state has the data from class "One", on initial load of the BrowserTable for the "Two" relation, the BrowserCell for the myfield column will attempt to render the object content from the "One" row.