### PR TITLE
feat: remove limitation to refresh Cloud Jobs list only after 30 seconds

### DIFF
--- a/src/lib/ParseApp.js
+++ b/src/lib/ParseApp.js
@@ -532,10 +532,6 @@ export default class ParseApp {
   }
 
   getJobStatus() {
-    // Cache it for a 30s
-    if (new Date() - this.jobStatus.lastFetched < 30000) {
-      return Promise.resolve(this.jobStatus.status);
-    }
     let query = new Parse.Query('_JobStatus');
     query.descending('createdAt');
     return query.find({ useMasterKey: true }).then((status) => {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description

Related issue: #2333 
Closes #2333

### Approach

Remove 30 seconds refresh block.

### TODOs before merging
n/a