### PR TITLE
fix: column names in data browser menu not left-aligned

### DIFF
--- a/src/components/ColumnsConfiguration/ColumnConfigurationItem.react.js
+++ b/src/components/ColumnsConfiguration/ColumnConfigurationItem.react.js
@@ -35,7 +35,7 @@ export default ({ name, handleColumnDragDrop, index, onChangeVisible, visible })
         <Icon name={visible ? 'visibility' : 'visibility_off'} width={18} height={18} fill={visible ? 'white' : 'rgba(0,0,0,0.4)'} />
       </div>
       <div className={styles.columnConfigItemName} title={name}>{name}</div>
-      <div className={styles.icon}>
+      <div className={[styles.icon, styles.columnIcon].join(' ')}>
         <Icon name='drag-indicator' width={14} height={14} fill="white" />
       </div>
     </section>

--- a/src/components/ColumnsConfiguration/ColumnConfigurationItem.scss
+++ b/src/components/ColumnsConfiguration/ColumnConfigurationItem.scss
@@ -1,7 +1,6 @@
 .columnConfigItem {
   padding: 8px 10px;
   display: flex;
-  justify-content: space-between;
   border-radius: 5px;
   cursor: grab;
 }
@@ -21,4 +20,10 @@
   text-overflow: ellipsis;
   overflow: hidden;
   line-height: 24px;
+}
+
+.columnIcon {
+  width: auto;
+  flex-grow: 1;
+  justify-content: end;
 }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Column names should be aligned to the left to be easier to read

Related issue: #2262

### Approach
<!-- Add a description of the approach in this PR. -->

Aligns to the left

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
