### PR TITLE
fix: Open pointer in new tab in data browser not working when mount path is not root

### DIFF
--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -1030,7 +1030,7 @@ class Browser extends DashboardView {
       },
     ]);
     window.open(
-      generatePath(this.context, `browser/${className}?filters=${encodeURIComponent(filters)}`),
+      generatePath(this.context, `browser/${className}?filters=${encodeURIComponent(filters)}`, true),
       '_blank'
     );
   }

--- a/src/lib/generatePath.js
+++ b/src/lib/generatePath.js
@@ -1,3 +1,8 @@
-export default function generatePath(currentApp, path) {
+const MOUNT_PATH = window.PARSE_DASHBOARD_PATH;
+
+export default function generatePath(currentApp, path, prependMountPath = false) {
+  if (prependMountPath && MOUNT_PATH) {
+    return `${MOUNT_PATH}apps/${currentApp.slug}/${path}`;
+  }
   return `/apps/${currentApp.slug}/${path}`;
 }


### PR DESCRIPTION
### New Pull Request Checklist
- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description

Closes: #2509 

### Approach
Implemented the addition of an optional parameter to the 'generatepath' function, enabling the ability to prepend the mount path to the given path.

