### PR TITLE
fix: File uploading status not updating in data browser

### DIFF
--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -177,6 +177,9 @@ export default class BrowserCell extends Component {
   componentDidUpdate(prevProps) {
     if ( this.props.value !== prevProps.value ) {
       this.renderCellContent();
+      this.props.value._previousSave
+        ?.then(() => this.renderCellContent())
+        ?.catch(err => console.log(err))
     }
     if (this.props.current) {
       const node = this.cellRef.current;


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
there was a problem of status change when u do upload a file. The problem was that even after the file is uploaded there is no way the user is getting notified of it as the field will show uploading.. even though the upload is completed.

Closes: #2274 

### Approach
So the issue is that we are saving the row before saving of file gets completed and thus we are not able to identify that the change has occurred. This PR resolve it by resolving the pending file upload promise if its there and than re-render the cell.

### TODOs before merging
None