### PR TITLE
feat: Add export all rows of a class and export in JSON format

### DIFF
--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -1262,13 +1262,13 @@ class Browser extends DashboardView {
     const className = this.props.params.className;
     const query = new Parse.Query(className);
 
-    if (!rows["*"]) {
+    if (!rows['*']) {
       // Export selected
       const objectIds = [];
       for (const objectId in this.state.rowsToExport) {
         objectIds.push(objectId);
       }
-      query.containedIn("objectId", objectIds);
+      query.containedIn('objectId', objectIds);
       query.limit(objectIds.length);
     }
 
@@ -1286,8 +1286,8 @@ class Browser extends DashboardView {
         className
       ).filter((column) => column.visible);
 
-      if (type === ".json") {
-        const element = document.createElement("a");
+      if (type === '.json') {
+        const element = document.createElement('a');
         const file = new Blob(
           [
             JSON.stringify(
@@ -1300,7 +1300,7 @@ class Browser extends DashboardView {
               indentation ? 2 : null,
             ),
           ],
-          { type: "application/json" }
+          { type: 'application/json' }
         );
         element.href = URL.createObjectURL(file);
         element.download = `${className}.json`;
@@ -1310,22 +1310,22 @@ class Browser extends DashboardView {
         return;
       }
 
-      let csvString = columns.map((column) => column.name).join(",") + "\n";
+      let csvString = columns.map((column) => column.name).join(',') + '\n';
       for (const object of objects) {
         const row = columns
           .map((column) => {
             const type = columnsObject[column.name].type;
-            if (column.name === "objectId") {
+            if (column.name === 'objectId') {
               return object.id;
-            } else if (type === "Relation" || type === "Pointer") {
+            } else if (type === 'Relation' || type === 'Pointer') {
               if (object.get(column.name)) {
                 return object.get(column.name).id;
               } else {
-                return "";
+                return '';
               }
             } else {
               let colValue;
-              if (column.name === "ACL") {
+              if (column.name === 'ACL') {
                 colValue = object.getACL();
               } else {
                 colValue = object.get(column.name);
@@ -1333,18 +1333,18 @@ class Browser extends DashboardView {
               // Stringify objects and arrays
               if (
                 Object.prototype.toString.call(colValue) ===
-                  "[object Object]" ||
-                Object.prototype.toString.call(colValue) === "[object Array]"
+                  '[object Object]' ||
+                Object.prototype.toString.call(colValue) === '[object Array]'
               ) {
                 colValue = JSON.stringify(colValue);
               }
-              if (typeof colValue === "string") {
+              if (typeof colValue === 'string') {
                 if (colValue.includes('"')) {
                   // Has quote in data, escape and quote
                   // If the value contains both a quote and delimiter, adding quotes and escaping will take care of both scenarios
                   colValue = colValue.split('"').join('""');
                   return `"${colValue}"`;
-                } else if (colValue.includes(",")) {
+                } else if (colValue.includes(',')) {
                   // Has delimiter in data, surround with quote (which the value doesn't already contain)
                   return `"${colValue}"`;
                 } else {
@@ -1353,19 +1353,19 @@ class Browser extends DashboardView {
                 }
               } else if (colValue === undefined) {
                 // Export as empty CSV field
-                return "";
+                return '';
               } else {
                 return `${colValue}`;
               }
             }
           })
-          .join(",");
-        csvString += row + "\n";
+          .join(',');
+        csvString += row + '\n';
       }
 
       // Deliver to browser to download file
-      const element = document.createElement("a");
-      const file = new Blob([csvString], { type: "text/csv" });
+      const element = document.createElement('a');
+      const file = new Blob([csvString], { type: 'text/csv' });
       element.href = URL.createObjectURL(file);
       element.download = `${className}.csv`;
       document.body.appendChild(element); // Required for this to work in FireFox
@@ -1373,7 +1373,7 @@ class Browser extends DashboardView {
       document.body.removeChild(element);
     };
 
-    if (!rows["*"]) {
+    if (!rows['*']) {
       const objects = await query.find({ useMasterKey: true });
       processObjects(objects);
       this.setState({ exporting: false, exportingCount: objects.length });

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -1864,6 +1864,8 @@ class Browser extends DashboardView {
         <ExportSelectedRowsDialog
           className={className}
           selection={this.state.rowsToExport}
+          count={this.state.counts[className]}
+          data={this.state.data}
           onCancel={this.cancelExportSelectedRows}
           onConfirm={(type, indentation) => this.confirmExportSelectedRows(this.state.rowsToExport, type, indentation)}
         />

--- a/src/dashboard/Data/Browser/ExportSelectedRowsDialog.react.js
+++ b/src/dashboard/Data/Browser/ExportSelectedRowsDialog.react.js
@@ -61,7 +61,7 @@ export default class ExportSelectedRowsDialog extends React.Component {
         onCancel={this.props.onCancel}
         onConfirm={() => this.props.onConfirm(this.state.exportType, this.state.indentation)}>
         <div className={styles.row} >
-          <Label text="Do you really want to export all rows?" description={<span className={styles.label}>Estimated row count: {this.props.count}<br/>Estimated export size: {this.formatBytes(fileSize)}</span>}/>
+          <Label text="Do you really want to export all rows?" description={<span className={styles.label}>Estimated row count: {this.props.count}<br/>Estimated export size: {this.formatBytes(fileSize * this.props.count)}</span>}/>
         </div>
         <Field
           label={<Label text='Select export type' />}

--- a/src/dashboard/Data/Browser/ExportSelectedRowsDialog.react.js
+++ b/src/dashboard/Data/Browser/ExportSelectedRowsDialog.react.js
@@ -27,6 +27,9 @@ export default class ExportSelectedRowsDialog extends React.Component {
   }
 
   valid() {
+    if (!this.props.selection['*']) {
+      return true;
+    }
     if (this.state.confirmation !== 'export all') {
       return false;
     }
@@ -60,9 +63,10 @@ export default class ExportSelectedRowsDialog extends React.Component {
         cancelText='Cancel'
         onCancel={this.props.onCancel}
         onConfirm={() => this.props.onConfirm(this.state.exportType, this.state.indentation)}>
-        <div className={styles.row} >
-          <Label text="Do you really want to export all rows?" description={<span className={styles.label}>Estimated row count: {this.props.count}<br/>Estimated export size: {this.formatBytes(fileSize * this.props.count)}</span>}/>
+        {this.props.selection['*'] && <div className={styles.row} >
+          <Label text="Do you really want to export all rows?" description={<span className={styles.label}>Estimated row count: {this.props.count}<br/>Estimated export size: {this.formatBytes(fileSize * this.props.count)}<br/>⚠️ Exporting all rows may significantly impact resources.</span>}/>
         </div>
+        }
         <Field
           label={<Label text='Select export type' />}
           input={
@@ -77,7 +81,7 @@ export default class ExportSelectedRowsDialog extends React.Component {
           label={<Label text='Indentation' />}
           input={<Toggle value={this.state.indentation} type={Toggle.Types.YES_NO} onChange={(indentation) => {this.setState({indentation})}} />} />
           }
-        <Field
+        {this.props.selection['*'] && <Field
           label={
             <Label
               text='Confirm Export all'
@@ -89,6 +93,7 @@ export default class ExportSelectedRowsDialog extends React.Component {
               value={this.state.confirmation}
               onChange={(confirmation) => this.setState({ confirmation })} />
           } />
+        }
       </Modal>
     );
   }

--- a/src/dashboard/Data/Browser/ExportSelectedRowsDialog.react.js
+++ b/src/dashboard/Data/Browser/ExportSelectedRowsDialog.react.js
@@ -5,12 +5,13 @@
  * This source code is licensed under the license found in the LICENSE file in
  * the root directory of this source tree.
  */
-import Modal     from 'components/Modal/Modal.react';
-import React     from 'react';
+import Modal       from 'components/Modal/Modal.react';
+import React       from 'react';
 import Dropdown    from 'components/Dropdown/Dropdown.react';
 import Field       from 'components/Field/Field.react';
 import Label       from 'components/Label/Label.react';
 import Option      from 'components/Dropdown/Option.react';
+import Toggle      from 'components/Toggle/Toggle.react';
 
 export default class ExportSelectedRowsDialog extends React.Component {
   constructor() {
@@ -18,7 +19,8 @@ export default class ExportSelectedRowsDialog extends React.Component {
 
     this.state = {
       confirmation: '',
-      exportType: '.csv'
+      exportType: '.csv',
+      indentation: true,
     };
   }
 
@@ -38,7 +40,7 @@ export default class ExportSelectedRowsDialog extends React.Component {
         confirmText='Export'
         cancelText='Cancel'
         onCancel={this.props.onCancel}
-        onConfirm={() => this.props.onConfirm(this.state.exportType)}>
+        onConfirm={() => this.props.onConfirm(this.state.exportType, this.state.indentation)}>
         <Field
           label={<Label text='Select export type' />}
           input={
@@ -49,6 +51,10 @@ export default class ExportSelectedRowsDialog extends React.Component {
                 <Option value='.json'>.json</Option>
             </Dropdown>
           } />
+        {this.state.exportType === '.json' && <Field
+          label={<Label text='Indentation' />}
+          input={<Toggle value={this.state.indentation} type={Toggle.Types.YES_NO} onChange={(indentation) => {this.setState({indentation})}} />} />
+          }
       </Modal>
     );
   }

--- a/src/dashboard/Data/Browser/ExportSelectedRowsDialog.react.js
+++ b/src/dashboard/Data/Browser/ExportSelectedRowsDialog.react.js
@@ -83,7 +83,7 @@ export default class ExportSelectedRowsDialog extends React.Component {
         {this.props.selection['*'] && <Field
           label={
             <Label
-              text='Confirm Export all'
+              text='Confirm this action'
               description='Enter "export all" to continue.' />
           }
           input={

--- a/src/dashboard/Data/Browser/ExportSelectedRowsDialog.react.js
+++ b/src/dashboard/Data/Browser/ExportSelectedRowsDialog.react.js
@@ -12,6 +12,8 @@ import Field       from 'components/Field/Field.react';
 import Label       from 'components/Label/Label.react';
 import Option      from 'components/Dropdown/Option.react';
 import Toggle      from 'components/Toggle/Toggle.react';
+import TextInput   from 'components/TextInput/TextInput.react';
+import styles      from 'dashboard/Data/Browser/ExportSelectedRowsDialog.scss';
 
 export default class ExportSelectedRowsDialog extends React.Component {
   constructor() {
@@ -25,11 +27,28 @@ export default class ExportSelectedRowsDialog extends React.Component {
   }
 
   valid() {
+    if (this.state.confirmation !== 'export all') {
+      return false;
+    }
     return true;
   }
 
+  formatBytes(bytes) {
+    if (!+bytes) return '0 Bytes'
+
+    const k = 1024
+    const decimals = 2
+    const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+
+    const i = Math.floor(Math.log(bytes) / Math.log(k))
+
+    return `${parseFloat((bytes / Math.pow(k, i)).toFixed(decimals))} ${sizes[i]}`
+}
+
+
   render() {
     let selectionLength = Object.keys(this.props.selection).length;
+    const fileSize = new TextEncoder().encode(JSON.stringify(this.props.data, null, this.state.exportType === '.json' && this.state.indentation ? 2 : null)).length / this.props.data.length
     return (
       <Modal
         type={Modal.Types.INFO}
@@ -41,6 +60,9 @@ export default class ExportSelectedRowsDialog extends React.Component {
         cancelText='Cancel'
         onCancel={this.props.onCancel}
         onConfirm={() => this.props.onConfirm(this.state.exportType, this.state.indentation)}>
+        <div className={styles.row} >
+          <Label text="Do you really want to export all rows?" description={<span className={styles.label}>Estimated row count: {this.props.count}<br/>Estimated export size: {this.formatBytes(fileSize)}</span>}/>
+        </div>
         <Field
           label={<Label text='Select export type' />}
           input={
@@ -55,6 +77,18 @@ export default class ExportSelectedRowsDialog extends React.Component {
           label={<Label text='Indentation' />}
           input={<Toggle value={this.state.indentation} type={Toggle.Types.YES_NO} onChange={(indentation) => {this.setState({indentation})}} />} />
           }
+        <Field
+          label={
+            <Label
+              text='Confirm Export all'
+              description='Enter "export all" to continue.' />
+          }
+          input={
+            <TextInput
+              placeholder='export all'
+              value={this.state.confirmation}
+              onChange={(confirmation) => this.setState({ confirmation })} />
+          } />
       </Modal>
     );
   }

--- a/src/dashboard/Data/Browser/ExportSelectedRowsDialog.react.js
+++ b/src/dashboard/Data/Browser/ExportSelectedRowsDialog.react.js
@@ -35,7 +35,7 @@ export default class ExportSelectedRowsDialog extends React.Component {
         type={Modal.Types.INFO}
         icon='warn-outline'
         title={this.props.selection['*'] ? 'Export all rows?' : (selectionLength === 1 ? 'Export 1 selected row?' : `Export ${selectionLength} selected rows?`)}
-        subtitle={this.props.selection['*'] ? 'Note: This will export mutliple files with maximum 1gb each. This might take a while.' : ''}
+        subtitle={this.props.selection['*'] ? 'Large datasets are exported as multiple files of up to 1 GB each.' : ''}
         disabled={!this.valid()}
         confirmText='Export'
         cancelText='Cancel'

--- a/src/dashboard/Data/Browser/ExportSelectedRowsDialog.react.js
+++ b/src/dashboard/Data/Browser/ExportSelectedRowsDialog.react.js
@@ -7,13 +7,18 @@
  */
 import Modal     from 'components/Modal/Modal.react';
 import React     from 'react';
+import Dropdown    from 'components/Dropdown/Dropdown.react';
+import Field       from 'components/Field/Field.react';
+import Label       from 'components/Label/Label.react';
+import Option      from 'components/Dropdown/Option.react';
 
 export default class ExportSelectedRowsDialog extends React.Component {
   constructor() {
     super();
 
     this.state = {
-      confirmation: ''
+      confirmation: '',
+      exportType: '.csv'
     };
   }
 
@@ -28,13 +33,22 @@ export default class ExportSelectedRowsDialog extends React.Component {
         type={Modal.Types.INFO}
         icon='warn-outline'
         title={this.props.selection['*'] ? 'Export all rows?' : (selectionLength === 1 ? 'Export 1 selected row?' : `Export ${selectionLength} selected rows?`)}
-        subtitle={this.props.selection['*'] ? 'Note: Exporting is limited to the first 10,000 rows.' : ''}
+        subtitle={this.props.selection['*'] ? 'Note: This will export mutliple files with maximum 1gb each. This might take a while.' : ''}
         disabled={!this.valid()}
         confirmText='Export'
         cancelText='Cancel'
         onCancel={this.props.onCancel}
-        onConfirm={this.props.onConfirm}>
-        {}
+        onConfirm={() => this.props.onConfirm(this.state.exportType)}>
+        <Field
+          label={<Label text='Select export type' />}
+          input={
+            <Dropdown
+              value={this.state.exportType}
+              onChange={(exportType) => this.setState({ exportType })}>
+                <Option value='.csv'>.csv</Option>
+                <Option value='.json'>.json</Option>
+            </Dropdown>
+          } />
       </Modal>
     );
   }

--- a/src/dashboard/Data/Browser/ExportSelectedRowsDialog.react.js
+++ b/src/dashboard/Data/Browser/ExportSelectedRowsDialog.react.js
@@ -57,14 +57,13 @@ export default class ExportSelectedRowsDialog extends React.Component {
         type={Modal.Types.INFO}
         icon='warn-outline'
         title={this.props.selection['*'] ? 'Export all rows?' : (selectionLength === 1 ? 'Export 1 selected row?' : `Export ${selectionLength} selected rows?`)}
-        subtitle={this.props.selection['*'] ? 'Large datasets are exported as multiple files of up to 1 GB each.' : ''}
         disabled={!this.valid()}
         confirmText='Export'
         cancelText='Cancel'
         onCancel={this.props.onCancel}
         onConfirm={() => this.props.onConfirm(this.state.exportType, this.state.indentation)}>
         {this.props.selection['*'] && <div className={styles.row} >
-          <Label text="Do you really want to export all rows?" description={<span className={styles.label}>Estimated row count: {this.props.count}<br/>Estimated export size: {this.formatBytes(fileSize * this.props.count)}<br/>⚠️ Exporting all rows may significantly impact resources.</span>}/>
+          <Label text="Do you really want to export all rows?" description={<span className={styles.label}>Estimated row count: {this.props.count}<br/>Estimated export size: {this.formatBytes(fileSize * this.props.count)}<br/><br/>⚠️ Exporting all rows may severely impact server or database resources.<br/>Large datasets are exported as multiple files of up to 1 GB each.</span>}/>
         </div>
         }
         <Field

--- a/src/dashboard/Data/Browser/ExportSelectedRowsDialog.scss
+++ b/src/dashboard/Data/Browser/ExportSelectedRowsDialog.scss
@@ -1,0 +1,9 @@
+.row {
+  display: block;
+  position: relative;
+  height: 100px;
+  border-bottom: 1px solid #e0e0e1;
+}
+.label {
+  line-height: 16px;
+}


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

It's currently only possible to export 10,000 rows, and only as a CSV

Closes: #1961

### Approach
<!-- Add a description of the approach in this PR. -->

Uses `Parse.Query.eachBatch` to paginate over full class and exports as files when:

- Array of objects is over 1gb in memory
- New objects length is less than batch size (`eachBatch` has finished)

![Screenshot 2023-01-19 at 3 45 34 pm](https://user-images.githubusercontent.com/4974769/213362955-15d130f2-b78c-4a5c-8ade-43b2bf21b75b.png)


### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
