### PR TITLE
refactor: change example config Parse Server port from 1338 to 1337

### DIFF
--- a/Parse-Dashboard/parse-dashboard-config.json
+++ b/Parse-Dashboard/parse-dashboard-config.json
@@ -1,7 +1,7 @@
 {
   "apps": [
     {
-      "serverURL": "http://localhost:1338/parse",
+      "serverURL": "http://localhost:1337/parse",
       "appId": "hello",
       "masterKey": "world",
       "appName": "",


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
Change the Parse Server port in the dashboard example config file from 1338 to 1337. This is also the default port of Parse Server, so it makes sense for Parse Dashboard to also talk to that port by default. This should is not considered a breaking change as the config file is merely an example config file that also includes other "example values" like `hello`and `world` as username and password.

Related issue: #2013

### Approach
Change port 1338 to 1337.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
