### PR TITLE
feat: Add refresh indicator to Cloud Config page

### DIFF
--- a/src/dashboard/Data/Config/Config.react.js
+++ b/src/dashboard/Data/Config/Config.react.js
@@ -35,6 +35,7 @@ class Config extends TableView {
       modalType: 'String',
       modalValue: '',
       modalMasterKeyOnly: false,
+      loading: false,
     };
   }
 
@@ -53,7 +54,10 @@ class Config extends TableView {
   }
 
   loadData() {
-    this.props.config.dispatch(ActionTypes.FETCH);
+    this.setState({ loading: true });
+    this.props.config.dispatch(ActionTypes.FETCH).finally(() => {
+      this.setState({ loading: false });
+    });
   }
 
   renderToolbar() {


### PR DESCRIPTION
### New Pull Request Checklist
- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
There is no refresh indicator for cloud config page. This leads to not able to disguise between refreshing and refreshed state.

Closes: #2494 

### Approach
Copy paste same functionality which is already there in PushAudiencesData page.

### TODOs before merging
NA
