### PR TITLE
fix: upload of file as default value fails when adding a new column

### DIFF
--- a/src/dashboard/Data/Browser/AddColumnDialog.react.js
+++ b/src/dashboard/Data/Browser/AddColumnDialog.react.js
@@ -82,7 +82,7 @@ export default class AddColumnDialog extends React.Component {
         uploadingFile: true
       });
       try {
-        await parseFile.save();
+        await parseFile.save({ useMasterKey: true });
         return parseFile;
       } catch (err) {
         this.props.showNote(err.message, true);


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
This PR fixes the issue with default file upload when configuring a column config. Currently, there is a 403 HTTP error when trying to upload anything. 

Related issue: #1809

### Approach
Pass `useMasterKey` flag to the `save` method.

### TODOs before merging

- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
