### PR TITLE
feat: auto-submit one-time password (OTP) after entering

### DIFF
--- a/Parse-Dashboard/Authentication.js
+++ b/Parse-Dashboard/Authentication.js
@@ -30,13 +30,13 @@ function initialize(app, options) {
         otpCode: req.body.otpCode
       });
       if (!match.matchingUsername) {
-        return cb(null, false, { message: 'Invalid username or password' });
-      }
-      if (match.otpMissing) {
-        return cb(null, false, { message: 'Please enter your one-time password.' });
+        return cb(null, false, { message: JSON.stringify({ text: 'Invalid username or password' }) });
       }
       if (!match.otpValid) {
-        return cb(null, false, { message: 'Invalid one-time password.' });
+        return cb(null, false, { message: JSON.stringify({ text: 'Invalid one-time password.', otpLength: match.otpMissingLength || 6}) });
+      }
+      if (match.otpMissingLength) {
+        return cb(null, false, { message: JSON.stringify({ text: 'Please enter your one-time password.', otpLength: match.otpMissingLength || 6 })});
       }
       cb(null, match.matchingUsername);
     })
@@ -91,7 +91,7 @@ function authenticate(userToTest, usernameOnly) {
   let appsUserHasAccessTo = null;
   let matchingUsername = null;
   let isReadOnly = false;
-  let otpMissing = false;
+  let otpMissingLength = false;
   let otpValid = true;
 
   //they provided auth
@@ -104,17 +104,20 @@ function authenticate(userToTest, usernameOnly) {
       let usernameMatches = userToTest.name == user.user;
       if (usernameMatches && user.mfa && !usernameOnly) {
         if (!userToTest.otpCode) {
-          otpMissing = true;
+          otpMissingLength = user.mfaDigits || 6;
         } else {
           const totp = new OTPAuth.TOTP({
             algorithm: user.mfaAlgorithm || 'SHA1',
-            secret: OTPAuth.Secret.fromBase32(user.mfa)
+            secret: OTPAuth.Secret.fromBase32(user.mfa),
+            digits: user.mfaDigits,
+	          period: user.mfaPeriod,
           });
           const valid = totp.validate({
             token: userToTest.otpCode
           });
           if (valid === null) {
             otpValid = false;
+            otpMissingLength = user.mfaDigits || 6;
           }
         }
       }
@@ -132,7 +135,7 @@ function authenticate(userToTest, usernameOnly) {
   return {
     isAuthenticated,
     matchingUsername,
-    otpMissing,
+    otpMissingLength,
     otpValid,
     appsUserHasAccessTo,
     isReadOnly,

--- a/Parse-Dashboard/Authentication.js
+++ b/Parse-Dashboard/Authentication.js
@@ -110,7 +110,7 @@ function authenticate(userToTest, usernameOnly) {
             algorithm: user.mfaAlgorithm || 'SHA1',
             secret: OTPAuth.Secret.fromBase32(user.mfa),
             digits: user.mfaDigits,
-	          period: user.mfaPeriod,
+            period: user.mfaPeriod,
           });
           const valid = totp.validate({
             token: userToTest.otpCode

--- a/Parse-Dashboard/CLI/mfa.js
+++ b/Parse-Dashboard/CLI/mfa.js
@@ -189,10 +189,10 @@ module.exports = {
       if (algorithm !== 'SHA1') {
         data.mfaAlgorithm = algorithm;
       }
-      if (digits !== 6) {
+      if (digits != 6) {
         data.mfaDigits = digits;
       }
-      if (period !== 30) {
+      if (period != 30) {
         data.mfaPeriod = period;
       }
       showQR(data.url);
@@ -225,10 +225,10 @@ module.exports = {
     if (algorithm !== 'SHA1') {
       config.mfaAlgorithm = algorithm;
     }
-    if (digits !== 6) {
+    if (digits != 6) {
       config.mfaDigits = digits;
     }
-    if (period !== 30) {
+    if (period != 30) {
       config.mfaPeriod = period;
     }
     showInstructions({ app, username, secret, url, config });

--- a/Parse-Dashboard/CLI/mfa.js
+++ b/Parse-Dashboard/CLI/mfa.js
@@ -101,14 +101,14 @@ const showInstructions = ({ app, username, passwordCopied, secret, url, encrypt,
 
   if (secret) {
     console.log(
-      `\n${getOrder()}. Open the authenticator app to scan the QR code above or enter this secret code:` + 
-      `\n\n   ${secret}` + 
+      `\n${getOrder()}. Open the authenticator app to scan the QR code above or enter this secret code:` +
+      `\n\n   ${secret}` +
       '\n\n   If the secret code generates incorrect one-time passwords, try this alternative:' +
-      `\n\n   ${url}` + 
+      `\n\n   ${url}` +
       `\n\n${getOrder()}. Destroy any records of the QR code and the secret code to secure the account.`
     );
   }
-  
+
   if (encrypt) {
     console.log(
       `\n${getOrder()}. Make sure that "useEncryptedPasswords" is set to "true" in your dashboard configuration.` +
@@ -189,6 +189,12 @@ module.exports = {
       if (algorithm !== 'SHA1') {
         data.mfaAlgorithm = algorithm;
       }
+      if (digits !== 6) {
+        data.mfaDigits = digits;
+      }
+      if (period !== 30) {
+        data.mfaPeriod = period;
+      }
       showQR(data.url);
     }
 
@@ -214,11 +220,16 @@ module.exports = {
 
     const { url, secret } = generateSecret({ app, username, algorithm, digits, period });
     showQR(url);
-    
     // Compose config
     const config = { mfa: secret };
     if (algorithm !== 'SHA1') {
       config.mfaAlgorithm = algorithm;
+    }
+    if (digits !== 6) {
+      config.mfaDigits = digits;
+    }
+    if (period !== 30) {
+      config.mfaPeriod = period;
     }
     showInstructions({ app, username, secret, url, config });
   }

--- a/Parse-Dashboard/CLI/mfa.js
+++ b/Parse-Dashboard/CLI/mfa.js
@@ -65,7 +65,19 @@ const generateSecret = ({ app, username, algorithm, digits, period }) => {
     secret
   });
   const url = totp.toString();
-  return { secret: secret.base32, url };
+  const config = { mfa: secret.base32 };
+  config.app = app;
+  config.url = url;
+  if (algorithm !== 'SHA1') {
+    config.mfaAlgorithm = algorithm;
+  }
+  if (digits != 6) {
+    config.mfaDigits = digits;
+  }
+  if (period != 30) {
+    config.mfaPeriod = period;
+  }
+  return { config };
 };
 const showQR = text => {
   const QRCode = require('qrcode');
@@ -77,7 +89,10 @@ const showQR = text => {
   });
 };
 
-const showInstructions = ({ app, username, passwordCopied, secret, url, encrypt, config }) => {
+const showInstructions = ({ app, username, passwordCopied, encrypt, config }) => {
+  const {secret, url} = config;
+  const mfaJSON = {...config};
+  delete mfaJSON.url;
   let orderCounter = 0;
   const getOrder = () => {
     orderCounter++;
@@ -90,7 +105,7 @@ const showInstructions = ({ app, username, passwordCopied, secret, url, encrypt,
 
   console.log(
     `\n${getOrder()}. Add the following settings for user "${username}" ${app ? `in app "${app}" ` : '' }to the Parse Dashboard configuration.` +
-    `\n\n   ${JSON.stringify(config)}`
+    `\n\n   ${JSON.stringify(mfaJSON)}`
   );
 
   if (passwordCopied) {
@@ -173,6 +188,7 @@ module.exports = {
       const salt = bcrypt.genSaltSync(10);
       data.pass = bcrypt.hashSync(data.pass, salt);
     }
+    const config = {};
     if (mfa) {
       const { app } = await inquirer.prompt([
         {
@@ -182,24 +198,13 @@ module.exports = {
         }
       ]);
       const { algorithm, digits, period } = await getAlgorithm();
-      const { secret, url } = generateSecret({ app, username, algorithm, digits, period });
-      data.mfa = secret;
-      data.app = app;
-      data.url = url;
-      if (algorithm !== 'SHA1') {
-        data.mfaAlgorithm = algorithm;
-      }
-      if (digits != 6) {
-        data.mfaDigits = digits;
-      }
-      if (period != 30) {
-        data.mfaPeriod = period;
-      }
-      showQR(data.url);
+      const secret  =generateSecret({ app, username, algorithm, digits, period });
+      Object.assign(config, secret.config);
+      showQR(secret.config.url);
     }
-
-    const config = { mfa: data.mfa, user: data.user, pass: data.pass };
-    showInstructions({ app: data.app, username, passwordCopied: true, secret: data.mfa, url: data.url, encrypt, config });
+    config.user = data.user;
+    config.pass = data.pass ;
+    showInstructions({ app: data.app, username, passwordCopied: true, encrypt, config });
   },
   async createMFA() {
     console.log('');
@@ -218,19 +223,9 @@ module.exports = {
     ]);
     const { algorithm, digits, period } = await getAlgorithm();
 
-    const { url, secret } = generateSecret({ app, username, algorithm, digits, period });
-    showQR(url);
+    const { config } = generateSecret({ app, username, algorithm, digits, period });
+    showQR(config.url);
     // Compose config
-    const config = { mfa: secret };
-    if (algorithm !== 'SHA1') {
-      config.mfaAlgorithm = algorithm;
-    }
-    if (digits != 6) {
-      config.mfaDigits = digits;
-    }
-    if (period != 30) {
-      config.mfaPeriod = period;
-    }
-    showInstructions({ app, username, secret, url, config });
+    showInstructions({ app, username, config });
   }
 };

--- a/src/lib/tests/Authentication.test.js
+++ b/src/lib/tests/Authentication.test.js
@@ -10,7 +10,7 @@ jest.dontMock('bcryptjs');
 
 const Authentication = require('../../../Parse-Dashboard/Authentication');
 const apps = [{appId: 'test123'}, {appId: 'test789'}];
-const readOnlyApps = apps.map((app) => { 
+const readOnlyApps = apps.map((app) => {
   app.readOnly = true;
   return app;
 });
@@ -55,7 +55,7 @@ function createAuthenticationResult(isAuthenticated, matchingUsername, appsUserH
     matchingUsername,
     appsUserHasAccessTo,
     isReadOnly,
-    otpMissing: false,
+    otpMissingLength: false,
     otpValid: true
   }
 }

--- a/src/login/Login.js
+++ b/src/login/Login.js
@@ -24,7 +24,7 @@ export default class Login extends React.Component {
         this.errors = json.text
         otpLength = json.otpLength;
       } catch (e) {
-        console.log(`could not pass error json: ${e}`);
+        this.errors = `could not pass error json: ${e}`;
       }
     }
 

--- a/src/login/Login.js
+++ b/src/login/Login.js
@@ -31,8 +31,7 @@ export default class Login extends React.Component {
     this.state = {
       forgot: false,
       username: sessionStorage.getItem('username') || '',
-      password: sessionStorage.getItem('password') || '',
-      otp: ''
+      password: sessionStorage.getItem('password') || ''
     };
     sessionStorage.clear();
     setBasePath(props.path);
@@ -115,7 +114,6 @@ export default class Login extends React.Component {
               <input
                 name='otpCode'
                 type='number'
-                value={this.state.otp}
                 onChange={e => updateField('otp', e)}
                 ref={this.inputRefMfa}
               />

--- a/src/login/Login.js
+++ b/src/login/Login.js
@@ -24,7 +24,7 @@ export default class Login extends React.Component {
         this.errors = json.text
         otpLength = json.otpLength;
       } catch (e) {
-        /* */
+        console.log(`could not pass error json: ${e}`);
       }
     }
 
@@ -113,7 +113,10 @@ export default class Login extends React.Component {
             input={
               <input
                 name='otpCode'
-                type='number'
+                type='text'
+                inputMode="numeric"
+                autoComplete='one-time-code'
+                pattern="[0-9]*"
                 onChange={e => updateField('otp', e)}
                 ref={this.inputRefMfa}
               />

--- a/src/login/Login.js
+++ b/src/login/Login.js
@@ -16,20 +16,30 @@ export default class Login extends React.Component {
     super();
 
     let errorDiv = document.getElementById('login_errors');
+    let otpLength = 6;
     if (errorDiv) {
       this.errors = errorDiv.innerHTML;
+      try {
+        const json = JSON.parse(this.errors)
+        this.errors = json.text
+        otpLength = json.otpLength;
+      } catch (e) {
+        /* */
+      }
     }
 
     this.state = {
       forgot: false,
       username: sessionStorage.getItem('username') || '',
-      password: sessionStorage.getItem('password') || ''
+      password: sessionStorage.getItem('password') || '',
+      otp: ''
     };
     sessionStorage.clear();
     setBasePath(props.path);
     this.inputRefUser = React.createRef();
     this.inputRefPass = React.createRef();
     this.inputRefMfa = React.createRef();
+    this.otpLength = otpLength;
   }
 
   componentDidMount() {
@@ -53,6 +63,15 @@ export default class Login extends React.Component {
     const {path} = this.props;
     const updateField  = (field, e) => {
       this.setState({[field]: e.target.value});
+      if (field === 'otp' && e.target.value.length >= this.otpLength) {
+        const input = document.querySelectorAll('input');
+        for (const field of input) {
+          if (field.type === 'submit') {
+            field.click();
+            break;
+          }
+        }
+      }
     }
     const formSubmit = () => {
       sessionStorage.setItem('username', this.state.username);
@@ -96,6 +115,8 @@ export default class Login extends React.Component {
               <input
                 name='otpCode'
                 type='number'
+                value={this.state.otp}
+                onChange={e => updateField('otp', e)}
                 ref={this.inputRefMfa}
               />
             } />


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

OTPs should autosubmit when they reach the required length

Related issue: #2164

### Approach
<!-- Add a description of the approach in this PR. -->

The MFA algorithm doesn't currently store `digits` or `period` - this PR fixes that and passes digits to fronttend.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
