### PR TITLE
ci(changelog): add changelog reminder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,20 @@ on:
     branches:
       - '**'
 jobs:
-  changelog:
+  changelog-update:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
     - uses: actions/checkout@v2
     - uses: dangoslen/changelog-enforcer@v2
+  changelog-syntax:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+    - uses: ardalanamini/auto-changelog@v1.1.0
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        exclude: 'revert,other,breaking'
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,14 @@ on:
     branches:
       - '**'
 jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+    - uses: actions/checkout@v2
+    - uses: dangoslen/changelog-enforcer@v2
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: dangoslen/changelog-enforcer@v2
-  changelog-syntax:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-    - uses: ardalanamini/auto-changelog@v1.1.0
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        exclude: 'revert,other,breaking'
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,15 @@ on:
     branches:
       - '**'
 jobs:
-  changelog-update:
-    runs-on: ubuntu-latest
+  check-changelog:
+    name: Changelog
     timeout-minutes: 5
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
     - uses: dangoslen/changelog-enforcer@v2
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 
 ## New Features
 ## Improvements
-- Add CI check to add changelog entry (Manuel Trezza)
+- Add CI check to add changelog entry (Manuel Trezza) [#1764](https://github.com/parse-community/parse-dashboard/pull/1764)
+
 ## Fixes
 
 # 2.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## New Features
 ## Improvements
+- Add CI check to add changelog entry (Manuel Trezza)
 ## Fixes
 
 # 2.2.0


### PR DESCRIPTION
Ensures a PR modifies the CHANGELOG.md file:
![image](https://user-images.githubusercontent.com/5673677/130494689-63220d95-da54-4e35-9cdb-9d1ece2c26e3.png)

Transitional solution until we move to automated releases which will generate the changelog entry.

TODO:

- [ ] Add check to required tests for merge in repo settings