### PR TITLE
fix: file upload dialog in data browser shows multiple times

### DIFF
--- a/src/dashboard/Data/Browser/EditRowDialog.react.js
+++ b/src/dashboard/Data/Browser/EditRowDialog.react.js
@@ -23,7 +23,7 @@ export default class EditRowDialog extends React.Component {
     const { currentObject, openObjectPickers, expandedTextAreas } = this.initializeState(
       selectedObject
     );
-    this.state = { currentObject, openObjectPickers, expandedTextAreas, showFileEditor: false };
+    this.state = { currentObject, openObjectPickers, expandedTextAreas, showFileEditor: null };
 
     this.updateCurrentObject = this.updateCurrentObject.bind(this);
     this.handleChange = this.handleChange.bind(this);
@@ -224,15 +224,15 @@ export default class EditRowDialog extends React.Component {
     this.setState({ expandedTextAreas });
   }
 
-  openFileEditor() {
+  openFileEditor(column) {
     this.setState({
-      showFileEditor: true
+      showFileEditor: column
     });
   }
 
   hideFileEditor() {
     this.setState({
-      showFileEditor: false
+      showFileEditor: null
     });
   }
 
@@ -358,9 +358,9 @@ export default class EditRowDialog extends React.Component {
               <div style={{ cursor: 'pointer' }}>
                 <Pill
                   value={file ? 'Change file' : 'Select file'}
-                  onClick={() => this.openFileEditor()}
+                  onClick={() => this.openFileEditor(name)}
                 />
-                {this.state.showFileEditor && (
+                {this.state.showFileEditor === name && (
                   <FileEditor
                     value={file}
                     onCancel={this.hideFileEditor}


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

FileUpload dialog appears multiple times

Related issue: #2268
Closes: #2268

### Approach
<!-- Add a description of the approach in this PR. -->

Only show the dialog on the current row when clicked

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
