### PR TITLE
showing '(auto)' for auto-generated fields

### DIFF
--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -324,7 +324,7 @@ export default class BrowserCell extends Component {
             }
           }}
         >
-          {content}
+          {row < 0 ? '(auto)' : content}
         </span>
       </Tooltip>
     ) : (


### PR DESCRIPTION
Showing 'auto' for auto-generated fields while creating new row or editing cloned rows.
Bascially for readOnly fields while adding new row.

![Screenshot from 2021-04-28 23-45-52](https://user-images.githubusercontent.com/44117648/116891101-f356aa80-ac4b-11eb-9e8c-c9e4cbe721dd.png)
