### PR TITLE
fix: Selecting a saved filter in data browser also highlights other filters with equal names

### DIFF
--- a/src/components/CategoryList/CategoryList.react.js
+++ b/src/components/CategoryList/CategoryList.react.js
@@ -102,7 +102,7 @@ export default class CategoryList extends React.Component {
           let count = c.count;
           let className = id === this.props.current ? styles.active : '';
           let selectedFilter = null;
-          if (this.state.openClasses.includes(id)) {
+            if (this.state.openClasses.includes(id) && id === this.props.current) {
             const query = new URLSearchParams(this.props.params);
             if (query.has('filters')) {
               const queryFilter = query.get('filters')

--- a/src/components/CategoryList/CategoryList.react.js
+++ b/src/components/CategoryList/CategoryList.react.js
@@ -102,7 +102,7 @@ export default class CategoryList extends React.Component {
           let count = c.count;
           let className = id === this.props.current ? styles.active : '';
           let selectedFilter = null;
-            if (this.state.openClasses.includes(id) && id === this.props.current) {
+          if (this.state.openClasses.includes(id) && id === this.props.current) {
             const query = new URLSearchParams(this.props.params);
             if (query.has('filters')) {
               const queryFilter = query.get('filters')


### PR DESCRIPTION
- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

Closes: #2459 

### Approach
<!-- Add a description of the approach in this PR. -->
To prevent both different filters from being highlighted, the class names should also be compared.
