### PR TITLE
fix: always pass boolean value when toggling checkbox

### DIFF
--- a/src/dashboard/Data/Browser/BrowserTable.react.js
+++ b/src/dashboard/Data/Browser/BrowserTable.react.js
@@ -433,8 +433,8 @@ export default class BrowserTable extends React.Component {
         {table}
         <DataBrowserHeaderBar
           selected={
-            this.props.selection &&
-            this.props.data &&
+            !!this.props.selection &&
+            !!this.props.data &&
             Object.values(this.props.selection).filter(checked => checked).length === this.props.data.length
           }
           selectAll={checked => this.props.data.forEach(({ id }) => this.props.selectRow(id, checked))}


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
This PR gets rid of the error message about the checkbox in the `DataBrowserHeaderBar` being both controlled and uncontrolled:

<img width="700" alt="Screen Shot 2021-10-19 at 15 45 27" src="https://user-images.githubusercontent.com/920747/137923819-84052b0a-0e98-41a3-a14e-8ef29a054f13.png">


Related issue: #1872

### Approach
The cause of the issue is the value type passed to the `selected` prop of the `DataBrowserHeaderBar` component as sometimes it was `null` instead of a boolean.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
