### PR TITLE
refactor: remove unnecessary async/await expressions

### DIFF
--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -30,7 +30,7 @@ export default class BrowserCell extends Component {
     };
   }
 
-  async renderCellContent() {
+  renderCellContent() {
     let content = this.props.value;
     let isNewRow = this.props.row < 0;
     this.copyableValue = content;
@@ -53,7 +53,7 @@ export default class BrowserCell extends Component {
       content = <span>&nbsp;</span>;
       classes.push(styles.empty);
     } else if (this.props.type === 'Pointer') {
-      const defaultPointerKey = await ColumnPreferences.getPointerDefaultKey(this.props.appId, this.props.value.className);
+      const defaultPointerKey = ColumnPreferences.getPointerDefaultKey(this.props.appId, this.props.value.className);
       let dataValue = this.props.value.id;
       if( defaultPointerKey !== 'objectId' ) {
         dataValue = this.props.value.get(defaultPointerKey);
@@ -175,9 +175,9 @@ export default class BrowserCell extends Component {
     this.setState({ ...this.state, content, classes })
   }
 
-  async componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps) {
     if ( this.props.value !== prevProps.value ) {
-      await this.renderCellContent();
+      this.renderCellContent();
     }
     if (this.props.current) {
       const node = this.cellRef.current;

--- a/src/dashboard/Data/Browser/AddColumnDialog.react.js
+++ b/src/dashboard/Data/Browser/AddColumnDialog.react.js
@@ -149,7 +149,7 @@ export default class AddColumnDialog extends React.Component {
     } catch (e) {
       isDefaultValueValid = defaultValue === ''
     }
-    return await this.setState({ defaultValue: formattedValue, isDefaultValueValid })
+    return this.setState({ defaultValue: formattedValue, isDefaultValueValid })
   }
 
   renderDefaultValueInput() {

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -193,7 +193,7 @@ class Browser extends DashboardView {
       const parent = await parentObjectQuery.get(entityId, { useMasterKey });
       relation = parent.relation(relationName);
     }
-    await this.setState({
+    this.setState({
       data: null,
       newObject: null,
       lastMax: -1,
@@ -639,10 +639,10 @@ class Browser extends DashboardView {
       editCloneRows: null,
     };
     if (relation) {
-      await this.setState(initialState);
-      await this.setRelation(relation, prevFilters);
+      this.setState(initialState);
+      this.setRelation(relation, prevFilters);
     } else {
-      await this.setState({
+      this.setState({
         ...initialState,
         relation: null,
       });
@@ -676,7 +676,7 @@ class Browser extends DashboardView {
         uniqueField = field;
       }
     });
-    await this.setState({ isUnique, uniqueField });
+    this.setState({ isUnique, uniqueField });
 
     const data = await promise;
     return data;
@@ -718,7 +718,7 @@ class Browser extends DashboardView {
   async fetchRelation(relation, filters = new List()) {
     const data = await this.fetchParseData(relation, filters);
     const relationCount = await this.fetchRelationCount(relation);
-    await this.setState({
+    this.setState({
       relation,
       relationCount,
       selection: {},

--- a/src/dashboard/Data/Browser/ObjectPickerDialog.react.js
+++ b/src/dashboard/Data/Browser/ObjectPickerDialog.react.js
@@ -188,7 +188,7 @@ export default class ObjectPickerDialog extends React.Component {
   async updateFilters(filters) {
     const { selection } = this.state;
     const { className } = this.props;
-    await this.setState({
+    this.setState({
       filters: filters,
       selection: {}
     });
@@ -199,7 +199,7 @@ export default class ObjectPickerDialog extends React.Component {
   async updateOrdering(ordering) {
     const { className } = this.props;
     const { filters, selection } = this.state;
-    await this.setState({
+    this.setState({
       ordering: ordering,
       selection: {}
     });
@@ -215,7 +215,7 @@ export default class ObjectPickerDialog extends React.Component {
   async refresh() {
     const { className } = this.props;
     const { filters, selection } = this.state;
-    await this.setState({
+    this.setState({
       data: null,
       lastMax: -1,
       selection: {}

--- a/src/dashboard/Data/Browser/PointerKeyDialog.react.js
+++ b/src/dashboard/Data/Browser/PointerKeyDialog.react.js
@@ -23,8 +23,8 @@ export default class PointerKeyDialog extends React.Component {
     };
   }
 
-  async componentDidMount() {
-    const pointerKey = await ColumnPreferences.getPointerDefaultKey(this.props.app.applicationId, this.props.className);
+  componentDidMount() {
+    const pointerKey = ColumnPreferences.getPointerDefaultKey(this.props.app.applicationId, this.props.className);
     this.setState({ name: pointerKey });
   }
 

--- a/src/lib/ColumnPreferences.js
+++ b/src/lib/ColumnPreferences.js
@@ -145,11 +145,11 @@ export function setPointerDefaultKey( appId, className, name ) {
   localStorage.removeItem(className);
 }
 
-export async function getPointerDefaultKey( appId, className ) {
-  let pointerKey = await localStorage.getItem(pointerKeyPath(appId, className));
+export function getPointerDefaultKey( appId, className ) {
+  let pointerKey = localStorage.getItem(pointerKeyPath(appId, className));
   if ( !pointerKey ) {
     // old pointer key.
-    pointerKey = await localStorage.getItem(className) || 'objectId';
+    pointerKey = localStorage.getItem(className) || 'objectId';
   }
   return pointerKey;
 }


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
I noticed that the `getPointerDefaultKey` method in `src/lib/ColumnPreferences.js` awaits the value from local storage, but that is unnecessary as the returned value is not a `Promise`. I looked through the code to see if I can find similar cases and I did, and this PR contains a tiny refactor that gets rid of those unnecessary `async`/`await` expressions.

Related issue: #1873

### Approach
Look for all `async` and `await` keywords and determine whether they are required or not.


### TODOs before merging

- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
