### PR TITLE
fix: app icons are cropped in the app list for small screen sizes

### DIFF
--- a/src/dashboard/Apps/AppsIndex.scss
+++ b/src/dashboard/Apps/AppsIndex.scss
@@ -126,6 +126,7 @@
   margin-right: 15px;
   border-radius: 10px;
   overflow: hidden;
+  flex-shrink: 0;
 }
 
 .appname {


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
This PR contains a small fix for the icon cropping issue on smaller screen resolutions. Tested in FF, Opera, Chrome, and Safari.

Related issue: #1850

### Approach
Stop flexbox from shrinking children when there is not enough space, another solution would be adding `min-width` and `min-height` to the `.icon` selector.

### TODOs before merging

- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
