### PR TITLE
feat: Add descriptive statistics for number cells in data browser

### DIFF
--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -536,6 +536,8 @@ export default class BrowserCell extends Component {
       onEditSelectedRow,
       isRequired,
       markRequiredFieldRow,
+      handleCellClick,
+      selectedCells,
     } = this.props;
 
     const classes = [...this.state.classes];
@@ -573,6 +575,21 @@ export default class BrowserCell extends Component {
       );
     }
 
+    if (selectedCells.list.has(`${row}-${col}`)) {
+      if (selectedCells.rowStart === row) {
+        classes.push(styles.topBorder);
+      }
+      if (selectedCells.rowEnd === row) {
+        classes.push(styles.bottomBorder);
+      }
+      if (selectedCells.colStart === col) {
+        classes.push(styles.leftBorder);
+      }
+      if (selectedCells.colEnd === col) {
+        classes.push(styles.rightBorder);
+      }
+    }
+
     return (
       <span
         ref={this.cellRef}
@@ -582,8 +599,8 @@ export default class BrowserCell extends Component {
           if (e.metaKey === true && type === 'Pointer') {
             onPointerCmdClick(value);
           } else {
-            onSelect({ row, col });
             setCopyableValue(hidden ? undefined : this.copyableValue);
+            handleCellClick(e, row, col);
           }
         }}
         onDoubleClick={() => {

--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -588,6 +588,7 @@ export default class BrowserCell extends Component {
       if (selectedCells.colEnd === col) {
         classes.push(styles.rightBorder);
       }
+      classes.push(styles.selected);
     }
 
     return (

--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -526,7 +526,6 @@ export default class BrowserCell extends Component {
       hidden,
       width,
       current,
-      onSelect,
       onEditChange,
       setCopyableValue,
       onPointerCmdClick,
@@ -575,7 +574,7 @@ export default class BrowserCell extends Component {
       );
     }
 
-    if (selectedCells.list.has(`${row}-${col}`)) {
+    if (selectedCells?.list.has(`${row}-${col}`)) {
       if (selectedCells.rowStart === row) {
         classes.push(styles.topBorder);
       }

--- a/src/components/BrowserCell/BrowserCell.scss
+++ b/src/components/BrowserCell/BrowserCell.scss
@@ -96,6 +96,10 @@
   }
 }
 
+.selected {
+  background-color: #e3effd;
+}
+
 .hasMore {
   height: auto;
   max-height: 25px;

--- a/src/components/BrowserCell/BrowserCell.scss
+++ b/src/components/BrowserCell/BrowserCell.scss
@@ -36,7 +36,67 @@
   }
 }
 
-.hasMore{
+.leftBorder {
+  position: relative;
+
+  &:after {
+    position: absolute;
+    pointer-events: none;
+    content: '';
+    border-left: 2px solid #555572;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+  }
+}
+
+.rightBorder {
+  position: relative;
+
+  &:after {
+    position: absolute;
+    pointer-events: none;
+    content: '';
+    border-right: 2px solid #555572;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+  }
+}
+
+.topBorder {
+  position: relative;
+
+  &:after {
+    position: absolute;
+    pointer-events: none;
+    content: '';
+    border-top: 2px solid #555572;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+  }
+}
+
+.bottomBorder {
+  position: relative;
+
+  &:after {
+    position: absolute;
+    pointer-events: none;
+    content: '';
+    border-bottom: 2px solid #555572;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+  }
+}
+
+.hasMore {
   height: auto;
   max-height: 25px;
   overflow-y: scroll;

--- a/src/components/BrowserRow/BrowserRow.react.js
+++ b/src/components/BrowserRow/BrowserRow.react.js
@@ -136,6 +136,8 @@ export default class BrowserRow extends Component {
               showNote={this.props.showNote}
               onRefresh={this.props.onRefresh}
               scripts={this.props.scripts}
+              handleCellClick={this.props.handleCellClick}
+              selectedCells={this.props.selectedCells}
             />
           );
         })}

--- a/src/components/Toolbar/Toolbar.react.js
+++ b/src/components/Toolbar/Toolbar.react.js
@@ -6,10 +6,109 @@
  * the root directory of this source tree.
  */
 import PropTypes from 'lib/PropTypes';
-import React from 'react';
+import React, { useEffect } from 'react';
 import Icon from 'components/Icon/Icon.react';
 import styles from 'components/Toolbar/Toolbar.scss';
+import Popover from 'components/Popover/Popover.react';
+import Position from 'lib/Position';
 import { useNavigate, useNavigationType, NavigationType } from 'react-router-dom';
+
+const POPOVER_CONTENT_ID = 'toolbarStatsPopover';
+
+const Stats = ({ data }) => {
+  const [selected, setSelected] = React.useState(null);
+  const [open, setOpen] = React.useState(false);
+  const buttonRef = React.useRef();
+
+  const statsOptions = [
+    {
+      type: 'sum',
+      label: 'Sum',
+      getValue: data => data.reduce((sum, value) => sum + value, 0),
+    },
+    {
+      type: 'mean',
+      label: 'Mean',
+      getValue: data => data.reduce((sum, value) => sum + value, 0) / data.length,
+    },
+    {
+      type: 'count',
+      label: 'Count',
+      getValue: data => data.length,
+    },
+    {
+      type: 'p99',
+      label: 'P99',
+      getValue: data => {
+        const sorted = data.sort((a, b) => a - b);
+        return sorted[Math.floor(sorted.length * 0.99)];
+      },
+    },
+  ];
+
+  const toggle = () => {
+    setOpen(!open);
+  };
+
+  const renderPopover = () => {
+    const node = buttonRef.current;
+    const position = Position.inDocument(node);
+    return (
+      <Popover
+        fixed={true}
+        position={position}
+        onExternalClick={toggle}
+        contentId={POPOVER_CONTENT_ID}
+      >
+        <div id={POPOVER_CONTENT_ID}>
+          <div
+            onClick={toggle}
+            style={{
+              cursor: 'pointer',
+              width: node.clientWidth,
+              height: node.clientHeight,
+            }}
+          ></div>
+          <div className={styles.stats_popover_container}>
+            {statsOptions.map(item => {
+              const itemStyle = [styles.stats_popover_item];
+              if (item.type === selected?.type) {
+                itemStyle.push(styles.active);
+              }
+              return (
+                <div
+                  key={item.type}
+                  className={itemStyle.join(' ')}
+                  onClick={() => {
+                    setSelected(item);
+                    toggle();
+                  }}
+                >
+                  <span>{item.label}</span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </Popover>
+    );
+  };
+
+  useEffect(() => {
+    setSelected(statsOptions[0]);
+  }, []);
+
+  return (
+    <>
+      {selected ? (
+        <button ref={buttonRef} className={styles.stats} onClick={toggle}>
+          {`${selected.label}: ${selected.getValue(data)}`}
+        </button>
+      ) : null}
+      {open ? renderPopover() : null}
+    </>
+  );
+};
 
 const Toolbar = props => {
   const action = useNavigationType();
@@ -34,6 +133,7 @@ const Toolbar = props => {
           </div>
         </div>
       </div>
+      {props.selectedData.length ? <Stats data={props.selectedData} /> : null}
       <div className={styles.actions}>{props.children}</div>
     </div>
   );
@@ -44,6 +144,7 @@ Toolbar.propTypes = {
   subsection: PropTypes.string,
   details: PropTypes.string,
   relation: PropTypes.object,
+  selectedData: PropTypes.array,
 };
 
 export default Toolbar;

--- a/src/components/Toolbar/Toolbar.scss
+++ b/src/components/Toolbar/Toolbar.scss
@@ -85,3 +85,41 @@ body:global(.expanded) {
   right: 14px;
   top: 4px;
 }
+
+.stats {
+  position: absolute;
+  right: 20px;
+  bottom: 10px;
+  background: $blue;
+  border-radius: 3px;
+  padding: 2px 4px;
+  font-size: 16px;
+  color: white;
+  box-shadow: none;
+  border: none;
+}
+
+.stats_popover_container {
+  display: flex;
+  flex-direction: column;
+  background: $blue;
+  gap: 4px;
+  padding: 2px 0px;
+  font-size: 16px;
+  color: white;
+}
+
+.stats_popover_item {
+  cursor: pointer;
+  padding: 0px 8px;
+
+  &:hover {
+    color: $blue;
+    background-color: white;
+  }
+}
+
+.active {
+  color: $blue;
+  background-color: white;
+}

--- a/src/components/Toolbar/Toolbar.scss
+++ b/src/components/Toolbar/Toolbar.scss
@@ -92,7 +92,7 @@ body:global(.expanded) {
   bottom: 10px;
   background: $blue;
   border-radius: 3px;
-  padding: 2px 4px;
+  padding: 2px 6px;
   font-size: 14px;
   color: white;
   box-shadow: none;
@@ -103,7 +103,9 @@ body:global(.expanded) {
   display: flex;
   flex-direction: column;
   background: $blue;
-  gap: 4px;
+  border-radius: 3px;
+  margin-top: 1px;
+  gap: 2px;
   padding: 2px 0px;
   font-size: 14px;
   color: white;
@@ -111,7 +113,7 @@ body:global(.expanded) {
 
 .stats_popover_item {
   cursor: pointer;
-  padding: 0px 8px;
+  padding: 0px 6px;
 
   &:hover {
     color: $blue;

--- a/src/components/Toolbar/Toolbar.scss
+++ b/src/components/Toolbar/Toolbar.scss
@@ -93,7 +93,7 @@ body:global(.expanded) {
   background: $blue;
   border-radius: 3px;
   padding: 2px 4px;
-  font-size: 16px;
+  font-size: 14px;
   color: white;
   box-shadow: none;
   border: none;
@@ -105,7 +105,7 @@ body:global(.expanded) {
   background: $blue;
   gap: 4px;
   padding: 2px 0px;
-  font-size: 16px;
+  font-size: 14px;
   color: white;
 }
 

--- a/src/dashboard/Data/Browser/BrowserTable.react.js
+++ b/src/dashboard/Data/Browser/BrowserTable.react.js
@@ -168,6 +168,8 @@ export default class BrowserTable extends React.Component {
                     showNote={this.props.showNote}
                     onRefresh={this.props.onRefresh}
                     scripts={this.context.scripts}
+                    selectedCells={this.props.selectedCells}
+                    handleCellClick={this.props.handleCellClick}
                   />
                   <Button
                     value="Clone"
@@ -236,6 +238,8 @@ export default class BrowserTable extends React.Component {
               showNote={this.props.showNote}
               onRefresh={this.props.onRefresh}
               scripts={this.context.scripts}
+              selectedCells={this.props.selectedCells}
+              handleCellClick={this.props.handleCellClick}
             />
             <Button
               value="Add"
@@ -312,6 +316,8 @@ export default class BrowserTable extends React.Component {
             showNote={this.props.showNote}
             onRefresh={this.props.onRefresh}
             scripts={this.context.scripts}
+            selectedCells={this.props.selectedCells}
+            handleCellClick={this.props.handleCellClick}
           />
         );
       }

--- a/src/dashboard/Data/Browser/BrowserToolbar.react.js
+++ b/src/dashboard/Data/Browser/BrowserToolbar.react.js
@@ -72,6 +72,8 @@ const BrowserToolbar = ({
   login,
   logout,
   toggleMasterKeyUsage,
+
+  selectedData,
 }) => {
   const selectionLength = Object.keys(selection).length;
   const isPendingEditCloneRows = editCloneRows && editCloneRows.length > 0;
@@ -238,6 +240,7 @@ const BrowserToolbar = ({
       section={relation ? `Relation <${relation.targetClassName}>` : 'Class'}
       subsection={subsection}
       details={details.join(' \u2022 ')}
+      selectedData={selectedData}
     >
       {onAddRow && (
         <a className={classes.join(' ')} onClick={onClick}>

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -214,10 +214,10 @@ export default class DataBrowser extends React.Component {
               e.ctrlKey || e.metaKey
                 ? firstVisibleColumnIndex
                 : this.getNextVisibleColumnIndex(
-                    -1,
-                    firstVisibleColumnIndex,
-                    lastVisibleColumnIndex
-                  ),
+                  -1,
+                  firstVisibleColumnIndex,
+                  lastVisibleColumnIndex
+                ),
           },
         });
         e.preventDefault();
@@ -243,10 +243,10 @@ export default class DataBrowser extends React.Component {
               e.ctrlKey || e.metaKey
                 ? lastVisibleColumnIndex
                 : this.getNextVisibleColumnIndex(
-                    1,
-                    firstVisibleColumnIndex,
-                    lastVisibleColumnIndex
-                  ),
+                  1,
+                  firstVisibleColumnIndex,
+                  lastVisibleColumnIndex
+                ),
           },
         });
         e.preventDefault();

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -214,10 +214,10 @@ export default class DataBrowser extends React.Component {
               e.ctrlKey || e.metaKey
                 ? firstVisibleColumnIndex
                 : this.getNextVisibleColumnIndex(
-                  -1,
-                  firstVisibleColumnIndex,
-                  lastVisibleColumnIndex
-                ),
+                    -1,
+                    firstVisibleColumnIndex,
+                    lastVisibleColumnIndex
+                  ),
           },
         });
         e.preventDefault();


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description

Closes: #2506 

### Approach

1. Holding down the Shift key while clicking will conveniently highlight the entire area.
2. Currently, I'm displaying statistics in the toolbar using a default theme. Feel free to share your preferences.
3. By clicking on the stats button, users can opt for different types of statistics.
4. If any selected column isn't categorized as "Number," it won't be displayed or included in calculations.
5. Null or undefined values will be disregarded, ensuring they don't impact the count or any statistics.


ss1:
<img width="711" alt="Screenshot 2024-02-23 at 1 33 09 PM" src="https://github.com/parse-community/parse-dashboard/assets/49753983/66591bb6-ea4a-4b52-b7f7-407b39c7ac67">

ss2:
<img width="654" alt="Screenshot 2024-02-23 at 1 33 17 PM" src="https://github.com/parse-community/parse-dashboard/assets/49753983/468dd43b-d6c9-48bb-a008-952ac5906241">
