### PR TITLE
fix: Add dashboard option `cookieSessionMaxAge` to keep user logged in across browser sessions

### DIFF
--- a/Parse-Dashboard/Authentication.js
+++ b/Parse-Dashboard/Authentication.js
@@ -54,13 +54,13 @@ function initialize(app, options) {
   });
 
   var cookieSessionSecret = options.cookieSessionSecret || require('crypto').randomBytes(64).toString('hex');
-  const cookieMaxAge = options.cookieMaxAge;
+  const cookieSessionMaxAge = options.cookieSessionMaxAge;
   app.use(require('connect-flash')());
   app.use(require('body-parser').urlencoded({ extended: true }));
   app.use(require('cookie-session')({
     key    : 'parse_dash',
     secret : cookieSessionSecret,
-    maxAge : cookieMaxAge
+    maxAge : cookieSessionMaxAge
   }));
   app.use(passport.initialize());
   app.use(passport.session());

--- a/Parse-Dashboard/Authentication.js
+++ b/Parse-Dashboard/Authentication.js
@@ -54,14 +54,13 @@ function initialize(app, options) {
   });
 
   var cookieSessionSecret = options.cookieSessionSecret || require('crypto').randomBytes(64).toString('hex');
+  const cookieMaxAge = options.cookieMaxAge;
   app.use(require('connect-flash')());
   app.use(require('body-parser').urlencoded({ extended: true }));
   app.use(require('cookie-session')({
     key    : 'parse_dash',
     secret : cookieSessionSecret,
-    cookie : {
-      maxAge: (2 * 7 * 24 * 60 * 60 * 1000) // 2 weeks
-    }
+    maxAge : cookieMaxAge
   }));
   app.use(passport.initialize());
   app.use(passport.session());

--- a/Parse-Dashboard/app.js
+++ b/Parse-Dashboard/app.js
@@ -68,7 +68,7 @@ module.exports = function(config, options) {
     const users = config.users;
     const useEncryptedPasswords = config.useEncryptedPasswords ? true : false;
     const authInstance = new Authentication(users, useEncryptedPasswords, mountPath);
-    authInstance.initialize(app, { cookieSessionSecret: options.cookieSessionSecret, cookieMaxAge: options.cookieMaxAge });
+    authInstance.initialize(app, { cookieSessionSecret: options.cookieSessionSecret, cookieSessionMaxAge: options.cookieSessionMaxAge });
 
     // CSRF error handler
     app.use(function (err, req, res, next) {

--- a/Parse-Dashboard/app.js
+++ b/Parse-Dashboard/app.js
@@ -68,7 +68,7 @@ module.exports = function(config, options) {
     const users = config.users;
     const useEncryptedPasswords = config.useEncryptedPasswords ? true : false;
     const authInstance = new Authentication(users, useEncryptedPasswords, mountPath);
-    authInstance.initialize(app, { cookieSessionSecret: options.cookieSessionSecret });
+    authInstance.initialize(app, { cookieSessionSecret: options.cookieSessionSecret, cookieMaxAge: options.cookieMaxAge });
 
     // CSRF error handler
     app.use(function (err, req, res, next) {

--- a/Parse-Dashboard/index.js
+++ b/Parse-Dashboard/index.js
@@ -28,7 +28,7 @@ program.option('--trustProxy [trustProxy]', 'set this flag when you are behind a
 program.option('--cookieSessionSecret [cookieSessionSecret]', 'set the cookie session secret, defaults to a random string. You should set that value if you want sessions to work across multiple server, or across restarts');
 program.option('--createUser', 'helper tool to allow you to generate secure user passwords and secrets. Use this on trusted devices only.');
 program.option('--createMFA', 'helper tool to allow you to generate multi-factor authentication secrets.');
-program.option('--cookieMaxAge [cookieMaxAge]', 'set the cookie maxAge, defaults to session');
+program.option('--cookieSessionMaxAge [cookieSessionMaxAge]', 'set the cookie maxAge, defaults to session');
 
 program.action(async (options) => {
   for (const key in options) {

--- a/Parse-Dashboard/index.js
+++ b/Parse-Dashboard/index.js
@@ -28,7 +28,7 @@ program.option('--trustProxy [trustProxy]', 'set this flag when you are behind a
 program.option('--cookieSessionSecret [cookieSessionSecret]', 'set the cookie session secret, defaults to a random string. You should set that value if you want sessions to work across multiple server, or across restarts');
 program.option('--createUser', 'helper tool to allow you to generate secure user passwords and secrets. Use this on trusted devices only.');
 program.option('--createMFA', 'helper tool to allow you to generate multi-factor authentication secrets.');
-program.option('--cookieSessionMaxAge [cookieSessionMaxAge]', 'set the cookie maxAge, defaults to session');
+program.option('--cookieSessionMaxAge [cookieSessionMaxAge]', '(Optional) Sets the time in seconds for when the session cookie will be deleted and the dashboard user has to re-login; defaults to `undefined` which means the cookie will be deleted when the browser session ends.');
 
 program.action(async (options) => {
   for (const key in options) {

--- a/Parse-Dashboard/index.js
+++ b/Parse-Dashboard/index.js
@@ -28,7 +28,7 @@ program.option('--trustProxy [trustProxy]', 'set this flag when you are behind a
 program.option('--cookieSessionSecret [cookieSessionSecret]', 'set the cookie session secret, defaults to a random string. You should set that value if you want sessions to work across multiple server, or across restarts');
 program.option('--createUser', 'helper tool to allow you to generate secure user passwords and secrets. Use this on trusted devices only.');
 program.option('--createMFA', 'helper tool to allow you to generate multi-factor authentication secrets.');
-program.option('--cookieSessionMaxAge [cookieSessionMaxAge]', '(Optional) Sets the time in seconds for when the session cookie will be deleted and the dashboard user has to re-login; defaults to `undefined` which means the cookie will be deleted when the browser session ends.');
+program.option('--cookieSessionMaxAge [cookieSessionMaxAge]', '(Optional) Sets the time in seconds for when the session cookie will be deleted and the dashboard user has to re-login; if no value is set then the cookie will be deleted when the browser session ends.');
 
 program.action(async (options) => {
   for (const key in options) {

--- a/Parse-Dashboard/index.js
+++ b/Parse-Dashboard/index.js
@@ -28,6 +28,8 @@ program.option('--trustProxy [trustProxy]', 'set this flag when you are behind a
 program.option('--cookieSessionSecret [cookieSessionSecret]', 'set the cookie session secret, defaults to a random string. You should set that value if you want sessions to work across multiple server, or across restarts');
 program.option('--createUser', 'helper tool to allow you to generate secure user passwords and secrets. Use this on trusted devices only.');
 program.option('--createMFA', 'helper tool to allow you to generate multi-factor authentication secrets.');
+program.option('--cookieMaxAge [cookieMaxAge]', 'set the cookie maxAge, defaults to session');
+
 program.action(async (options) => {
   for (const key in options) {
     const func = CLIHelper[key];

--- a/Parse-Dashboard/server.js
+++ b/Parse-Dashboard/server.js
@@ -19,7 +19,7 @@ module.exports = (options) => {
   const allowInsecureHTTP = options.allowInsecureHTTP || process.env.PARSE_DASHBOARD_ALLOW_INSECURE_HTTP;
   const cookieSessionSecret = options.cookieSessionSecret || process.env.PARSE_DASHBOARD_COOKIE_SESSION_SECRET;
   const trustProxy = options.trustProxy || process.env.PARSE_DASHBOARD_TRUST_PROXY;
-  const cookieSessionMaxAge = options.cookieSessionMaxAge || process.env.PARSE_DASHBOARD_COOKIE_MAX_AGE;
+  const cookieSessionMaxAge = options.cookieSessionMaxAge || process.env.PARSE_DASHBOARD_COOKIE_SESSION_MAX_AGE;
   const dev = options.dev;
 
   if (trustProxy && allowInsecureHTTP) {

--- a/Parse-Dashboard/server.js
+++ b/Parse-Dashboard/server.js
@@ -19,7 +19,7 @@ module.exports = (options) => {
   const allowInsecureHTTP = options.allowInsecureHTTP || process.env.PARSE_DASHBOARD_ALLOW_INSECURE_HTTP;
   const cookieSessionSecret = options.cookieSessionSecret || process.env.PARSE_DASHBOARD_COOKIE_SESSION_SECRET;
   const trustProxy = options.trustProxy || process.env.PARSE_DASHBOARD_TRUST_PROXY;
-  const cookieMaxAge = options.cookieMaxAge || process.env.PARSE_DASHBOARD_COOKIE_MAX_AGE;
+  const cookieSessionMaxAge = options.cookieSessionMaxAge || process.env.PARSE_DASHBOARD_COOKIE_MAX_AGE;
   const dev = options.dev;
 
   if (trustProxy && allowInsecureHTTP) {
@@ -146,7 +146,7 @@ module.exports = (options) => {
   if (allowInsecureHTTP || trustProxy || dev) app.enable('trust proxy');
 
   config.data.trustProxy = trustProxy;
-  let dashboardOptions = { allowInsecureHTTP, cookieSessionSecret, dev, cookieMaxAge };
+  let dashboardOptions = { allowInsecureHTTP, cookieSessionSecret, dev, cookieSessionMaxAge };
   app.use(mountPath, parseDashboard(config.data, dashboardOptions));
   let server;
   if(!configSSLKey || !configSSLCert){

--- a/Parse-Dashboard/server.js
+++ b/Parse-Dashboard/server.js
@@ -19,6 +19,7 @@ module.exports = (options) => {
   const allowInsecureHTTP = options.allowInsecureHTTP || process.env.PARSE_DASHBOARD_ALLOW_INSECURE_HTTP;
   const cookieSessionSecret = options.cookieSessionSecret || process.env.PARSE_DASHBOARD_COOKIE_SESSION_SECRET;
   const trustProxy = options.trustProxy || process.env.PARSE_DASHBOARD_TRUST_PROXY;
+  const cookieMaxAge = options.cookieMaxAge || process.env.PARSE_DASHBOARD_COOKIE_MAX_AGE;
   const dev = options.dev;
 
   if (trustProxy && allowInsecureHTTP) {
@@ -145,7 +146,7 @@ module.exports = (options) => {
   if (allowInsecureHTTP || trustProxy || dev) app.enable('trust proxy');
 
   config.data.trustProxy = trustProxy;
-  let dashboardOptions = { allowInsecureHTTP, cookieSessionSecret, dev };
+  let dashboardOptions = { allowInsecureHTTP, cookieSessionSecret, dev, cookieMaxAge };
   app.use(mountPath, parseDashboard(config.data, dashboardOptions));
   let server;
   if(!configSSLKey || !configSSLCert){


### PR DESCRIPTION
Added maxAge config for cookie session, cookieMaxAge

Closes: https://github.com/parse-community/parse-dashboard/issues/2365