### PR TITLE
fix: view relation dialog requires browser refresh when navigating

### DIFF
--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -149,6 +149,13 @@ class Browser extends DashboardView {
     this.cancelPendingEditRows = this.cancelPendingEditRows.bind(this);
 
     this.dataBrowserRef = React.createRef();
+    window.addEventListener('popstate', () => {
+      this.setState({
+        relation: null,
+        data: null,
+      })
+      this.refresh();
+    });
   }
 
   componentWillMount() {
@@ -832,6 +839,7 @@ class Browser extends DashboardView {
       const url = `${this.getRelationURL()}${filterQueryString ? `?filters=${filterQueryString}` : ''}`;
       history.push(url);
     });
+    this.fetchRelation(relation, filters);
   }
 
   handlePointerClick({ className, id, field = 'objectId' }) {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Relation requires page reload when navigating backwards and forwards

Related issue: #2171
Closes: #2171

### Approach
<!-- Add a description of the approach in this PR. -->

Loads pointers on setting relation, and loads data when going back

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
