### PR TITLE
fix: increase required Node engine version to `>=14.20.1`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
       matrix:
         include:
           - name: Node 14
-            NODE_VERSION: 14.20.0
+            NODE_VERSION: 14.20.1
           - name: Node 16
             NODE_VERSION: 16.17.0
           - name: Node 18

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Parse Dashboard is continuously tested with the most recent releases of Node.js 
 
 | Version    | Latest Version | End-of-Life | Compatible   |
 |------------|----------------|-------------|--------------|
-| Node.js 14 | 14.20.0        | April 2023  | ✅ Yes        |
+| Node.js 14 | 14.20.1        | April 2023  | ✅ Yes        |
 | Node.js 16 | 16.17.0        | April 2024  | ✅ Yes        |
 | Node.js 18 | 18.9.0         | May 2025    | ✅ Yes        |
 

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "parse-dashboard": "./bin/parse-dashboard"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=14.20.1"
   },
   "main": "Parse-Dashboard/app.js",
   "jest": {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description

The release `5.0.0-alpha.1` bumped the node engine version to `>=14.0.0`, but it should be `>=14.20.1` to increase changes of being able to upgrade dependencies. The older a Node version is, the higher the risk that a dependency requires a higher Node version.

Related issue: #n/a

### Approach

Upgrade Node engine version to 14.20.1

### TODOs before merging
n/a