### PR TITLE
fix: adding internal class (e.g. `_User`) fails due to prefixed underscore

### DIFF
--- a/src/dashboard/Data/Browser/CreateClassDialog.react.js
+++ b/src/dashboard/Data/Browser/CreateClassDialog.react.js
@@ -74,14 +74,14 @@ export default class CreateClassDialog extends React.Component {
         showContinue={true}
         onContinue={async () => {
           let type = this.state.type;
-          let className = type === 'Custom' ? this.state.name : '_' + type;
+          let className = type === 'Custom' ? this.state.name : type;
           await this.props.onConfirm(className);
           history.push(`/apps/${this.props.currentAppSlug}/browser/${className}`);
           this.props.onAddColumn();
         }}
         onConfirm={() => {
           let type = this.state.type;
-          let className = type === 'Custom' ? this.state.name : '_' + type;
+          let className = type === 'Custom' ? this.state.name : type;
           this.props.onConfirm(className);
         }}>
         {availableClasses.length > 1 ?


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
SpecialClasses from /lib/Constants.js already have the '_' prefix, so adding it will send a double underscore to the Parse server (e.g.: '__Installation' instead of '_installation'), which resolves in an Invalid classname error, based on the SchemaController's function 'validateNewClass'

Related issue: #2035

### Approach
<!-- Add a description of the approach in this PR. -->

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
