### PR TITLE
chore: Remove wontfix label from Stalebot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -4,15 +4,18 @@ daysUntilStale: 45
 daysUntilClose: 7
 # Issues with these labels will never be considered stale
 exemptLabels:
+  - bug
+  - enhancement
+  - feature request
+  - good first pr
+  - help wanted
   - pinned
   - security
-  - good-first-pr
-  - up-for-grabs
-  - enhancement
-  - help wanted
-  - bug
+  - up for grabs
 # Label to use when marking an issue as stale
-staleLabel: wontfix
+staleLabel: stale
+# Limit to only `issues` not `pulls`
+only: issues
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had

--- a/src/lib/tests/e2e/dashboard.e2e.test.js
+++ b/src/lib/tests/e2e/dashboard.e2e.test.js
@@ -39,7 +39,6 @@ describe('dashboard e2e', () => {
 
     await page.goto(`http://localhost:5051${mount}`);
     await page.waitForSelector('#browser_mount');
-console.log(page.url());
     expect(page.url().indexOf(`http://localhost:5051${mount}/apps`)).toBe(0);
 
     await page.close();


### PR DESCRIPTION
Similar to https://github.com/parse-community/parse-server/pull/6810

Fixes labels, allow stalebot for only issues.