### PR TITLE
fix: Option missing for Parse Config parameter to require master key

### DIFF
--- a/src/dashboard/Data/Config/Config.react.js
+++ b/src/dashboard/Data/Config/Config.react.js
@@ -58,7 +58,6 @@ class Config extends TableView {
   }
 
   renderExtras() {
-    const { currentApp = {} } = this.context;
     let extras = null;
     if (this.state.modalOpen) {
       extras = (
@@ -69,7 +68,7 @@ class Config extends TableView {
           type={this.state.modalType}
           value={this.state.modalValue}
           masterKeyOnly={this.state.modalMasterKeyOnly}
-          parseServerVersion={currentApp.serverInfo && currentApp.serverInfo.parseServerVersion} />
+          parseServerVersion={this.context.serverInfo?.parseServerVersion} />
       );
     } else if (this.state.showDeleteParameterDialog) {
       extras = (
@@ -129,7 +128,7 @@ class Config extends TableView {
       }
       openModal()
     }
-  
+
     let openDeleteParameterDialog = () => this.setState({
       showDeleteParameterDialog: true,
       modalParam: data.param


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

MasterKey field is missing for config.

Closes: #2439

### Approach
<!-- Add a description of the approach in this PR. -->

![Screenshot 2023-05-30 at 3 43 41 pm](https://github.com/parse-community/parse-dashboard/assets/4974769/da5cf5b8-48de-4f69-9f88-07912f12ee23)

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->


- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
