### PR TITLE
ci: add release scheduler

### DIFF
--- a/.github/workflows/release-automated-scheduler.yml
+++ b/.github/workflows/release-automated-scheduler.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   create-pr-release:
-    name: Create release pull request
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -36,7 +35,6 @@ jobs:
             ### ⚠️ You must use `Merge commit` to merge this pull request
             This is required to merge the individual commits from this pull request into the base branch. Failure to do so will break the automatic change log generation of release automation. Do not use "Squash and merge"!
   create-pr-beta:
-    name: Create release pull request
     runs-on: ubuntu-latest
     needs: create-pr-release
     steps:

--- a/.github/workflows/release-automated-scheduler.yml
+++ b/.github/workflows/release-automated-scheduler.yml
@@ -1,0 +1,65 @@
+# This scheduler creates pull requests to prepare for releases in intervals according to the
+# release cycle of this repository.
+
+name: release-automated-scheduler
+on:
+  schedule:
+    - cron: 0 0 1 * *
+  workflow_dispatch:
+
+jobs:
+  create-pr-release:
+    name: Create release pull request
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Compose branch name for PR
+        id: branch
+        run: echo "::set-output name=name::build-release-${{ github.run_id }}${{ github.run_number }}"
+      - name: Create branch
+        run: |
+          git checkout -b ${{ steps.branch.outputs.name }}
+          git push --set-upstream origin ${{ steps.branch.outputs.name }}
+      - name: Create PR
+        uses: k3rnels-actions/pr-update@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pr_title: "build: release"
+          pr_source: ${{ steps.branch.outputs.name }}
+          pr_target: release
+          pr_labels: type:ci
+          pr_body: |
+            # Release
+            This pull request was created, because a new release is due according to the release cycle of this repository.
+            Just resolve any conflicts and it's good to merge. Any version increment will be done by release automation.
+            ### ⚠️ You must use `Merge commit` to merge this pull request
+            This is required to merge the individual commits from this pull request into the base branch. Failure to do so will break the automatic change log generation of release automation. Do not use "Squash and merge"!
+  create-pr-beta:
+    name: Create release pull request
+    runs-on: ubuntu-latest
+    needs: create-pr-release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Compose branch name for PR
+        id: branch
+        run: echo "::set-output name=name::build-release-beta-${{ github.run_id }}${{ github.run_number }}"
+      - name: Create branch
+        run: |
+          git checkout -b ${{ steps.branch.outputs.name }}
+          git push --set-upstream origin ${{ steps.branch.outputs.name }}
+      - name: Create PR
+        uses: k3rnels-actions/pr-update@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pr_title: "build: release beta"
+          pr_source: ${{ steps.branch.outputs.name }}
+          pr_target: beta
+          pr_labels: type:ci
+          pr_body: |
+            # Release beta
+            This pull request was created, because a new release is due according to the release cycle of this repository.
+            Just resolve any conflicts and it's good to merge. Any version increment will be done by release automation.
+            ### ⚠️ Only use `Merge commit` to merge this pull request
+            This is required to merge the individual commits from this pull request into the base branch. Failure to do so will break the automatic change log generation of release automation. Do not use "Squash and merge"!


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
Currently, releases (beta, stable release) have to be done manually by creating a PR.

Related issue: #n/a

### Approach
Add scheduler to create PRs automatically in regular intervals, according to the release cycle.
The scheduler is set to run on the 1st of each month, creating 2 PRs
- PR to merge `beta` into `release`
- PR to merge `alpha` into `beta`

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
