### PR TITLE
fix: Uncaught error when editing Number field in Edit Row dialog

### DIFF
--- a/src/dashboard/Data/Browser/EditRowDialog.react.js
+++ b/src/dashboard/Data/Browser/EditRowDialog.react.js
@@ -14,6 +14,7 @@ import ObjectPickerDialog from 'dashboard/Data/Browser/ObjectPickerDialog.react'
 import styles from 'dashboard/Data/Browser/Browser.scss';
 import getFileName from 'lib/getFileName';
 import encode from 'parse/lib/browser/encode';
+import validateNumeric from 'lib/validateNumeric';
 
 export default class EditRowDialog extends React.Component {
   constructor(props) {
@@ -291,8 +292,8 @@ export default class EditRowDialog extends React.Component {
               disabled={isDisabled}
               value={currentObject[name]}
               placeholder={val === undefined ? '(undefined)' : ''}
-              onChange={newValue => this.updateCurrentObject(newValue, name)}
-              onBlur={newValue => this.handleChange(parseFloat(newValue), name)}
+              onChange={newValue => this.updateCurrentObject(validateNumeric(newValue) ? newValue : currentObject[name], name)}
+              onBlur={newValue => this.handleChange(validateNumeric(parseFloat(newValue)) ? parseFloat(newValue) : undefined, name)}
             />
           );
           break;


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [ ] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [ ] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
`Uncaught (in promise) Error: Maximum update depth exceeded. ` is called when typing an empty field or non alpha numberic characters.

Closes: https://github.com/parse-community/parse-dashboard/issues/2324

### Approach
<!-- Add a description of the approach in this PR. -->
* Allow clearing number field (undefined)
* Prevent non numberic characters from being entered
