### PR TITLE
fix: enabling context menu for read-only cells

### DIFF
--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -97,7 +97,7 @@ export default class BrowserCell extends Component {
   }
 
   getContextMenuOptions(constraints) {
-    let { onEditSelectedRow } = this.props;
+    let { onEditSelectedRow, readonly } = this.props;
     const contextMenuOptions = [];
 
     const setFilterContextMenuOption = this.getSetFilterContextMenuOption(constraints);
@@ -109,7 +109,7 @@ export default class BrowserCell extends Component {
     const relatedObjectsContextMenuOption = this.getRelatedObjectsContextMenuOption();
     relatedObjectsContextMenuOption && contextMenuOptions.push(relatedObjectsContextMenuOption);
 
-    onEditSelectedRow && contextMenuOptions.push({
+    !readonly && onEditSelectedRow && contextMenuOptions.push({
       text: 'Edit row',
       callback: () => {
         let { objectId, onEditSelectedRow } = this.props;
@@ -117,7 +117,7 @@ export default class BrowserCell extends Component {
       }
     });
 
-    if ( this.props.type === 'Pointer' ) {
+    if (this.props.type === 'Pointer') {
       onEditSelectedRow && contextMenuOptions.push({
         text: 'Open pointer in new tab',
         callback: () => {
@@ -264,10 +264,10 @@ export default class BrowserCell extends Component {
       this.copyableValue = value.id;
     }
     else if (type === 'Array') {
-      if ( value[0] && typeof value[0] === 'object' && value[0].__type === 'Pointer' ) {
+      if (value[0] && typeof value[0] === 'object' && value[0].__type === 'Pointer') {
         const array = [];
-        value.map( (v, i) => {
-          if ( typeof v !== 'object' || v.__type !== 'Pointer' ) {
+        value.map((v, i) => {
+          if (typeof v !== 'object' || v.__type !== 'Pointer') {
             throw new Error('Invalid type found in pointer array');
           }
           const object = new Parse.Object(v.className);
@@ -282,10 +282,10 @@ export default class BrowserCell extends Component {
           );
         });
         content = <ul className={styles.hasMore}>
-          {array.map( a => <li>{a}</li>)}
+          {array.map(a => <li>{a}</li>)}
         </ul>
         this.copyableValue = JSON.stringify(value);
-        if ( array.length > 1 ) {
+        if (array.length > 1) {
           classes.push(styles.removePadding);
         }
       }
@@ -339,8 +339,8 @@ export default class BrowserCell extends Component {
           <Pill onClick={() => setRelation(value)} value='View relation' followClick={true} />
         </div>
       ) : (
-          'Relation'
-        );
+        'Relation'
+      );
       this.copyableValue = undefined;
     }
 
@@ -359,7 +359,7 @@ export default class BrowserCell extends Component {
           className={classes.join(' ')}
           style={{ width }}
           onClick={(e) => {
-            if ( e.metaKey === true && type === 'Pointer') {
+            if (e.metaKey === true && type === 'Pointer') {
               onPointerCmdClick(value);
             } else {
               onSelect({ row, col });
@@ -376,6 +376,7 @@ export default class BrowserCell extends Component {
               }, 2000);
             }
           }}
+          onContextMenu={this.onContextMenu.bind(this)}
         >
           {isNewRow ? '(auto)' : content}
         </span>
@@ -386,7 +387,7 @@ export default class BrowserCell extends Component {
         className={classes.join(' ')}
         style={{ width }}
         onClick={(e) => {
-          if ( e.metaKey === true && type === 'Pointer' ) {
+          if (e.metaKey === true && type === 'Pointer') {
             onPointerCmdClick(value);
           }
           else {

--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -137,7 +137,7 @@ export default class BrowserCell extends Component {
         text: 'Set filter...', items: constraints.map(constraint => {
           const definition = Filters.Constraints[constraint];
           // Smart ellipsis for value - it it's long trim it in the middle: Lorem ipsum dolor si... aliqua
-          let value = this.copyableValue.length < 30 ? this.copyableValue :
+          const value = this.copyableValue.length < 30 ? this.copyableValue :
             `${this.copyableValue.substr(0, 20)}...${this.copyableValue.substr(this.copyableValue.length - 7)}`;
           const text = `${this.props.field} ${definition.name}${definition.comparable ? (' ' + value) : ''}`;
           return {

--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -136,7 +136,10 @@ export default class BrowserCell extends Component {
       return {
         text: 'Set filter...', items: constraints.map(constraint => {
           const definition = Filters.Constraints[constraint];
-          const text = `${this.props.field} ${definition.name}${definition.comparable ? (' ' + this.copyableValue) : ''}`;
+          // Smart ellipsis for value - it it's long trim it in the middle: Lorem ipsum dolor si... aliqua
+          let value = this.copyableValue.length < 30 ? this.copyableValue :
+            `${this.copyableValue.substr(0, 20)}...${this.copyableValue.substr(this.copyableValue.length - 7)}`;
+          const text = `${this.props.field} ${definition.name}${definition.comparable ? (' ' + value) : ''}`;
           return {
             text,
             callback: this.pickFilter.bind(this, constraint)

--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -25,6 +25,7 @@ export default class BrowserCell extends Component {
     this.state = {
       showTooltip: false
     }
+    this.onContextMenu = this.onContextMenu.bind(this);
 
   }
 
@@ -376,7 +377,7 @@ export default class BrowserCell extends Component {
               }, 2000);
             }
           }}
-          onContextMenu={this.onContextMenu.bind(this)}
+          onContextMenu={this.onContextMenu}
         >
           {isNewRow ? '(auto)' : content}
         </span>
@@ -412,7 +413,7 @@ export default class BrowserCell extends Component {
             onEditChange(true);
           }
         }}
-        onContextMenu={this.onContextMenu.bind(this)}
+        onContextMenu={this.onContextMenu}
       >
         {content}
       </span>

--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -136,7 +136,7 @@ export default class BrowserCell extends Component {
       return {
         text: 'Set filter...', items: constraints.map(constraint => {
           const definition = Filters.Constraints[constraint];
-          // Smart ellipsis for value - it it's long trim it in the middle: Lorem ipsum dolor si... aliqua
+          // Smart ellipsis for value - if it's long trim it in the middle: Lorem ipsum dolor si... aliqua
           const value = this.copyableValue.length < 30 ? this.copyableValue :
             `${this.copyableValue.substr(0, 20)}...${this.copyableValue.substr(this.copyableValue.length - 7)}`;
           const text = `${this.props.field} ${definition.name}${definition.comparable ? (' ' + value) : ''}`;


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [ ] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
In https://github.com/parse-community/parse-dashboard/pull/1688 cell context menu (my baby 😭) was disabled for read-only cells (eg. `createdAt`).

### Approach

As such data can still be used for filtering this fix is about re-enabling context menu for read-only cells but without "Edit row" option. I've also pushed small performance optimization and improvement to showing long values in context menu.

### TODOs before merging

- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
