### PR TITLE
Fix: Modal Z-index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - fix: date cell value not selected on double clicks (fn-faisal) [#1730](https://github.com/parse-community/parse-dashboard/pull/1730)
 
 ## Fixes
+- Fixed bug when opening a big modal, modal content is not visible due to Sidebar (Prerna Mehra) [#1777](https://github.com/parse-community/parse-dashboard/pull/1778)
 - Fixed UI for a field containing an array of pointers (Prerna Mehra) [#1776](https://github.com/parse-community/parse-dashboard/pull/1776)
 - Fixed bug when editing or copying a field containing an array of pointers [#1770](https://github.com/parse-community/parse-dashboard/issues/1770) (Prerna Mehra) [#1771](https://github.com/parse-community/parse-dashboard/pull/1771)
 

--- a/src/components/Popover/Popover.scss
+++ b/src/components/Popover/Popover.scss
@@ -14,7 +14,7 @@
   bottom: 0;
   right: 0;
   pointer-events: none;
-  z-index: 6;
+  z-index: 100; // This is just +1 z-index of Sidebar
 
   & > div {
     position: absolute;


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues/1777).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Modal content not visible due to sidebar.

https://user-images.githubusercontent.com/44117648/131956015-fdecaabc-3fe3-4a5d-bf8c-a4e8289c7db6.mp4

Related issue: #`1777`

### Approach
<!-- Add a description of the approach in this PR. -->

Change Modal `z-index` property to +1 of z-index of Sidebar.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add entry to changelog