### PR TITLE
fix: Navigation to page fails if user re-login is required

### DIFF
--- a/Parse-Dashboard/Authentication.js
+++ b/Parse-Dashboard/Authentication.js
@@ -68,11 +68,17 @@ function initialize(app, options) {
 
   app.post('/login',
     csrf(),
-    passport.authenticate('local', {
-      successRedirect: `${self.mountPath}apps`,
-      failureRedirect: `${self.mountPath}login`,
-      failureFlash : true
-    })
+      (req,res,next) => {
+        let redirect = 'apps';
+        if (req.body.redirect) {
+          redirect = req.body.redirect.charAt(0) === '/' ? req.body.redirect.substring(1) : req.body.redirect
+        }
+        return passport.authenticate('local', {
+          successRedirect: `${self.mountPath}${redirect}`,
+          failureRedirect: `${self.mountPath}login${req.body.redirect ? `?redirect=${req.body.redirect}` : ''}`,
+          failureFlash : true
+        })(req, res, next)
+    },
   );
 
   app.get('/logout', function(req, res){

--- a/Parse-Dashboard/app.js
+++ b/Parse-Dashboard/app.js
@@ -173,8 +173,9 @@ module.exports = function(config, options) {
     }
 
     app.get('/login', csrf(), function(req, res) {
+      const redirectURL = req.url.includes('?redirect=') && req.url.split('?redirect=')[1];
       if (!users || (req.user && req.user.isAuthenticated)) {
-        return res.redirect(`${mountPath}apps`);
+        return res.redirect(`${mountPath}${redirectURL || 'apps'}`);
       }
 
       let errors = req.flash('error');
@@ -206,7 +207,7 @@ module.exports = function(config, options) {
     // For every other request, go to index.html. Let client-side handle the rest.
     app.get('/*', function(req, res) {
       if (users && (!req.user || !req.user.isAuthenticated)) {
-        return res.redirect(`${mountPath}login`);
+        return res.redirect(`${mountPath}login?redirect=${req.url.replace('/login', '')}`);
       }
       if (users && req.user && req.user.matchingUsername ) {
         res.append('username', req.user.matchingUsername);

--- a/src/login/Login.js
+++ b/src/login/Login.js
@@ -28,10 +28,13 @@ export default class Login extends React.Component {
       }
     }
 
+    const url = new URL(window.location);
+    const redirect = url.searchParams.get('redirect');
     this.state = {
       forgot: false,
       username: sessionStorage.getItem('username') || '',
-      password: sessionStorage.getItem('password') || ''
+      password: sessionStorage.getItem('password') || '',
+      redirect
     };
     sessionStorage.clear();
     setBasePath(props.path);
@@ -106,6 +109,11 @@ export default class Login extends React.Component {
               ref={this.inputRefPass}
             />
           } />
+          {this.state.redirect && <input
+              name='redirect'
+              type='hidden'
+              value={this.state.redirect}
+            />}
         {
           this.errors && this.errors.includes('one-time') ?
           <LoginRow


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Dashboard does not maintain original requested URL when login is needed

Closes: #2368

### Approach
<!-- Add a description of the approach in this PR. -->

Adds parameter "redirectURL" and returns there on successful login

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
