### PR TITLE
ci: Skip unnecessary builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-${{ env.NODE_VERSION }}-
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: CI Node Engine Check
         run: npm run ci:checkNodeEngine
   check-lint:
@@ -47,7 +47,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-${{ env.NODE_VERSION }}-
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
       - run: npm run lint
   check-circular:
      name: Circular Dependencies
@@ -67,7 +67,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-${{ env.NODE_VERSION }}-
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Scan for circular dependencies
         run: npm run madge:circular
   check-docker:
@@ -143,12 +143,8 @@ jobs:
           key: ${{ runner.os }}-node-${{ matrix.NODE_VERSION }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
               ${{ runner.os }}-node-${{ matrix.NODE_VERSION }}-
-      - name: Install dependencies (Node < 10)
-        run: npm install
-        if: ${{ steps.node.outputs.node_major < 10 }}
-      - name: Install dependencies (Node >= 10)
+      - name: Install dependencies
         run: npm ci
-        if: ${{ steps.node.outputs.node_major >= 10 }}
       - name: Tests
         run: npm test
       - name: Test bundles


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
We can make CI faster by skipping unnecessary builds that happen as a side-effect of installing the dependencies through the `prepare` hook.

Closes: #2390

### Approach
<!-- Add a description of the approach in this PR. -->

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
