### PR TITLE
cell select height fix

### DIFF
--- a/src/components/BrowserCell/BrowserCell.scss
+++ b/src/components/BrowserCell/BrowserCell.scss
@@ -13,7 +13,7 @@
   color: #0E69A1;
   height: 30px;
   // line-height: 22px;
-  padding: 6px 4px 0;
+  padding: 5px 4px 0;
   border-right: 1px solid #e3e3ea;
 }
 

--- a/src/components/BrowserCell/BrowserCell.scss
+++ b/src/components/BrowserCell/BrowserCell.scss
@@ -11,7 +11,7 @@
   text-overflow: ellipsis;
   cursor: default;
   color: #0E69A1;
-  height: 32px;
+  height: 30px;
   line-height: 22px;
   padding: 5px 4px 0;
   border-right: 1px solid #e3e3ea;

--- a/src/components/BrowserCell/BrowserCell.scss
+++ b/src/components/BrowserCell/BrowserCell.scss
@@ -13,7 +13,7 @@
   color: #0E69A1;
   height: 30px;
   // line-height: 22px;
-  padding: 5px 4px 0;
+  padding: 6px 4px 0;
   border-right: 1px solid #e3e3ea;
 }
 

--- a/src/components/BrowserCell/BrowserCell.scss
+++ b/src/components/BrowserCell/BrowserCell.scss
@@ -12,7 +12,7 @@
   cursor: default;
   color: #0E69A1;
   height: 30px;
-  line-height: 22px;
+  // line-height: 22px;
   padding: 5px 4px 0;
   border-right: 1px solid #e3e3ea;
 }

--- a/src/components/BrowserCell/BrowserCell.scss
+++ b/src/components/BrowserCell/BrowserCell.scss
@@ -11,7 +11,7 @@
   text-overflow: ellipsis;
   cursor: default;
   color: #0E69A1;
-  height: 35px;
+  height: 32px;
   line-height: 22px;
   padding: 5px 4px 0;
   border-right: 1px solid #e3e3ea;

--- a/src/components/BrowserCell/BrowserCell.scss
+++ b/src/components/BrowserCell/BrowserCell.scss
@@ -11,7 +11,7 @@
   text-overflow: ellipsis;
   cursor: default;
   color: #0E69A1;
-  height: 30px;
+  height: 35px;
   line-height: 22px;
   padding: 5px 4px 0;
   border-right: 1px solid #e3e3ea;

--- a/src/components/BrowserCell/BrowserCell.scss
+++ b/src/components/BrowserCell/BrowserCell.scss
@@ -12,8 +12,8 @@
   cursor: default;
   color: #0E69A1;
   height: 30px;
-  // line-height: 22px;
-  padding: 5px 4px 0;
+  line-height: 20px;
+  padding: 5px;
   border-right: 1px solid #e3e3ea;
 }
 

--- a/src/components/Pill/Pill.scss
+++ b/src/components/Pill/Pill.scss
@@ -11,19 +11,17 @@
   @include MonospaceFont;
   display: flex;
   justify-content: space-between;
-  // align-items: center;
+  align-items: center;
   color: #0E69A1;
-  // height: 20px;
-  line-height: 18px;
+  height: 20px;
+  line-height: 20px;
   border-radius: 10px;
   font-size: 11px;
   width: 100%;
-  // overflow: hidden;
-  // text-overflow: ellipsis;
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
-  margin-bottom: 4px;
   & a {
-    margin-top: -1.5px;
     height: 20px;
     width: 20px;
     background: #d6e5f2;

--- a/src/components/Pill/Pill.scss
+++ b/src/components/Pill/Pill.scss
@@ -11,10 +11,10 @@
   @include MonospaceFont;
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  // align-items: center;
   color: #0E69A1;
-  height: 18px;
-  line-height: 20px;
+  // height: 20px;
+  line-height: 18px;
   border-radius: 10px;
   font-size: 11px;
   width: 100%;

--- a/src/components/Pill/Pill.scss
+++ b/src/components/Pill/Pill.scss
@@ -13,7 +13,7 @@
   justify-content: space-between;
   align-items: center;
   color: #0E69A1;
-  height: 20px;
+  height: 18px;
   line-height: 20px;
   border-radius: 10px;
   font-size: 11px;

--- a/src/components/Pill/Pill.scss
+++ b/src/components/Pill/Pill.scss
@@ -18,11 +18,12 @@
   border-radius: 10px;
   font-size: 11px;
   width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  // overflow: hidden;
+  // text-overflow: ellipsis;
   white-space: nowrap;
   margin-bottom: 4px;
   & a {
+    margin-top: -1.5px;
     height: 20px;
     width: 20px;
     background: #d6e5f2;

--- a/src/dashboard/Data/Browser/Browser.scss
+++ b/src/dashboard/Data/Browser/Browser.scss
@@ -102,7 +102,7 @@
   @include MonospaceFont;
   font-size: 12px;
   white-space: nowrap;
-  height: 32px;
+  height: 31px;
   border-bottom: 1px solid #e3e3ea;
 
   &:nth-child(odd) {

--- a/src/dashboard/Data/Browser/Browser.scss
+++ b/src/dashboard/Data/Browser/Browser.scss
@@ -102,7 +102,7 @@
   @include MonospaceFont;
   font-size: 12px;
   white-space: nowrap;
-  height: 35px;
+  height: 32px;
   border-bottom: 1px solid #e3e3ea;
 
   &:nth-child(odd) {

--- a/src/dashboard/Data/Browser/Browser.scss
+++ b/src/dashboard/Data/Browser/Browser.scss
@@ -102,7 +102,7 @@
   @include MonospaceFont;
   font-size: 12px;
   white-space: nowrap;
-  height: 31px;
+  height: 30px;
   border-bottom: 1px solid #e3e3ea;
 
   &:nth-child(odd) {

--- a/src/dashboard/Data/Browser/Browser.scss
+++ b/src/dashboard/Data/Browser/Browser.scss
@@ -102,7 +102,7 @@
   @include MonospaceFont;
   font-size: 12px;
   white-space: nowrap;
-  height: auto;
+  height: 35px;
   border-bottom: 1px solid #e3e3ea;
 
   &:nth-child(odd) {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues/1753).

### Issue Description
The border around the cell is no longer covering the whole cell when selecting a cell.

### Approach
The height of the row is different from the height of the cell which causes the small border. Increasing the height of cell and fixing the height of row to match the cell fixes the border issue.

<img width="720" alt="Screenshot 2021-08-05 at 7 05 24 PM" src="https://user-images.githubusercontent.com/23558802/128363761-7485c3ca-613c-4e03-87e9-f473b023e2fb.png">
