### PR TITLE
fix: Pasting location coordinates into field of type `GeoPoint` does not work in data browser

### DIFF
--- a/src/components/GeoPointEditor/GeoPointEditor.react.js
+++ b/src/components/GeoPointEditor/GeoPointEditor.react.js
@@ -106,17 +106,16 @@ export default class GeoPointEditor extends React.Component {
       let value = e.target.value;
 
       if (!validateNumeric(value)) {
-        // This regex will match this form of input: (x, y) or (x,y) or x, y or x,y
-        const regex = /\((-?\d+\.?\d*),\s*(-?\d+\.?\d*)\)|(-?\d+\.?\d*),\s*(-?\d+\.?\d*)/;
-        const match = value.match(regex);
+        // This regex will match this form of input: (x, y) or (x,y) or x, y or x,y and many more
+        const regex =
+          /[\[("' ]?(?<x>[0-9.]+)["' ]?,["' ]?(?<y>[0-9.]+)["' )\]]?/;
+        const match = regex.exec(value);
 
         if (!match) {
           return null;
         }
 
-        let values = match[0].replace(/[()]/g, '').split(',');
-
-        values = values.map(val => val.trim());
+        const values = [match.groups.x, match.groups.y];
 
         if (values[0].length > 0 && validateNumeric(values[0])) {
 

--- a/src/components/GeoPointEditor/GeoPointEditor.react.js
+++ b/src/components/GeoPointEditor/GeoPointEditor.react.js
@@ -106,7 +106,6 @@ export default class GeoPointEditor extends React.Component {
       let value = e.target.value;
 
       if (!validateNumeric(value)) {
-        // This regex will match this form of input: (x, y) or (x,y) or x, y or x,y and many more
         const regex =
           /[[("' ]?(?<x>[0-9.]+)["' ]?,["' ]?(?<y>[0-9.]+)["' )\]]?/;
         const match = regex.exec(value);

--- a/src/components/GeoPointEditor/GeoPointEditor.react.js
+++ b/src/components/GeoPointEditor/GeoPointEditor.react.js
@@ -106,26 +106,32 @@ export default class GeoPointEditor extends React.Component {
       let value = e.target.value;
 
       if (!validateNumeric(value)) {
-        var values = value.split(',');
+        // This regex will match this form of input: (x, y) or (x,y) or x, y or x,y
+        const regex = /\((-?\d+\.?\d*),\s*(-?\d+\.?\d*)\)|(-?\d+\.?\d*),\s*(-?\d+\.?\d*)/;
+        const match = value.match(regex);
 
-        if (values.length == 2) {
-          values = values.map(val => val.trim());
+        if (!match) {
+          return null;
+        }
 
-          if (values[0].length > 0 && validateNumeric(values[0])) {
+        let values = match[0].replace(/[\(\)]/g, '').split(',');
 
-            if (values[1].length <= 0 || !validateNumeric(values[1])) {
-              this.setState({ latitude: values[0] });
-              this.longitudeRef.current.focus();
-              this.longitudeRef.current.setSelectionRange(0, String(this.state.longitude).length);
-              return;
-            }
+        values = values.map(val => val.trim());
 
-            if (validateNumeric(values[1])) {
-              this.setState({ latitude: values[0] });
-              this.setState({ longitude: values[1] });
-              this.longitudeRef.current.focus();
-              return;
-            }
+        if (values[0].length > 0 && validateNumeric(values[0])) {
+
+          if (values[1].length <= 0 || !validateNumeric(values[1])) {
+            this.setState({ latitude: values[0] });
+            this.longitudeRef.current.focus();
+            this.longitudeRef.current.setSelectionRange(0, String(this.state.longitude).length);
+            return;
+          }
+
+          if (validateNumeric(values[1])) {
+            this.setState({ latitude: values[0] });
+            this.setState({ longitude: values[1] });
+            this.longitudeRef.current.focus();
+            return;
           }
         }
       }

--- a/src/components/GeoPointEditor/GeoPointEditor.react.js
+++ b/src/components/GeoPointEditor/GeoPointEditor.react.js
@@ -106,8 +106,7 @@ export default class GeoPointEditor extends React.Component {
       let value = e.target.value;
 
       if (!validateNumeric(value)) {
-        const regex =
-          /[[("' ]?(?<x>[0-9.]+)["' ]?,["' ]?(?<y>[0-9.]+)["' )\]]?/;
+        const regex = /[[("' ]?(?<x>[0-9.]+)["' ]?,["' ]?(?<y>[0-9.]+)["' )\]]?/;
         const match = regex.exec(value);
 
         if (!match) {

--- a/src/components/GeoPointEditor/GeoPointEditor.react.js
+++ b/src/components/GeoPointEditor/GeoPointEditor.react.js
@@ -114,7 +114,7 @@ export default class GeoPointEditor extends React.Component {
           return null;
         }
 
-        let values = match[0].replace(/[\(\)]/g, '').split(',');
+        let values = match[0].replace(/[()]/g, '').split(',');
 
         values = values.map(val => val.trim());
 

--- a/src/components/GeoPointEditor/GeoPointEditor.react.js
+++ b/src/components/GeoPointEditor/GeoPointEditor.react.js
@@ -108,7 +108,7 @@ export default class GeoPointEditor extends React.Component {
       if (!validateNumeric(value)) {
         // This regex will match this form of input: (x, y) or (x,y) or x, y or x,y and many more
         const regex =
-          /[\[("' ]?(?<x>[0-9.]+)["' ]?,["' ]?(?<y>[0-9.]+)["' )\]]?/;
+          /[[("' ]?(?<x>[0-9.]+)["' ]?,["' ]?(?<y>[0-9.]+)["' )\]]?/;
         const match = regex.exec(value);
 
         if (!match) {


### PR DESCRIPTION
- add formats like below to be paste-able in geo point field
    - (x, y)
    - (x,y)
    - x, y
    - x,y
  
### New Pull Request Checklist
- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
There was a paste functionality for GeoPoint that was accepting the x,y format already. But as when we are copying the field we are getting the format like (x, y) which makes the existing functionality outdated.

Closes: #2462 

### Approach
I basically added other formats including (x, y) that will get accepted when pasting.

### TODOs before merging
NA