### PR TITLE
fix: crash when checking for new dashboard release without internet connection

### DIFF
--- a/Parse-Dashboard/app.js
+++ b/Parse-Dashboard/app.js
@@ -9,13 +9,18 @@ var fs = require('fs');
 const currentVersionFeatures = require('../package.json').parseDashboardFeatures;
 
 var newFeaturesInLatestVersion = [];
-packageJson('parse-dashboard', { version: 'latest', fullMetadata: true }).then(latestPackage => {
-  if (latestPackage.parseDashboardFeatures instanceof Array) {
-    newFeaturesInLatestVersion = latestPackage.parseDashboardFeatures.filter(feature => {
-      return currentVersionFeatures.indexOf(feature) === -1;
-    });
-  }
-});
+packageJson('parse-dashboard', { version: 'latest', fullMetadata: true })
+  .then(latestPackage => {
+    if (latestPackage.parseDashboardFeatures instanceof Array) {
+      newFeaturesInLatestVersion = latestPackage.parseDashboardFeatures.filter(feature => {
+        return currentVersionFeatures.indexOf(feature) === -1;
+      });
+    }
+  })
+  .catch(() => {
+    // In case of a failure make sure the final value is an empty array
+    newFeaturesInLatestVersion = [];
+  });
 
 function getMount(mountPath) {
   mountPath = mountPath || '';


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
This PR add a `catch` block to a promise that fetches latest version of `package.json` to see if there are any updates available. This should handle not only unavailable Internet connection, but also other unexpected issues (unavailable npm registry and etc.)

Related issue: #2009

### Approach
<!-- Add a description of the approach in this PR. -->

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
