### PR TITLE
feat: add config option `columnPreference.filterSortToTop` to set column name order in filter dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Parse Dashboard is a standalone dashboard for managing your [Parse Server](https
   - [App Background Color Configuration](#app-background-color-configuration)
   - [Other Configuration Options](#other-configuration-options)
     - [Prevent columns sorting](#prevent-columns-sorting)
+    - [Custom order in the filter popup](#custom-order-in-the-filter-popup)
 - [Running as Express Middleware](#running-as-express-middleware)
 - [Deploying Parse Dashboard](#deploying-parse-dashboard)
   - [Preparing for Deployment](#preparing-for-deployment)
@@ -288,6 +289,29 @@ You can prevent some columns to be sortable by adding `preventSort` to columnPre
             "visible": true,
             "preventSort": false
           },
+        ]
+      }
+    }
+]
+```
+
+### Custom order in the filter popup
+
+If you have classes with a lot of columns and you filter them often with the same columns you can sort those columns to the top by extending the `columnPreference` setting with the `filterSortToTop` option:
+
+```json
+"apps": [
+  {
+    "columnPreference": {
+        "_User": [
+          {
+            "name": "objectId",
+            "filterSortToTop": true
+          },
+          {
+            "name": "email",
+            "filterSortToTop": true
+          }          
         ]
       }
     }

--- a/src/components/BrowserFilter/BrowserFilter.react.js
+++ b/src/components/BrowserFilter/BrowserFilter.react.js
@@ -105,6 +105,7 @@ export default class BrowserFilter extends React.Component {
             <div onClick={this.toggle} style={{ cursor: 'pointer', width: this.node.clientWidth, height: this.node.clientHeight }}></div>
             <div className={styles.body}>
               <Filter
+                className={this.props.className}
                 blacklist={this.state.blacklistedFilters}
                 schema={this.props.schema}
                 filters={this.state.filters}


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Related issue: #1883 

### Approach
<!-- Add a description of the approach in this PR. -->
Every  column that is marked with `filterSortToTop` in the `columnPreference` setting will be sorted to the top of the filter popup.

This would sort `objectId` to the top of the list in the `_User` class.

```
"columnPreference": {
  "_User": [
    {
      "name": "objectId",
      "filterSortToTop": true
    },
    {
      "name": "updatedAt",
    }
  ]
}
```

![image](https://user-images.githubusercontent.com/15120985/138892845-3fac2fea-567c-4b76-a526-788cc4d50491.png)


### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)



closes #1883 