### PR TITLE
feat: Add CSP options to dashboard

### DIFF
--- a/Parse-Dashboard/app.js
+++ b/Parse-Dashboard/app.js
@@ -62,6 +62,10 @@ module.exports = function(config, options) {
     app.enable('trust proxy');
   }
 
+  if (options.strictCSP && !options.CSPNonce) {
+    options.CSPNonce = require('crypto').randomBytes(64).toString('hex');
+  }
+
   // wait for app to mount in order to get mountpath
   app.on('mount', function() {
     const mountPath = getMount(app.mountpath);
@@ -188,8 +192,11 @@ module.exports = function(config, options) {
       <html>
         <head>
           <link rel="shortcut icon" type="image/x-icon" href="${mountPath}favicon.ico" />
+          <script nonce="${options.CSPNonce}">
+            window.nonce = "${options.CSPNonce}";
+          </script>
           <base href="${mountPath}"/>
-          <script>
+          <script nonce="${options.CSPNonce}">
             PARSE_DASHBOARD_PATH = "${mountPath}";
           </script>
           <title>Parse Dashboard</title>
@@ -197,8 +204,8 @@ module.exports = function(config, options) {
         <body>
           <div id="login_mount"></div>
           ${errors}
-          <script id="csrf" type="application/json">"${req.csrfToken()}"</script>
-          <script src="${mountPath}bundles/login.bundle.js"></script>
+          <script nonce="${options.CSPNonce}" id="csrf" type="application/json">"${req.csrfToken()}"</script>
+          <script nonce="${options.CSPNonce}" src="${mountPath}bundles/login.bundle.js"></script>
         </body>
       </html>
       `);
@@ -221,14 +228,15 @@ module.exports = function(config, options) {
         <head>
           <link rel="shortcut icon" type="image/x-icon" href="${mountPath}favicon.ico" />
           <base href="${mountPath}"/>
-          <script>
+          <script nonce="${options.CSPNonce}">
+            window.__CSP_NONCE = "${options.CSPNonce}";
             PARSE_DASHBOARD_PATH = "${mountPath}";
           </script>
           <title>Parse Dashboard</title>
         </head>
         <body>
           <div id="browser_mount"></div>
-          <script src="${mountPath}bundles/dashboard.bundle.js"></script>
+          <script nonce="${options.CSPNonce}" src="${mountPath}bundles/dashboard.bundle.js"></script>
         </body>
       </html>
       `);

--- a/Parse-Dashboard/server.js
+++ b/Parse-Dashboard/server.js
@@ -17,7 +17,7 @@ module.exports = (options) => {
   const port = options.port || process.env.PORT || 4040;
   const mountPath = options.mountPath || process.env.MOUNT_PATH || '/';
   const allowInsecureHTTP = options.allowInsecureHTTP || process.env.PARSE_DASHBOARD_ALLOW_INSECURE_HTTP;
-  const strictCSP = options.strictCSP || process.env.PARSE_DASHBOARD_STRICT_CSP || true;
+  const strictCSP = options.strictCSP || process.env.PARSE_DASHBOARD_STRICT_CSP;
   const cookieSessionSecret = options.cookieSessionSecret || process.env.PARSE_DASHBOARD_COOKIE_SESSION_SECRET;
   const trustProxy = options.trustProxy || process.env.PARSE_DASHBOARD_TRUST_PROXY;
   const cookieSessionMaxAge = options.cookieSessionMaxAge || process.env.PARSE_DASHBOARD_COOKIE_SESSION_MAX_AGE;

--- a/Parse-Dashboard/server.js
+++ b/Parse-Dashboard/server.js
@@ -158,7 +158,7 @@ module.exports = (options) => {
   if (allowInsecureHTTP || trustProxy || dev) app.enable('trust proxy');
 
   config.data.trustProxy = trustProxy;
-  let dashboardOptions = { allowInsecureHTTP, cookieSessionSecret, dev, cookieSessionMaxAge, CSPNonce: nonce };
+  let dashboardOptions = { allowInsecureHTTP, cookieSessionSecret, dev, cookieSessionMaxAge, CSPNonce: strictCSP ? nonce : undefined };
   app.use(mountPath, parseDashboard(config.data, dashboardOptions));
   let server;
   if(!configSSLKey || !configSSLCert){

--- a/Parse-Dashboard/server.js
+++ b/Parse-Dashboard/server.js
@@ -17,7 +17,7 @@ module.exports = (options) => {
   const port = options.port || process.env.PORT || 4040;
   const mountPath = options.mountPath || process.env.MOUNT_PATH || '/';
   const allowInsecureHTTP = options.allowInsecureHTTP || process.env.PARSE_DASHBOARD_ALLOW_INSECURE_HTTP;
-  const strictCSP = options.strictCSP || process.env.PARSE_DASHBOARD_STRICT_CSP;
+  const strictCSP = options.strictCSP || process.env.PARSE_DASHBOARD_STRICT_CSP || true;
   const cookieSessionSecret = options.cookieSessionSecret || process.env.PARSE_DASHBOARD_COOKIE_SESSION_SECRET;
   const trustProxy = options.trustProxy || process.env.PARSE_DASHBOARD_TRUST_PROXY;
   const cookieSessionMaxAge = options.cookieSessionMaxAge || process.env.PARSE_DASHBOARD_COOKIE_SESSION_MAX_AGE;

--- a/docker-compose.uffizzi.yml
+++ b/docker-compose.uffizzi.yml
@@ -9,7 +9,7 @@ x-uffizzi:
     deploy_preview_when_pull_request_is_opened: true
     delete_preview_when_pull_request_is_closed: true
     share_to_github: true
-    
+
 services:
 
   postgres:
@@ -56,6 +56,7 @@ services:
         - PARSE_DASHBOARD_USER_PASSWORD=pass
         - MOUNT_PATH=/dashboard
         - PARSE_DASHBOARD_ALLOW_INSECURE_HTTP=1
+        - PARSE_DASHBOARD_STRICT_CSP=true
         entrypoint: /bin/sh
         command:
          - "-c"

--- a/webpack/base.config.js
+++ b/webpack/base.config.js
@@ -15,9 +15,9 @@ var webpack = require('webpack');
 var fs = require('fs');
 var json = JSON.parse(fs.readFileSync('package.json', 'utf8'));
 var version = json.version;
-
 module.exports = {
   context: path.join(__dirname, '../src'),
+  devtool: "source-map",
   output: {
     filename: '[name].bundle.js',
     publicPath: 'bundles/',
@@ -78,6 +78,9 @@ module.exports = {
       'process.env': {
         'version' : JSON.stringify(version)
       }
+    }),
+    new webpack.DefinePlugin({
+      __webpack_nonce__: 'window.__CSP_NONCE',
     })
   ]
 };

--- a/webpack/base.config.js
+++ b/webpack/base.config.js
@@ -17,7 +17,7 @@ var json = JSON.parse(fs.readFileSync('package.json', 'utf8'));
 var version = json.version;
 module.exports = {
   context: path.join(__dirname, '../src'),
-  devtool: "source-map",
+  devtool: 'source-map',
   output: {
     filename: '[name].bundle.js',
     publicPath: 'bundles/',

--- a/webpack/plugins/svg-prep.js
+++ b/webpack/plugins/svg-prep.js
@@ -46,7 +46,7 @@ SvgPrepPlugin.prototype.apply = function(compiler) {
           .filter({ removeIds: true, noFill: true })
           .output();
 
-        compilation.emitAsset(this.options.output, new RawSource(sprited));
+        compilation.emitAsset(this.options.output, new RawSource(sprited.replace('style="display:none"', '')));
       });
   });
 }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Currently, Parse Dashboard cannot be used with strict CSP

Closes: #2392

### Approach
<!-- Add a description of the approach in this PR. -->

Adds dashboard options:

- `options.strictCSP`, which sets the express app's CSP to strict
- `options.CSPNonce`, which is a string that can be used to set `nonce`, in case the developer wants to override

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
