### PR TITLE
ci: Fix timeout of circular dependency check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - run: npm run lint
   check-circular:
      name: Circular Dependencies
-     timeout-minutes: 5
+     timeout-minutes: 15
      runs-on: ubuntu-latest
      steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description

Timeout of circular dependency check.

Closes: #n/a

### Approach

Increase timeout of circular dependency check.

### TODOs before merging
n/a