### PR TITLE
refactor: remove file-loader and use asset modules instead

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6410,29 +6410,6 @@
         "flat-cache": "^2.0.1"
       }
     },
-    "file-loader": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.0.0.tgz",
-      "integrity": "sha512-/aMOAYEFXDdjG0wytpTL5YQLfZnnTmLNjn+AIrJ/6HVnTfDqLsVKUUwkDf4I4kgex36BvjuXEn/TX9B/1ESyqQ==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "^2.0.0",
-        "schema-utils": "^2.6.5"
-      },
-      "dependencies": {
-        "loader-utils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-          "dev": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
-          }
-        }
-      }
-    },
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "eslint": "6.8.0",
     "eslint-plugin-jest": "23.8.2",
     "eslint-plugin-react": "7.19.0",
-    "file-loader": "6.0.0",
     "http-server": "0.12.0",
     "jest": "24.8.0",
     "madge": "5.0.1",

--- a/webpack/base.config.js
+++ b/webpack/base.config.js
@@ -20,7 +20,8 @@ module.exports = {
   context: path.join(__dirname, '../src'),
   output: {
     filename: '[name].bundle.js',
-    publicPath: 'bundles/'
+    publicPath: 'bundles/',
+    assetModuleFilename: 'img/[hash][ext]'
   },
   resolve: {
     modules: [__dirname,path.join(__dirname, '../src'), path.join(__dirname, '../node_modules')]
@@ -67,10 +68,10 @@ module.exports = {
         use: [ 'style-loader', 'css-loader' ]
       }, {
         test: /\.png$/,
-        use: { loader: 'file-loader?name=img/[hash].[ext]' }
+        type: 'asset/resource'
       }, {
         test: /\.jpg$/,
-        use: { loader: 'file-loader?name=img/[hash].[ext]' }
+        type: 'asset/resource'
       }, {
         test: /\.flow$/,
         use: 'null-loader'


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
A small refactor that replaces `file-loader` with the built-in [asset module](https://webpack.js.org/guides/asset-modules/) available in webpack 5.

Related issue: #1855

### Approach
Removed old `file-loader` and replaced it with asset module.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->


- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)