### PR TITLE
fix: Allow other key binding while adding new row

### DIFF
--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -159,7 +159,6 @@ export default class DataBrowser extends React.Component {
         this.props.onAbortAddRow();
         e.preventDefault();
       }
-      return;
     }
     if (this.state.editing) {
       switch (e.keyCode) {


### PR DESCRIPTION
Hello,

This PR allow using CTRL C/V and other key biding while adding a new row using the new Adding row feature.
Before, only escape key was binded

<img width="1492" alt="Capture d’écran 2021-05-25 à 11 53 09" src="https://user-images.githubusercontent.com/644360/119478120-d5163300-bd4f-11eb-858b-0b7a9e021ce1.png">
