### PR TITLE
feat: Add Node 20 support; remove Node 14, 16 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,8 @@ Parse Dashboard is continuously tested with the most recent releases of Node.js 
 
 | Version    | Latest Version | End-of-Life | Compatible |
 |------------|----------------|-------------|------------|
-| Node.js 14 | 14.20.1        | April 2023  | ✅ Yes      |
-| Node.js 16 | 16.17.0        | April 2024  | ✅ Yes      |
-| Node.js 18 | 18.9.0         | May 2025    | ✅ Yes      |
+| Node.js 18 | 18.9.1         | May 2025    | ✅ Yes      |
+| Node.js 20 | 20.11.1         | April 2026    | ✅ Yes      |
 
 ## Configuring Parse Dashboard
 


### PR DESCRIPTION
Closes #2533 

This add the missing breaking change commit message, which was missing in #2532.