### PR TITLE
Edit Array of pointers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 - fix: date cell value not selected on double clicks (fn-faisal) [#1730](https://github.com/parse-community/parse-dashboard/pull/1730)
 
 ## Fixes
-- Fixes: Unable to edit array of pointer field [#1770](https://github.com/parse-community/parse-dashboard/issues/1770) (Prerna Mehra) [#1771](https://github.com/parse-community/parse-dashboard/pull/1771)
+- Fixed bug when editing or copying a field containing an array of pointers [#1770](https://github.com/parse-community/parse-dashboard/issues/1770) (Prerna Mehra) [#1771](https://github.com/parse-community/parse-dashboard/pull/1771)
+
 # 2.2.0
 [Full Changelog](https://github.com/parse-community/parse-dashboard/compare/2.1.0...2.2.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Refactor: uniform issue templates across repos (Manuel Trezza) [#1767](https://github.com/parse-community/parse-dashboard/pull/1767)
 
 ## Fixes
-
+- Fixes: Unable to edit array of pointer field [#1770](https://github.com/parse-community/parse-dashboard/issues/1770) (Prerna Mehra) [#1771](https://github.com/parse-community/parse-dashboard/pull/1771)
 # 2.2.0
 [Full Changelog](https://github.com/parse-community/parse-dashboard/compare/2.1.0...2.2.0)
 

--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -281,9 +281,10 @@ export default class BrowserCell extends Component {
             />
           );
         });
-        this.copyableValue = content = <ul>
+        content = <ul>
           { array.map( a => <li>{a}</li>) }
         </ul>
+        this.copyableValue = JSON.stringify(value);
         if ( array.length > 1 ) {
           classes.push(styles.hasMore);
         }

--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -273,9 +273,13 @@ export default class BrowserCell extends Component {
           const object = new Parse.Object(v.className);
           object.id = v.objectId;
           array.push(
-            <a key={i} href='javascript:;' onClick={onPointerClick.bind(undefined, object)}>
-              <Pill value={v.objectId} />
-            </a>);
+            <Pill
+              key={v.objectId}
+              value={v.objectId}
+              onClick={onPointerClick.bind(undefined, object)}
+              followClick={true}
+            />
+          );
         });
         this.copyableValue = content = <ul>
           { array.map( a => <li>{a}</li>) }

--- a/src/dashboard/Data/Browser/EditRowDialog.react.js
+++ b/src/dashboard/Data/Browser/EditRowDialog.react.js
@@ -15,6 +15,7 @@ import FileEditor from 'components/FileEditor/FileEditor.react';
 import ObjectPickerDialog from 'dashboard/Data/Browser/ObjectPickerDialog.react';
 import styles from 'dashboard/Data/Browser/Browser.scss';
 import getFileName from 'lib/getFileName';
+import encode from 'parse/lib/browser/encode';
 
 export default class EditRowDialog extends React.Component {
   constructor(props) {
@@ -57,7 +58,12 @@ export default class EditRowDialog extends React.Component {
     columns.forEach(column => {
       const { name, type } = column;
       if (['Array', 'Object'].indexOf(type) >= 0) {
-        const stringifyValue = JSON.stringify(currentObject[name], null, 4);
+        // This is needed to avoid unwanted conversions of objects to Parse.Objects.
+        // "Parse._encoding" is responsible to convert Parse data into raw data.
+        // Since array and object are generic types, we want to render them the way
+        // they were stored in the database.
+        let val = encode(currentObject[name], undefined, true);
+        const stringifyValue = JSON.stringify(val, null, 4);
         currentObject[name] = stringifyValue;
         const rows = stringifyValue ? stringifyValue.split('\n').length : 1;
         expandedTextAreas[name] = { rows: rows, expanded: false };


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues/1770).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
- Not able to edit array of pointer field, as single click on the cell redirects to pointer class.
- Ctrl+c copies `[object Object]` instead of field json value.
- Edit modal displays wrong data for array of pointers.

Related issue: #1770

### Approach
<!-- Add a description of the approach in this PR. -->
- Using Pill design for pointer fields. that will only redirect to pointer class on arrow icon click, otherwise on single should select the cell & on double click opens Editor for that cell.
- set copyableValue to json of field value.
- Using `Prase._encoding` to avoid converting object into parseObjects.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add entry to changelog