### PR TITLE
fix: Internal error message on login with missing credential

### DIFF
--- a/src/login/Login.js
+++ b/src/login/Login.js
@@ -24,7 +24,7 @@ export default class Login extends React.Component {
         this.errors = json.text
         otpLength = json.otpLength;
       } catch (e) {
-        this.errors = `could not pass error json: ${e}`;
+        /* */
       }
     }
 

--- a/src/login/Login.js
+++ b/src/login/Login.js
@@ -24,7 +24,7 @@ export default class Login extends React.Component {
         this.errors = json.text
         otpLength = json.otpLength;
       } catch (e) {
-        /* */
+        this.errors = this.errors ?? `Error: ${JSON.stringify(e)}`;
       }
     }
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Passport can throw error strings, which cannot be converted to JSON. In this case, the errors should not be overridden.

Closes: #2367

### Approach
<!-- Add a description of the approach in this PR. -->

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
