### PR TITLE
refactor: Remove warnings in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
 ############################################################
 # Build stage
 ############################################################
-FROM node:lts-alpine AS base
+FROM node:lts-alpine AS build
 
-RUN apk update; \
-  apk add git;
+RUN apk --no-cache add git
 WORKDIR /src
 
 # Copy package.json first to benefit from layer caching
@@ -32,11 +31,11 @@ FROM node:lts-alpine AS release
 WORKDIR /src
 
 # Copy production node_modules
-COPY --from=base /src/prod_node_modules /src/node_modules
-COPY --from=base /src/package*.json /src/
+COPY --from=build /src/prod_node_modules /src/node_modules
+COPY --from=build /src/package*.json /src/
 
 # Copy compiled src dirs
-COPY --from=base /src/Parse-Dashboard/ /src/Parse-Dashboard/
+COPY --from=build /src/Parse-Dashboard/ /src/Parse-Dashboard/
 
 USER node
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /src
 COPY package*.json ./
 
 # Install without scripts otherwise webpack will fail
-RUN npm ci --production --ignore-scripts
+RUN npm ci --omit=dev --ignore-scripts
 
 # Copy production node_modules aside for later
 RUN cp -R node_modules prod_node_modules


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
The Dockerfile currently doesn't conform to the [docker best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) or [alpine recommendations](https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md). This results in a larger than necessary compressed/decompressed image.

I've made similar fixes on the server: https://github.com/parse-community/parse-server/pull/8359

Closes: #2351 

### Approach
<!-- Add a description of the approach in this PR. -->
Follow the best practices linked above to properly build the image in stages. This PR has no breaking changes.

For example, when installing packages, [alpine docs](https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md#disabling-cache) and [docker docs](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#use-multi-stage-builds)(uses `git` in example code like parse-server) state to use `--no-cache`.

Lastly, the current image uses `--production` where it should use `--omit=dev` resulting in additional warnings being thrown in the docker build. This is discussed on [stackoverflow](https://stackoverflow.com/a/9276112/4639041).

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Verify image builds and runs
