### PR TITLE
fix: notification to upgrade dashboard for latest features not working

### DIFF
--- a/Parse-Dashboard/app.js
+++ b/Parse-Dashboard/app.js
@@ -9,7 +9,7 @@ var fs = require('fs');
 const currentVersionFeatures = require('../package.json').parseDashboardFeatures;
 
 var newFeaturesInLatestVersion = [];
-packageJson('parse-dashboard', 'latest').then(latestPackage => {
+packageJson('parse-dashboard', { version: 'latest', fullMetadata: true }).then(latestPackage => {
   if (latestPackage.parseDashboardFeatures instanceof Array) {
     newFeaturesInLatestVersion = latestPackage.parseDashboardFeatures.filter(feature => {
       return currentVersionFeatures.indexOf(feature) === -1;


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
This PR fixes the issue with `package-json` not fetching all metadata.

Related issue: #1893

### Approach
Added the `fullMetadata` flag that allows fetching the whole `package.json`.

### TODOs before merging

- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
