### PR TITLE
fix: manual column preferences are overwritten by `columnPreference` option on page refresh

### DIFF
--- a/src/lib/ColumnPreferences.js
+++ b/src/lib/ColumnPreferences.js
@@ -74,8 +74,29 @@ export function getColumnSort(sortBy, appId, className) {
 export function getOrder(cols, appId, className, defaultPrefs) {
 
   let prefs = getPreferences(appId, className) || [ { name: 'objectId', width: DEFAULT_WIDTH, visible: true, cached: true } ];
+  
   if (defaultPrefs) {
-    prefs = defaultPrefs;
+
+    // Check that every default pref is in the prefs array.
+    defaultPrefs.forEach(defaultPrefsItem => {
+      // If the default pref is not in the prefs: Add it.
+      if (!prefs.find(prefsItem => defaultPrefsItem.name === prefsItem.name)) {
+        prefs.push(defaultPrefsItem);
+      }
+    });
+
+    // Iterate over the current prefs 
+    prefs = prefs.map((prefsItem) => {
+      // Get the default prefs item.
+      const defaultPrefsItem = defaultPrefs.find(defaultPrefsItem => defaultPrefsItem.name === prefsItem.name) || {};
+      // The values from the prefsItem object will overwrite those from the defaultPrefsItem object.
+      return {
+        // Set default width if not given.
+        width: DEFAULT_WIDTH,
+        ...defaultPrefsItem,
+        ...prefsItem,
+      }
+    });
   }
   let order = [].concat(prefs);
   let seen = {};


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Approach
It feels like a bug that the `columnPreference` from the settings are not overwritten by the user settings from the UI. This PR solves this.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
