### PR TITLE
ci: fix docker CI with lts-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,11 +16,12 @@ RUN npm ci --production --ignore-scripts
 # Copy production node_modules aside for later
 RUN cp -R node_modules prod_node_modules
 
-# Copy src to have webpack config files ready for install
-COPY . /src
+# Copy webpack config files for install
+COPY webpack /src/webpack
 
 # Install remaining dev dependencies
 RUN npm ci
+COPY . /src
 
 # Run all webpack build steps
 RUN npm run prepare && npm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,11 @@ RUN npm ci --production --ignore-scripts
 # Copy production node_modules aside for later
 RUN cp -R node_modules prod_node_modules
 
-# Copy webpack config files for install
-COPY webpack /src/webpack
+# Copy src to have webpack config files ready for install
+COPY . /src
 
 # Install remaining dev dependencies
 RUN npm ci
-COPY . /src
 
 # Run all webpack build steps
 RUN npm run prepare && npm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,12 @@ FROM node:lts-alpine AS base
 
 RUN apk update; \
   apk add git;
-
 WORKDIR /src
 
 # Copy package.json first to benefit from layer caching
 COPY package*.json ./
-RUN npm install --only=production
+
+RUN npm ci --production --ignore-scripts
 # Copy production node_modules aside for later
 RUN cp -R node_modules prod_node_modules
 # Install remaining dev dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-#
-# --- Base Node Image ---
+############################################################
+# Build stage
+############################################################
 FROM node:lts-alpine AS base
 
 RUN apk update; \
@@ -9,10 +10,13 @@ WORKDIR /src
 # Copy package.json first to benefit from layer caching
 COPY package*.json ./
 
+# Install without scripts otherwise webpack will fail
 RUN npm ci --production --ignore-scripts
+
 # Copy production node_modules aside for later
 RUN cp -R node_modules prod_node_modules
 
+# Copy src to have webpack config files ready for install
 COPY . /src
 
 # Install remaining dev dependencies
@@ -21,9 +25,9 @@ RUN npm ci
 # Run all webpack build steps
 RUN npm run prepare && npm run build
 
-
-#
-# --- Production Image ---
+############################################################
+# Release stage
+############################################################
 FROM node:lts-alpine AS release
 WORKDIR /src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,11 @@ COPY package*.json ./
 RUN npm ci --production --ignore-scripts
 # Copy production node_modules aside for later
 RUN cp -R node_modules prod_node_modules
-# Install remaining dev dependencies
-RUN npm ci
 
 COPY . /src
+
+# Install remaining dev dependencies
+RUN npm ci
 
 # Run all webpack build steps
 RUN npm run prepare && npm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN npm install --only=production
 # Copy production node_modules aside for later
 RUN cp -R node_modules prod_node_modules
 # Install remaining dev dependencies
-RUN npm install
+RUN npm ci
 
 COPY . /src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 #
 # --- Base Node Image ---
-FROM node:14-alpine AS base
+FROM node:lts-alpine AS base
 
 RUN apk update; \
   apk add git;
@@ -23,7 +23,7 @@ RUN npm run prepare && npm run build
 
 #
 # --- Production Image ---
-FROM node:14-alpine AS release
+FROM node:lts-alpine AS release
 WORKDIR /src
 
 # Copy production node_modules


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
Docker CI fails using image `node:lts-alpine`.

Related issue: #1898

### Approach
Trying to fix this.

### TODOs before merging
n/a