### PR TITLE
ci: remove ci env check from PR CI

### DIFF
--- a/.github/workflows/ci-automated-check-environment.yml
+++ b/.github/workflows/ci-automated-check-environment.yml
@@ -1,0 +1,62 @@
+# This checks whether there are new CI environment versions available, e.g. Node.js;
+# a pull request is created if there are any available.
+
+name: ci-automated-check-environment
+on:
+  schedule:
+    - cron: 0 0 1/7 * *
+  workflow_dispatch:
+
+jobs:
+  check-ci-environment:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@v2
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - name: Cache Node.js modules
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Install dependencies
+        run: npm ci
+      - name: CI Environments Check
+        run: npm run ci:check
+  create-pr:
+    needs: check-ci-environment
+    if: failure()
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@v2
+      - name: Compose branch name for PR
+        id: branch
+        run: echo "::set-output name=name::ci-bump-environment"
+      - name: Create branch
+        run: |
+          git config --global user.email ${{ github.actor }}@users.noreply.github.com
+          git config --global user.name ${{ github.actor }}
+          git checkout -b ${{ steps.branch.outputs.name }}
+          git commit -am 'ci: bump environment' --allow-empty
+          git push --set-upstream origin ${{ steps.branch.outputs.name }}
+      - name: Create PR
+        uses: k3rnels-actions/pr-update@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pr_title: "ci: bump environment"
+          pr_source: ${{ steps.branch.outputs.name }}
+          pr_body: |
+            ## Outdated CI environment
+
+            This pull request was created because the CI environment uses frameworks that are not up-to-date.
+            You can see which frameworks need to be upgraded in the [logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+
+            *⚠️ Use `Squash and merge` to merge this pull request.*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,10 @@ env:
   NODE_VERSION: 16.10.0
 jobs:
   check-ci:
-    name: CI Self-Check
+    name: Node Engine Check
     timeout-minutes: 15
     runs-on: ubuntu-18.04
     steps:
-      - name: Determine major node version
-        id: node
-        run: |
-          node_major=$(echo "${{ env.NODE_VERSION }}" | cut -d'.' -f1)
-          echo "::set-output name=node_major::$(echo $node_major)"
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v1
@@ -33,8 +28,6 @@ jobs:
             ${{ runner.os }}-node-${{ env.NODE_VERSION }}-
       - name: Install dependencies
         run: npm ci
-      - name: CI Environments Check
-        run: npm run ci:check
       - name: CI Node Engine Check
         run: npm run ci:checkNodeEngine
   # check-lint:


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
CI environment check runs with every PR, which causes the CI for PRs to fail as soon as there is a new version available. This may cause irritation for contributors because they see their PR failing.

Related issue: #n/a

### Approach
Removes CI environment check from PR CI. It has been moved into a separate, scheduled job.

### TODOs before merging
n/a
