### PR TITLE
revert: fix: Vertical scrollbar in data browser is outside visible area when scrolling horizontally (#2457)

### DIFF
--- a/src/components/DataBrowserHeaderBar/DataBrowserHeaderBar.scss
+++ b/src/components/DataBrowserHeaderBar/DataBrowserHeaderBar.scss
@@ -8,7 +8,7 @@
 @import 'stylesheets/globals.scss';
 
 .bar {
-  position: sticky;
+  position: absolute;
   top: 0;
   left: 0;
   height: 30px;

--- a/src/dashboard/Data/Browser/Browser.scss
+++ b/src/dashboard/Data/Browser/Browser.scss
@@ -14,13 +14,12 @@
   right: 0;
   bottom: 0;
   overflow: auto;
-  width: calc(100% - 300px);
+  padding-top: 30px;
 }
 
 body:global(.expanded) {
   .browser {
     left: $sidebarCollapsedWidth;
-    width: calc(100% - $sidebarCollapsedWidth);
   }
 }
 
@@ -83,7 +82,9 @@ body:global(.expanded) {
   top: 30px;
   bottom: 0;
   left: 0;
-  width: 100%;
+  min-width: 100%;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .table .empty {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Closes: #2475 

### Approach

This reverts commit 5acac3fb5c74cbb24ec96b721d874fbc36096c39.

