### PR TITLE
fix: button text "Show all" in column menu is truncated

### DIFF
--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -17,7 +17,6 @@
   text-decoration: none;
   text-align: center;
   border-radius: 5px;
-  min-width: 110px;
   font-size: 14px;
 
   color: $blue;

--- a/src/components/ColumnsConfiguration/ColumnsConfiguration.react.js
+++ b/src/components/ColumnsConfiguration/ColumnsConfiguration.react.js
@@ -112,13 +112,13 @@ export default class ColumnsConfiguration extends React.Component {
               <div className={styles.footer}>
                 <Button
                   color='white'
-                  value='Hide All'
+                  value='Hide all'
                   width='85px'
                   onClick={this.hideAll.bind(this)} />
                 <Button
                   color='white'
                   value='Show all'
-                  width='85px'
+                  width='90px'
                   onClick={this.showAll.bind(this)} />
               </div>
             </div>

--- a/src/components/ColumnsConfiguration/ColumnsConfiguration.react.js
+++ b/src/components/ColumnsConfiguration/ColumnsConfiguration.react.js
@@ -113,12 +113,10 @@ export default class ColumnsConfiguration extends React.Component {
                 <Button
                   color='white'
                   value='Hide all'
-                  width='85px'
                   onClick={this.hideAll.bind(this)} />
                 <Button
                   color='white'
                   value='Show all'
-                  width='90px'
                   onClick={this.showAll.bind(this)} />
               </div>
             </div>


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Related issue: https://github.com/parse-community/parse-dashboard/issues/2187

### Approach
The label "Show All" in menu Manage Columns overflows the button container, I added some extra px to accommodate the text

### TODOs before merging

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
