### PR TITLE
fix: cookieSessionSecret cannot be set in Dashboard options

### DIFF
--- a/Parse-Dashboard/app.js
+++ b/Parse-Dashboard/app.js
@@ -5,6 +5,7 @@ const packageJson = require('package-json');
 const csrf = require('csurf');
 const Authentication = require('./Authentication.js');
 var fs = require('fs');
+const cluster = require('cluster');
 
 const currentVersionFeatures = require('../package.json').parseDashboardFeatures;
 
@@ -68,6 +69,10 @@ module.exports = function(config, options) {
     const users = config.users;
     const useEncryptedPasswords = config.useEncryptedPasswords ? true : false;
     const authInstance = new Authentication(users, useEncryptedPasswords, mountPath);
+    const cookieSessionSecret = config.cookieSessionSecret || options.cookieSessionSecret;
+    if (cluster.isWorker && !cookieSessionSecret) {
+      console.warn('When using clusters, you must set a static cookieSessionSecret.');
+    }
     authInstance.initialize(app, { cookieSessionSecret: options.cookieSessionSecret });
 
     // CSRF error handler


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

`cookieSessionSecret` is not infered from `config`, from options only (which is only set from CLI). This means dashboard + users breaks when using clusters.

Related issue: #970

### Approach
<!-- Add a description of the approach in this PR. -->

Adds cookieSessionSecret

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
