### PR TITLE
Fix: Column name starting with numbers

### DIFF
--- a/src/dashboard/Data/Browser/AddColumnDialog.react.js
+++ b/src/dashboard/Data/Browser/AddColumnDialog.react.js
@@ -27,7 +27,7 @@ import {
 }                         from 'lib/Constants';
 
 function validColumnName(name) {
-  return !!name.match(/^[a-zA-Z0-9][_a-zA-Z0-9]*$/);
+  return !!name.match(/^[a-zA-Z][_a-zA-Z0-9]*$/);
 }
 
 export default class AddColumnDialog extends React.Component {

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -280,7 +280,9 @@ class Browser extends DashboardView {
       required,
       defaultValue
     };
-    this.props.schema.dispatch(ActionTypes.ADD_COLUMN, payload).finally(() => {
+    this.props.schema.dispatch(ActionTypes.ADD_COLUMN, payload).catch((err) => {
+      this.showNote(err.message, true);
+    }).finally(() => {
       this.setState({ showAddColumnDialog: false });
     });
   }


### PR DESCRIPTION
Creating new column name starting with number gives internal server error. Now, validating column name to not accept names starting with numbers.