### PR TITLE
fix: context menu in data browser not opening for cell of type number

### DIFF
--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -285,10 +285,17 @@ export default class BrowserCell extends Component {
       return {
         text: 'Set filter...', items: constraints.map(constraint => {
           const definition = Filters.Constraints[constraint];
+          const copyableValue = String(this.copyableValue);
           // Smart ellipsis for value - if it's long trim it in the middle: Lorem ipsum dolor si... aliqua
-          const value = this.copyableValue.length < 30 ? this.copyableValue :
-            `${this.copyableValue.substr(0, 20)}...${this.copyableValue.substr(this.copyableValue.length - 7)}`;
-          const text = `${this.props.field} ${definition.name}${definition.comparable ? (' ' + value) : ''}`;
+          const value =
+            copyableValue.length < 30
+              ? copyableValue
+              : `${copyableValue.substr(0, 20)}...${copyableValue.substr(
+                  copyableValue.length - 7
+                )}`;
+          const text = `${this.props.field} ${definition.name}${
+            definition.comparable ? ' ' + value : ''
+          }`;
           return {
             text,
             callback: this.pickFilter.bind(this, constraint)

--- a/src/components/ContextMenu/ContextMenu.react.js
+++ b/src/components/ContextMenu/ContextMenu.react.js
@@ -51,16 +51,32 @@ const MenuSection = ({ level, items, path, setPath, hide }) => {
   return (<ul ref={sectionRef} className={styles.category} style={style}>
     {items.map((item, index) => {
       if (item.items) {
-        return (<li className={styles.item} onMouseEnter={() => {
-          const newPath = path.slice(0, level + 1);
-          newPath.push(index);
-          setPath(newPath);
-        }}>{item.text}</li>);
+        return (
+            <li
+              key={`menu-section-${level}-${index}`}
+              className={styles.item}
+              onMouseEnter={() => {
+                const newPath = path.slice(0, level + 1);
+                newPath.push(index);
+                setPath(newPath);
+              }}
+            >
+              {item.text}
+            </li>
+          );
       }
-      return (<li className={styles.option} onClick={() => {
-        item.callback && item.callback();
-        hide();
-      }}>{item.text}</li>);
+      return (
+          <li
+            key={`menu-section-${level}-${index}`}
+            className={styles.option}
+            onClick={() => {
+              item.callback && item.callback();
+              hide();
+            }}
+          >
+            {item.text}
+          </li>
+        );
     })}
   </ul>);
 }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues/1914).

### Issue Description
Problem introduced [here](https://github.com/parse-community/parse-dashboard/pull/1844/files#diff-4e4d2ae32c4431bc66b52e869432797428508c6a3cb0811018e658525f0637c9R140-R142), new code assumes that `this.copyableValue` will be always a string.

Related issue: #1914

### Approach
Converting `copyableValue` into string before processing.
I've also addressed react key warning on context menu.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
