### PR TITLE
fix: Class Level Permissions dialog throws error `TypeError: ce.current is null` for newly created class

### DIFF
--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -368,6 +368,7 @@ class Browser extends DashboardView {
     this.props.schema
       .dispatch(ActionTypes.CREATE_CLASS, { className })
       .then(() => {
+        this.state.clp[className] = this.props.schema.data.get('CLPs').toJS()[className];
         this.state.counts[className] = 0;
         this.props.navigate(generatePath(this.context, 'browser/' + className));
       })
@@ -380,6 +381,7 @@ class Browser extends DashboardView {
     this.props.schema.dispatch(ActionTypes.DROP_CLASS, { className }).then(
       () => {
         this.setState({ showDropClassDialog: false });
+        delete this.state.clp[className];
         delete this.state.counts[className];
         this.props.navigate(generatePath(this.context, 'browser'));
       },

--- a/src/dashboard/Data/Browser/BrowserToolbar.react.js
+++ b/src/dashboard/Data/Browser/BrowserToolbar.react.js
@@ -341,7 +341,7 @@ const BrowserToolbar = ({
         disabled={isPendingEditCloneRows}
       />
       {onAddRow && <div className={styles.toolbarSeparator} />}
-      {perms && enableSecurityDialog ? (
+      {enableSecurityDialog ? (
         <SecurityDialog
           ref={clpDialogRef}
           disabled={!!relation || !!isUnique}


### PR DESCRIPTION

### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues/2547).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Closes: [#2547](https://github.com/parse-community/parse-dashboard/issues/2547)

### Approach
<!-- Add a description of the approach in this PR. -->
The SecurityDialog component is rendered based on the existence of the "perms" value, which is subject to a delay as it is fetched. In this scenario, if the user clicks on the menu item and the "perms" value isn't ready, the value of "clpDialogRef" will be null.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
