### PR TITLE
fix: Adding a file when adding a new row in the data browser doesn't show filename

### DIFF
--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -127,7 +127,7 @@ export default class BrowserCell extends Component {
     } else if (this.props.type === 'Object' || this.props.type === 'Bytes') {
       this.copyableValue = content = JSON.stringify(this.props.value);
     } else if (this.props.type === 'File') {
-      const fileName = this.props.value.url() ? getFileName(this.props.value) : 'Uploading\u2026';
+      const fileName = this.props.value ? this.props.value.url() ? getFileName(this.props.value) : this.props.value.name() : 'Uploading\u2026';
       content = <Pill value={fileName} fileDownloadLink={this.props.value.url()} shrinkablePill />;
       this.copyableValue = fileName;
     } else if (this.props.type === 'ACL') {

--- a/src/dashboard/Data/Browser/EditRowDialog.react.js
+++ b/src/dashboard/Data/Browser/EditRowDialog.react.js
@@ -352,7 +352,7 @@ export default class EditRowDialog extends React.Component {
           break;
         case 'File':
           let file = selectedObject[name];
-          let fileName = file && file.url() ? getFileName(file) : '';
+          let fileName = file ? file.url() ? getFileName(file) : file.name() : '';
           inputComponent = (
             <div style={{ padding: '25px' }}>
               {file && <Pill value={fileName} fileDownloadLink={file.url()} />}


### PR DESCRIPTION

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

Closes: #2418 

### Approach
<!-- Add a description of the approach in this PR. -->
showing filename without url.
