### PR TITLE
Fixes toolbar overlap to page title

### DIFF
--- a/src/components/Toolbar/Toolbar.scss
+++ b/src/components/Toolbar/Toolbar.scss
@@ -84,5 +84,5 @@
 .actions {
   position: absolute;
   right: 14px;
-  bottom: 14px;
+  top: 0;
 }


### PR DESCRIPTION
Fixes #1577

<img width="499" alt="Снимок экрана 2020-07-27 в 1 23 30" src="https://user-images.githubusercontent.com/545151/88521388-b1f0ea80-cfa9-11ea-9128-b7569c9c5e74.png">
<img width="815" alt="Снимок экрана 2020-07-27 в 1 23 42" src="https://user-images.githubusercontent.com/545151/88521395-b3221780-cfa9-11ea-99be-e17b841f563b.png">
