### PR TITLE
feat: Execute script for selected rows

### DIFF
--- a/src/dashboard/Data/Browser/BrowserToolbar.react.js
+++ b/src/dashboard/Data/Browser/BrowserToolbar.react.js
@@ -163,12 +163,6 @@ const BrowserToolbar = ({
           onClick={() => onDeleteRows(selection)}
         />
         <Separator />
-        <MenuItem
-          disabled={selectionLength === 0}
-          text={selectionLength === 1 && !selection['*'] ? 'Execute script on this row' : 'Execute script on these rows'}
-          onClick={() => onExecuteScriptRows(selection)}
-        />
-        <Separator />
         {enableColumnManipulation ? (
           <MenuItem text="Delete a column" onClick={onRemoveColumn} />
         ) : (
@@ -386,6 +380,18 @@ const BrowserToolbar = ({
         <noscript />
       )}
       {enableSecurityDialog ? <div className={styles.toolbarSeparator} /> : <noscript />}
+      <BrowserMenu
+        setCurrent={setCurrent}
+        title="Script"
+        icon="gear-solid"
+      >
+        <MenuItem
+          disabled={selectionLength === 0}
+          text={selectionLength === 1 && !selection['*'] ? 'Run script on selected row...' : `Run script on ${selectionLength} selected rows...`}
+          onClick={() => onExecuteScriptRows(selection)}
+        />
+      </BrowserMenu>
+      <div className={styles.toolbarSeparator} />
       {menu}
       {editCloneRows && editCloneRows.length > 0 && <div className={styles.toolbarSeparator} />}
       {editCloneRows && editCloneRows.length > 0 && (

--- a/src/dashboard/Data/Browser/BrowserToolbar.react.js
+++ b/src/dashboard/Data/Browser/BrowserToolbar.react.js
@@ -45,6 +45,7 @@ const BrowserToolbar = ({
   onExport,
   onRemoveColumn,
   onDeleteRows,
+  onExecuteScriptRows,
   onDropClass,
   onChangeCLP,
   onRefresh,
@@ -161,6 +162,13 @@ const BrowserToolbar = ({
           text={selectionLength === 1 && !selection['*'] ? 'Delete this row' : 'Delete these rows'}
           onClick={() => onDeleteRows(selection)}
         />
+        <Separator />
+        <MenuItem
+          disabled={selectionLength === 0}
+          text={selectionLength === 1 && !selection['*'] ? 'Execute script on this row' : 'Execute script on these rows'}
+          onClick={() => onExecuteScriptRows(selection)}
+        />
+        <Separator />
         {enableColumnManipulation ? (
           <MenuItem text="Delete a column" onClick={onRemoveColumn} />
         ) : (

--- a/src/dashboard/Data/Browser/ExecuteScriptRowsDialog.react.js
+++ b/src/dashboard/Data/Browser/ExecuteScriptRowsDialog.react.js
@@ -41,7 +41,7 @@ export default class ExecuteScriptRowsDialog extends React.Component {
 
   handleScriptChange(scriptName) {
     this.setState({
-      currentScript: validScripts.find(script => script.name === scriptName),
+      currentScript: this.state.validScripts.find(script => script.title === scriptName),
     });
   }
 

--- a/src/dashboard/Data/Browser/ExecuteScriptRowsDialog.react.js
+++ b/src/dashboard/Data/Browser/ExecuteScriptRowsDialog.react.js
@@ -1,0 +1,78 @@
+import React from 'react';
+import FormModal from 'components/FormModal/FormModal.react';
+import Field from 'components/Field/Field.react';
+import Label from 'components/Label/Label.react';
+import Dropdown from 'components/Dropdown/Dropdown.react';
+import Option from 'components/Dropdown/Option.react';
+import { CurrentApp } from 'context/currentApp';
+
+export default class ExecuteScriptRowsDialog extends React.Component {
+  static contextType = CurrentApp;
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      currentScript: null,
+      validScripts: [],
+    };
+
+    this.handleConfirm = this.handleConfirm.bind(this);
+    this.handleScriptChange = this.handleScriptChange.bind(this);
+  }
+
+  componentWillMount() {
+    const { selection, currentClass } = this.props;
+
+    const validScripts = (this.context.scripts || []).filter(script =>
+      script.classes?.includes(currentClass)
+    );
+
+    if (selection && validScripts.length > 0) {
+      this.setState({
+        currentScript: validScripts[0],
+        validScripts: validScripts,
+      });
+    }
+  }
+
+  handleConfirm() {
+    return this.props.onConfirm(this.state.currentScript);
+  }
+
+  handleScriptChange(scriptName) {
+    this.setState({
+      currentScript: validScripts.find(script => script.name === scriptName),
+    });
+  }
+
+  render() {
+    const { validScripts } = this.state;
+    const { selection, processedScripts } = this.props;
+
+    return (
+      <FormModal
+        open
+        icon="plus"
+        iconSize={40}
+        title="Select script run"
+        submitText="Execute"
+        inProgressText={`Executed ${processedScripts} of ${Object.keys(selection).length}`}
+        onClose={this.props.onCancel}
+        onSubmit={this.handleConfirm}
+      >
+        <Field
+          label={<Label text="Script" />}
+          input={
+            <Dropdown value={this.state.currentScript?.title} onChange={this.handleScriptChange}>
+              {validScripts.map(script => (
+                <Option key={script.title} value={script.title}>
+                  {script.title}
+                </Option>
+              ))}
+            </Dropdown>
+          }
+        />
+      </FormModal>
+    );
+  }
+}

--- a/src/dashboard/Data/Browser/ExecuteScriptRowsDialog.react.js
+++ b/src/dashboard/Data/Browser/ExecuteScriptRowsDialog.react.js
@@ -48,15 +48,15 @@ export default class ExecuteScriptRowsDialog extends React.Component {
   render() {
     const { validScripts } = this.state;
     const { selection, processedScripts } = this.props;
-
+    const selectionLength = Object.keys(selection).length;
     return (
       <FormModal
         open
-        icon="plus"
+        icon="gears"
         iconSize={40}
-        title="Select script run"
-        submitText="Execute"
-        inProgressText={`Executed ${processedScripts} of ${Object.keys(selection).length}`}
+        title={selectionLength > 1 ? `Run script on ${selectionLength} selected rows` : 'Run script on selected row'}
+        submitText="Run"
+        inProgressText={`Executed ${processedScripts} of ${selectionLength} rows`}
         onClose={this.props.onCancel}
         onSubmit={this.handleConfirm}
       >


### PR DESCRIPTION
### New Pull Request Checklist
- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
Currently we can't execute a script for selected rows directly and we have to execute it row by row manually.

Closes: #2497 

### Approach
Added an option in menu with other mass selection action. With this after selection of rows, user can select a script from dialog to execute on those selected rows.

### TODOs before merging
NA