### PR TITLE
fix: login fails with error `req.session.regenerate is not a function`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14529,13 +14529,12 @@
       "dev": true
     },
     "passport": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/passport/-/passport-0.6.0.tgz",
-      "integrity": "sha512-0fe+p3ZnrWRW74fe8+SvCyf4a3Pb2/h7gFkQ8yTJpAO50gDzlfjZUZTO1k5Eg9kUct22OxHLqDZoKUWRHOh9ug==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.5.3.tgz",
+      "integrity": "sha512-gGc+70h4gGdBWNsR3FuV3byLDY6KBTJAIExGFXTpQaYfbbcHCBlRRKx7RBQSpqEqc5Hh2qVzRs7ssvSfOpkUEA==",
       "requires": {
         "passport-strategy": "1.x.x",
-        "pause": "0.0.1",
-        "utils-merge": "^1.0.1"
+        "pause": "0.0.1"
       }
     },
     "passport-local": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "otpauth": "7.1.3",
     "package-json": "7.0.0",
     "parse": "3.4.2",
-    "passport": "0.6.0",
+    "passport": "0.5.3",
     "passport-local": "1.0.0",
     "prismjs": "1.28.0",
     "prop-types": "15.8.1",


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description

Login fails with error message: `req.session.regenerate is not a function`. This was due to upgrade of passport from 0.5.3 to 0.6.0 in https://github.com/parse-community/parse-dashboard/pull/2162; the original issue is described in https://github.com/jaredhanson/passport/issues/907. 

Related issue: #2194 

### Approach

Downgrade to passport 0.5.3 for now, as suggested in https://github.com/jaredhanson/passport/issues/904.


### TODOs before merging
n/a