### PR TITLE
(feat) Column Preference for Data Browser

### DIFF
--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -1124,10 +1124,12 @@ class Browser extends DashboardView {
         columnsObject[column.name] = column
       });
       // get ordered list of class columns
+      const columnPreferences = this.context.currentApp.columnPreference || {}
       const columns = ColumnPreferences.getOrder(
         columnsObject,
         this.context.currentApp.applicationId,
-        className
+        className,
+        columnPreferences[className]
       );
       // extend columns with their type and targetClass properties
       columns.forEach(column => {

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -24,12 +24,13 @@ export default class DataBrowser extends React.Component {
   constructor(props, context) {
     super(props, context);
 
+    const columnPreferences = context.currentApp.columnPreference || {}
     let order = ColumnPreferences.getOrder(
       props.columns,
       context.currentApp.applicationId,
-      props.className
+      props.className,
+      columnPreferences[props.className]
     );
-
     this.state = {
       order: order,
       current: null,
@@ -52,10 +53,12 @@ export default class DataBrowser extends React.Component {
 
   componentWillReceiveProps(props, context) {
     if (props.className !== this.props.className) {
+      const columnPreferences = context.currentApp.columnPreference || {}
       let order = ColumnPreferences.getOrder(
         props.columns,
         context.currentApp.applicationId,
-        props.className
+        props.className,
+        columnPreferences[props.className]
       );
       this.setState({
         order: order,
@@ -65,10 +68,12 @@ export default class DataBrowser extends React.Component {
       });
     } else if (Object.keys(props.columns).length !== Object.keys(this.props.columns).length
            || (props.isUnique && props.uniqueField !== this.props.uniqueField)) {
+      const columnPreferences = context.currentApp.columnPreference || {}
       let order = ColumnPreferences.getOrder(
         props.columns,
         context.currentApp.applicationId,
-        props.className
+        props.className,
+        columnPreferences[props.className]
       );
       this.setState({ order });
     }

--- a/src/lib/ColumnPreferences.js
+++ b/src/lib/ColumnPreferences.js
@@ -71,8 +71,12 @@ export function getColumnSort(sortBy, appId, className) {
   return currentSort;
 }
 
-export function getOrder(cols, appId, className) {
+export function getOrder(cols, appId, className, defaultPrefs) {
+
   let prefs = getPreferences(appId, className) || [ { name: 'objectId', width: DEFAULT_WIDTH, visible: true } ];
+  if (defaultPrefs) {
+    prefs = defaultPrefs;
+  }
   let order = [].concat(prefs);
   let seen = {};
   for (let i = 0; i < order.length; i++) {
@@ -83,7 +87,7 @@ export function getOrder(cols, appId, className) {
   for (let name in cols) {
     requested[name] = true;
     if (!seen[name]) {
-      order.push({ name: name, width: DEFAULT_WIDTH, visible: true });
+      order.push({ name: name, width: DEFAULT_WIDTH, visible: !defaultPrefs });
       seen[name] = true;
       updated = true;
     }

--- a/src/lib/ParseApp.js
+++ b/src/lib/ParseApp.js
@@ -43,7 +43,8 @@ export default class ParseApp {
     secondaryBackgroundColor,
     supportedPushLocales,
     preventSchemaEdits,
-    graphQLServerURL
+    graphQLServerURL,
+    columnPreference
   }) {
     this.name = appName;
     this.createdAt = created_at ? new Date(created_at) : new Date();
@@ -69,6 +70,7 @@ export default class ParseApp {
     this.supportedPushLocales = supportedPushLocales ? supportedPushLocales : [];
     this.preventSchemaEdits = preventSchemaEdits || false;
     this.graphQLServerURL = graphQLServerURL;
+    this.columnPreference = columnPreference;
 
     if(!supportedPushLocales) {
       console.warn('Missing push locales for \'' + appName + '\', see this link for details on setting localizations up. https://github.com/parse-community/parse-dashboard#configuring-localized-push-notifications');


### PR DESCRIPTION
Closes #172.

With this PR, you can specify "columnPreference" in your app settings.

This can easily allow you to order and size specific columns consistently across multiple devices and classes.

```
"apps": [
    {
      "serverURL": "http://localhost:1338/parse",
      "appId": "hello",
      "masterKey": "world",
      "columnPreference" : {
        "_Role" : [
          {"name":"updatedAt","width":250,"visible":true}
        ],
        "_User" : [
          {"name":"objectId","width":150,"visible":true},
          {"name":"updatedAt","width":150,"visible":true},
          {"name":"createdAt","width":150,"visible":true},
          {"name":"firstName","width":150,"visible":true},
          {"name":"lastName","width":150,"visible":true}
        ]
      }
    }
  ],
```

The remaining fields will still display in the "Manage Columns" option, but will be invisible.

If a class isn't specified in `columnPreference`, the default is applied.

What this looks like:

<img width="493" alt="Screen Shot 2020-11-19 at 3 34 02 am" src="https://user-images.githubusercontent.com/4974769/99559972-762ad680-2a19-11eb-9531-c99d0396afe5.png">

Note that my "_User" class has about 20 fields, and without this set, it ends up an unordered, scrambled mess.

<img width="754" alt="Screen Shot 2020-11-19 at 3 35 05 am" src="https://user-images.githubusercontent.com/4974769/99560169-ad998300-2a19-11eb-909a-a055fb11db76.png">
