### PR TITLE
fix: Data browser dialog "No data to display" may be outside of visible area in Safari browser

### DIFF
--- a/src/dashboard/Data/Browser/Browser.scss
+++ b/src/dashboard/Data/Browser/Browser.scss
@@ -15,12 +15,6 @@
   bottom: 0;
   overflow: auto;
   padding-top: 30px;
-  // fix for safari scrolling issue:
-  // https://css-tricks.com/forums/topic/safari-for-ios-z-index-ordering-bug-while-scrolling-a-page-with-a-fixed-element/
-  // only applying to safari as a side effect of this is emptystate component centering is off
-  &.safari {
-    -webkit-transform: translate3d(0,0,0);
-  }
 }
 
 body:global(.expanded) {

--- a/src/dashboard/Data/Browser/BrowserTable.react.js
+++ b/src/dashboard/Data/Browser/BrowserTable.react.js
@@ -6,7 +6,6 @@
  * the root directory of this source tree.
  */
 import BrowserRow             from 'components/BrowserRow/BrowserRow.react';
-import * as browserUtils      from 'lib/browserUtils';
 import DataBrowserHeaderBar   from 'components/DataBrowserHeaderBar/DataBrowserHeaderBar.react';
 import Editor                 from 'dashboard/Data/Browser/Editor.react';
 import EmptyState             from 'components/EmptyState/EmptyState.react';
@@ -429,7 +428,7 @@ export default class BrowserTable extends React.Component {
     }
 
     return (
-      <div className={[styles.browser, browserUtils.isSafari() ? styles.safari : ''].join(' ')}>
+      <div className={styles.browser}>
         {table}
         <DataBrowserHeaderBar
           selected={

--- a/src/lib/browserUtils.js
+++ b/src/lib/browserUtils.js
@@ -6,10 +6,6 @@
  * the root directory of this source tree.
  */
 
-export function isSafari() {
-  return /Safari/.test(navigator.userAgent) && /Apple Computer/.test(navigator.vendor);
-}
-
 export function isChrome() {
   return /Chrome/.test(navigator.userAgent) && /Google Inc/.test(navigator.vendor);
 }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
This PR fixes the bug in Safari that caused the empty state in browser to ignore the `position: fixed` rule.

I also removed the safari detection function as it was no longer used anywhere.

Closes: #2325

### Approach
<!-- Add a description of the approach in this PR. -->

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
