### PR TITLE
fix: Screen goes blank when trying to add column of type `Object` or `GeoPoint`

### DIFF
--- a/src/components/TextInput/TextInput.react.js
+++ b/src/components/TextInput/TextInput.react.js
@@ -11,15 +11,10 @@ import styles from 'components/TextInput/TextInput.scss';
 import { withForwardedRef } from 'lib/withForwardedRef';
 
 class TextInput extends React.Component {
-  componentWillReceiveProps(props) {
+  componentDidUpdate(props) {
     if (props.multiline !== this.props.multiline) {
       const node = props.forwardedRef.current;
-      // wait a little while for component to re-render
-      setTimeout(function() {
-        node.focus();
-        node.value = '';
-        node.value = props.value;
-      }.bind(this), 1);
+      node.focus();
     }
   }
 

--- a/src/lib/withForwardedRef.js
+++ b/src/lib/withForwardedRef.js
@@ -2,7 +2,9 @@ import React from 'react';
 
 export function withForwardedRef(Component) {
   function render(props, ref) {
-    return <Component {...props} forwardedRef={ref} />;
+    const innerRef = React.useRef();
+    React.useImperativeHandle(ref, () => innerRef.current, [props.multiline]);
+    return <Component {...props} forwardedRef={innerRef} />;
   }
 
   const name = Component.displayName || Component.name;


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
When `ref` is not passed to `TextInput` component it will crash itself when `multiline` prop is user. I had to add optional `ref` handling, as well as change `componentWillReceiveProps` to `componentDidUpdate` for two reasons:
1. To have a correct `ref` available to focus + remove the need for timeout hacks
2. CWRP is deprecated, this moves the dashboard a tiny step toward React 18

Closes: #2373

### Approach


### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
