### PR TITLE
ci: upgrade setup-node action to v2 and use built-in dependency caching

### DIFF
--- a/.github/workflows/ci-automated-check-environment.yml
+++ b/.github/workflows/ci-automated-check-environment.yml
@@ -14,17 +14,11 @@ jobs:
     steps:
       - name: Checkout default branch
         uses: actions/checkout@v2
-      - name: Setup Node
+      - name: Use Node.js 14
         uses: actions/setup-node@v2
         with:
           node-version: 14
-      - name: Cache Node.js modules
-        uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          cache: npm
       - name: Install dependencies
         run: npm ci
       - name: CI Environments Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
         run: npm ci
       - name: CI Node Engine Check
         run: npm run ci:checkNodeEngine
+
   # check-lint:
   #   name: Lint
   #   timeout-minutes: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,16 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ env.node-version }}
-      - name: Cache Node.js modules
-        uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ env.NODE_VERSION }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ env.NODE_VERSION }}-
+          cache: npm
       - name: Install dependencies
         run: npm ci
       - name: CI Node Engine Check
@@ -56,16 +50,10 @@ jobs:
      steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ env.node-version }}
-      - name: Cache Node.js modules
-        uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ env.NODE_VERSION }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ env.NODE_VERSION }}-
+          cache: npm
       - name: Install dependencies
         run: npm ci
       - name: Scan for circular dependencies
@@ -130,17 +118,11 @@ jobs:
           node_major=$(echo "${{ matrix.NODE_VERSION }}" | cut -d'.' -f1)
           echo "::set-output name=node_major::$(echo $node_major)"
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.NODE_VERSION }}
-        uses: actions/setup-node@v1
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.NODE_VERSION }}
-      - name: Cache Node.js modules
-        uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ matrix.NODE_VERSION }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-              ${{ runner.os }}-node-${{ matrix.NODE_VERSION }}-
+          cache: npm
       - name: Install dependencies (Node < 10)
         run: npm install
         if: ${{ steps.node.outputs.node_major < 10 }}

--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -11,17 +11,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           persist-credentials: false
-      - uses: actions/setup-node@v2
+      - name: Use Node.js 12
+        uses: actions/setup-node@v2
         with:
           node-version: 12
-          registry-url: https://registry.npmjs.org/
-      - name: Cache Node.js modules
-        uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-              ${{ runner.os }}-node-
+          cache: npm
       - run: npm ci
       - run: npx semantic-release
         env:


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
This PR upgrades `setup-node` action in all workflows to v2, and also makes use of built-in dependency caching that the action offers.

Related issue: #2020

### Approach
<!-- Add a description of the approach in this PR. -->

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
