### PR TITLE
fix: Scroll position is preserved when re-opening the same class in data browser via navigation bar

### DIFF
--- a/src/dashboard/Data/Browser/BrowserTable.react.js
+++ b/src/dashboard/Data/Browser/BrowserTable.react.js
@@ -47,6 +47,10 @@ export default class BrowserTable extends React.Component {
     } else if (this.props.ordering !== props.ordering) {
       this.setState({ offset: 0 });
       this.tableRef.current.scrollTop = 0;
+    } else if (this.props.filters.size !== props.filters.size) {
+      this.setState({ offset: 0 }, () => {
+        this.tableRef.current.scrollTop = 0;
+      });
     }
   }
 


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

Closes: #2443 

### Approach
<!-- Add a description of the approach in this PR. -->
Ensure that the `scrollTop` is set to 0 whenever there are updates in the filters. 
