### PR TITLE
feat: Add Cloud Config change history to roll back to previous values

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Parse Dashboard is a standalone dashboard for managing your [Parse Server](https
 - [Deploying Parse Dashboard](#deploying-parse-dashboard)
   - [Preparing for Deployment](#preparing-for-deployment)
   - [Security Considerations](#security-considerations)
-  - [Security Checks](#security-checks)
+    - [Security Checks](#security-checks)
     - [Configuring Basic Authentication](#configuring-basic-authentication)
     - [Multi-Factor Authentication (One-Time Password)](#multi-factor-authentication-one-time-password)
     - [Separating App Access Based on User Identity](#separating-app-access-based-on-user-identity)
@@ -541,7 +541,7 @@ var dashboard = new ParseDashboard({
 });
 ```
 
-## Security Checks
+### Security Checks
 
 You can view the security status of your Parse Server by enabling the dashboard option `enableSecurityChecks`, and visiting App Settings > Security.
 
@@ -558,8 +558,6 @@ const dashboard = new ParseDashboard({
   ],
 });
 ```
-
-
 
 ### Configuring Basic Authentication
 You can configure your dashboard for Basic Authentication by adding usernames and passwords your `parse-dashboard-config.json` configuration file:

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Parse Dashboard is a standalone dashboard for managing your [Parse Server](https
 - [Deploying Parse Dashboard](#deploying-parse-dashboard)
   - [Preparing for Deployment](#preparing-for-deployment)
   - [Security Considerations](#security-considerations)
+  - [Security Checks](#security-checks)
     - [Configuring Basic Authentication](#configuring-basic-authentication)
     - [Multi-Factor Authentication (One-Time Password)](#multi-factor-authentication-one-time-password)
     - [Separating App Access Based on User Identity](#separating-app-access-based-on-user-identity)
@@ -123,6 +124,7 @@ Parse Dashboard is continuously tested with the most recent releases of Node.js 
 | `apps.scripts.cloudCodeFunction`       | String              | no       | -       | `'deleteUser'`       | The name of the Parse Cloud Function to execute.                                                                                            |
 | `apps.scripts.showConfirmationDialog`  | Bool                | yes      | `false` | `true`               | Is `true` if a confirmation dialog should be displayed before the script is executed, `false` if the script should be executed immediately. |
 | `apps.scripts.confirmationDialogStyle` | String              | yes      | `info`  | `critical`           | The style of the confirmation dialog. Valid values: `info` (blue style), `critical` (red style).                                            |
+| `apps.cloudConfigHistoryLimit` | Integer              | yes      | `100`  | `100`           | The number of historic values that should be saved in the Cloud Config change history. Valid values: \{ x \in \mathbb{Z} \mid 0 \leq x \leq \text{Number.MAX_SAFE_INTEGER} \}. |
 
 ### File
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Parse Dashboard is continuously tested with the most recent releases of Node.js 
 | `apps.scripts.cloudCodeFunction`       | String              | no       | -       | `'deleteUser'`       | The name of the Parse Cloud Function to execute.                                                                                            |
 | `apps.scripts.showConfirmationDialog`  | Bool                | yes      | `false` | `true`               | Is `true` if a confirmation dialog should be displayed before the script is executed, `false` if the script should be executed immediately. |
 | `apps.scripts.confirmationDialogStyle` | String              | yes      | `info`  | `critical`           | The style of the confirmation dialog. Valid values: `info` (blue style), `critical` (red style).                                            |
-| `apps.cloudConfigHistoryLimit` | Integer              | yes      | `100`  | `100`           | The number of historic values that should be saved in the Cloud Config change history. Valid values: \{ x \in \mathbb{Z} \mid 0 \leq x \leq \text{Number.MAX_SAFE_INTEGER} \}. |
+| `apps.cloudConfigHistoryLimit` | Integer              | yes      | `100`  | `100`           | The number of historic values that should be saved in the Cloud Config change history. Valid values: `0`...`Number.MAX_SAFE_INTEGER`. |
 
 ### File
 

--- a/src/dashboard/Data/Browser/Browser.scss
+++ b/src/dashboard/Data/Browser/Browser.scss
@@ -141,6 +141,13 @@ body:global(.expanded) {
   }
 }
 
+.history {
+  display: flex;
+  flex-wrap: wrap;
+  padding: .5rem;
+  gap: .5rem;
+}
+
 .notificationMessage, .notificationError {
   @include animation('fade-in 0.2s ease-out');
   position: absolute;

--- a/src/dashboard/Data/Browser/Browser.scss
+++ b/src/dashboard/Data/Browser/Browser.scss
@@ -141,46 +141,6 @@ body:global(.expanded) {
   }
 }
 
-.option {
-  position: relative;
-  overflow: hidden;
-}
-
-.date  {
-  + div {
-    border: none !important;
-    position: absolute;
-    top: 0;
-    background-color: transparent !important;
-
-    :nth-child(1) {
-      padding: 4px;
-      padding-top: 1px;
-      padding-bottom: 1px;
-      background-color: white;
-  
-      span  {
-        display: block;
-        text-overflow: ellipsis;
-        overflow: hidden;
-        width: 78%;
-      }
-    }
-  }
-}
-
-.historyButton {
-  margin-right: .5rem;
-  padding: 0;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  background: none;
-  border: none;
-  cursor: pointer;
-}
-
-
 .notificationMessage, .notificationError {
   @include animation('fade-in 0.2s ease-out');
   position: absolute;

--- a/src/dashboard/Data/Browser/Browser.scss
+++ b/src/dashboard/Data/Browser/Browser.scss
@@ -143,7 +143,7 @@ body:global(.expanded) {
 
 .history {
   max-width: 100%;
-  max-height: 150px;
+  max-height: 200px;
   padding: .5rem;
   overflow-x: hidden;
   overflow-y: auto;
@@ -151,11 +151,33 @@ body:global(.expanded) {
   flex-direction: column;
   gap: .5rem;
 
-  span {
-    display: block;
-    overflow: hidden;
-    text-overflow: ellipsis;
+  button {
+    padding-left: 5px;
+    padding-right: 5px;
   }
+
+  .entry {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    align-items: center;
+    width: 100%;
+  }
+  
+  .entry div {
+    display: flex;
+  }
+}
+
+.historyButton {
+  margin-right: .5rem;
+  padding: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: none;
+  border: none;
+  cursor: pointer;
 }
 
 

--- a/src/dashboard/Data/Browser/Browser.scss
+++ b/src/dashboard/Data/Browser/Browser.scss
@@ -142,11 +142,22 @@ body:global(.expanded) {
 }
 
 .history {
-  display: flex;
-  flex-wrap: wrap;
+  max-width: 100%;
+  max-height: 150px;
   padding: .5rem;
+  overflow-x: hidden;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
   gap: .5rem;
+
+  span {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }
+
 
 .notificationMessage, .notificationError {
   @include animation('fade-in 0.2s ease-out');

--- a/src/dashboard/Data/Browser/Browser.scss
+++ b/src/dashboard/Data/Browser/Browser.scss
@@ -141,31 +141,31 @@ body:global(.expanded) {
   }
 }
 
-.history {
-  max-width: 100%;
-  max-height: 200px;
-  padding: .5rem;
-  overflow-x: hidden;
-  overflow-y: auto;
-  display: flex;
-  flex-direction: column;
-  gap: .5rem;
+.option {
+  position: relative;
+  overflow: hidden;
+}
 
-  button {
-    padding-left: 5px;
-    padding-right: 5px;
-  }
+.date  {
+  + div {
+    border: none !important;
+    position: absolute;
+    top: 0;
+    background-color: transparent !important;
 
-  .entry {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    align-items: center;
-    width: 100%;
-  }
+    :nth-child(1) {
+      padding: 4px;
+      padding-top: 1px;
+      padding-bottom: 1px;
+      background-color: white;
   
-  .entry div {
-    display: flex;
+      span  {
+        display: block;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        width: 78%;
+      }
+    }
   }
 }
 

--- a/src/dashboard/Data/Config/Config.react.js
+++ b/src/dashboard/Data/Config/Config.react.js
@@ -252,6 +252,18 @@ class Config extends TableView {
       .then(
         () => {
           this.setState({ modalOpen: false });
+          const configHistory = localStorage.getItem('configHistory')
+          if(!configHistory) {
+            localStorage.setItem('configHistory', JSON.stringify({
+              [name]: [value]
+            }));
+          } else {
+            const history = JSON.parse(configHistory)
+            localStorage.setItem('configHistory', JSON.stringify({
+              ...history,
+              [name]: !history[name] ? [value] : [value, ...history[name]].slice(0, 5)
+            }));
+          }
         },
         () => {
           // Catch the error
@@ -263,6 +275,19 @@ class Config extends TableView {
     this.props.config.dispatch(ActionTypes.DELETE, { param: name }).then(() => {
       this.setState({ showDeleteParameterDialog: false });
     });
+    const configHistory = localStorage.getItem('configHistory')
+    if(configHistory) {
+      const history = JSON.parse(configHistory);
+      if(history[name]) {
+        delete history[name]
+        if(Object.keys(history).length === 0) {
+          localStorage.removeItem('configHistory');
+        }
+        else {
+          localStorage.setItem('configHistory', JSON.stringify(history));
+        }
+      }
+    }
   }
 
   createParameter() {

--- a/src/dashboard/Data/Config/Config.react.js
+++ b/src/dashboard/Data/Config/Config.react.js
@@ -276,7 +276,7 @@ class Config extends TableView {
               ...oldConfigHistory,
               [name]: !oldConfigHistory[name] ?
                 [{time: new Date(), value: transformedValue}]
-                : [{time: new Date(), value: transformedValue}, ...oldConfigHistory[name]].slice(0, limit)
+                : [{time: new Date(), value: transformedValue}, ...oldConfigHistory[name]].slice(0, limit || 100)
             }));
           }
         },

--- a/src/dashboard/Data/Config/Config.react.js
+++ b/src/dashboard/Data/Config/Config.react.js
@@ -254,7 +254,8 @@ class Config extends TableView {
       .then(
         () => {
           this.setState({ modalOpen: false });
-          const limit = this.context.historylimit;
+          const limit = this.context.cloudConfigHistoryLimit;
+          const applicationId = this.context.applicationId;
           let transformedValue = value;
           if(type === 'Date') {
             transformedValue = {__type: 'Date', iso: value};
@@ -262,9 +263,9 @@ class Config extends TableView {
           if(type === 'File') {
             transformedValue = {name: value._name, url: value._url};
           }
-          const configHistory = localStorage.getItem('configHistory');
+          const configHistory = localStorage.getItem(`${applicationId}_configHistory`);
           if(!configHistory) {
-            localStorage.setItem('configHistory', JSON.stringify({
+            localStorage.setItem(`${applicationId}_configHistory`, JSON.stringify({
               [name]: [{
                 time: new Date(),
                 value: transformedValue
@@ -272,7 +273,7 @@ class Config extends TableView {
             }));
           } else {
             const oldConfigHistory = JSON.parse(configHistory);
-            localStorage.setItem('configHistory', JSON.stringify({
+            localStorage.setItem(`${applicationId}_configHistory`, JSON.stringify({
               ...oldConfigHistory,
               [name]: !oldConfigHistory[name] ?
                 [{time: new Date(), value: transformedValue}]

--- a/src/dashboard/Data/Config/Config.react.js
+++ b/src/dashboard/Data/Config/Config.react.js
@@ -20,9 +20,11 @@ import TableHeader from 'components/Table/TableHeader.react';
 import TableView from 'dashboard/TableView.react';
 import Toolbar from 'components/Toolbar/Toolbar.react';
 import browserStyles from 'dashboard/Data/Browser/Browser.scss';
+import { CurrentApp } from 'context/currentApp';
 
 @subscribeTo('Config', 'config')
 class Config extends TableView {
+  static contextType = CurrentApp;
   constructor() {
     super();
     this.section = 'Core';
@@ -252,6 +254,7 @@ class Config extends TableView {
       .then(
         () => {
           this.setState({ modalOpen: false });
+          const limit = this.context.historylimit;
           let transformedValue = value;
           if(type === 'Date') {
             transformedValue = {__type: 'Date', iso: value};
@@ -273,7 +276,7 @@ class Config extends TableView {
               ...oldConfigHistory,
               [name]: !oldConfigHistory[name] ?
                 [{time: new Date(), value: transformedValue}]
-                : [{time: new Date(), value: transformedValue}, ...oldConfigHistory[name]]
+                : [{time: new Date(), value: transformedValue}, ...oldConfigHistory[name]].slice(0, limit)
             }));
           }
         },

--- a/src/dashboard/Data/Config/Config.react.js
+++ b/src/dashboard/Data/Config/Config.react.js
@@ -287,6 +287,15 @@ class Config extends TableView {
     this.props.config.dispatch(ActionTypes.DELETE, { param: name }).then(() => {
       this.setState({ showDeleteParameterDialog: false });
     });
+    const configHistory = localStorage.getItem('configHistory') && JSON.parse(localStorage.getItem('configHistory'));
+    if(configHistory) {
+      delete configHistory[name];
+      if(Object.keys(configHistory).length === 0) {
+        localStorage.removeItem('configHistory');
+      } else {
+        localStorage.setItem('configHistory', JSON.stringify(configHistory));
+      }
+    }
   }
 
   createParameter() {

--- a/src/dashboard/Data/Config/Config.react.js
+++ b/src/dashboard/Data/Config/Config.react.js
@@ -242,7 +242,7 @@ class Config extends TableView {
     return data;
   }
 
-  saveParam({ name, type, value, masterKeyOnly }) {
+  saveParam({ name, value, masterKeyOnly }) {
     this.props.config
       .dispatch(ActionTypes.SET, {
         param: name,
@@ -257,24 +257,15 @@ class Config extends TableView {
 
           if(!configHistory) {
             localStorage.setItem('configHistory', JSON.stringify({
-              [name]: {
-                type,
-                history: [{time: new Date(), value}]
-              }
+              [name]: [{time: new Date(), value}]
             }));
           } else {
-            const oldConfigHistory = JSON.parse(configHistory)
+            const oldConfigHistory = JSON.parse(configHistory);
             localStorage.setItem('configHistory', JSON.stringify({
               ...oldConfigHistory,
               [name]: !oldConfigHistory[name] ?
-                {
-                  type,
-                  history: [{time: new Date(), value}]
-                }
-                : {
-                  ...oldConfigHistory[name],
-                  history: [{time: new Date(), value}, ...oldConfigHistory[name].history]
-                }
+                [{time: new Date(), value}]
+                : [{time: new Date(), value}, ...oldConfigHistory[name]]
             }));
           }
         },
@@ -292,7 +283,7 @@ class Config extends TableView {
     if(configHistory) {
       const history = JSON.parse(configHistory);
       if(history[name]) {
-        delete history[name]
+        delete history[name];
         if(Object.keys(history).length === 0) {
           localStorage.removeItem('configHistory');
         }

--- a/src/dashboard/Data/Config/Config.react.js
+++ b/src/dashboard/Data/Config/Config.react.js
@@ -243,7 +243,6 @@ class Config extends TableView {
   }
 
   saveParam({ name, value, type,  masterKeyOnly }) {
-    console.log('type', type);
     this.props.config
       .dispatch(ActionTypes.SET, {
         param: name,

--- a/src/dashboard/Data/Config/Config.react.js
+++ b/src/dashboard/Data/Config/Config.react.js
@@ -242,7 +242,8 @@ class Config extends TableView {
     return data;
   }
 
-  saveParam({ name, type, value, masterKeyOnly }) {
+  saveParam({ name, value, type,  masterKeyOnly }) {
+    console.log('type', type);
     this.props.config
       .dispatch(ActionTypes.SET, {
         param: name,
@@ -255,20 +256,27 @@ class Config extends TableView {
           if(type === 'File') {
             return;
           }
+          let dateObject;
+          if(type === 'Date') {
+            dateObject = {__type: 'Date', iso: value};
+          }
           const configHistory = localStorage.getItem('configHistory');
           if(!configHistory) {
             localStorage.setItem('configHistory', JSON.stringify({
-              [name]: [{time: new Date(), value}]
+              [name]: [{
+                time: new Date(),
+                value: dateObject ? dateObject : value
+              }]
             }));
           } else {
             const oldConfigHistory = JSON.parse(configHistory);
             localStorage.setItem('configHistory', JSON.stringify({
               ...oldConfigHistory,
               [name]: !oldConfigHistory[name] ?
-                [{time: new Date(), value}]
-                : [{time: new Date(), value}, ...oldConfigHistory[name]]
+                [{time: new Date(), value: dateObject ? dateObject : value}]
+                : [{time: new Date(), value: dateObject ? dateObject : value}, ...oldConfigHistory[name]]
             }));
-          };
+          }
         },
         () => {
           // Catch the error
@@ -280,19 +288,6 @@ class Config extends TableView {
     this.props.config.dispatch(ActionTypes.DELETE, { param: name }).then(() => {
       this.setState({ showDeleteParameterDialog: false });
     });
-    const configHistory = localStorage.getItem('configHistory')
-    if(configHistory) {
-      const history = JSON.parse(configHistory);
-      if(history[name]) {
-        delete history[name];
-        if(Object.keys(history).length === 0) {
-          localStorage.removeItem('configHistory');
-        }
-        else {
-          localStorage.setItem('configHistory', JSON.stringify(history));
-        }
-      }
-    }
   }
 
   createParameter() {

--- a/src/dashboard/Data/Config/Config.react.js
+++ b/src/dashboard/Data/Config/Config.react.js
@@ -242,7 +242,7 @@ class Config extends TableView {
     return data;
   }
 
-  saveParam({ name, value, masterKeyOnly }) {
+  saveParam({ name, type, value, masterKeyOnly }) {
     this.props.config
       .dispatch(ActionTypes.SET, {
         param: name,
@@ -252,16 +252,29 @@ class Config extends TableView {
       .then(
         () => {
           this.setState({ modalOpen: false });
+
           const configHistory = localStorage.getItem('configHistory')
+
           if(!configHistory) {
             localStorage.setItem('configHistory', JSON.stringify({
-              [name]: [value]
+              [name]: {
+                type,
+                history: [{time: new Date(), value}]
+              }
             }));
           } else {
-            const history = JSON.parse(configHistory)
+            const oldConfigHistory = JSON.parse(configHistory)
             localStorage.setItem('configHistory', JSON.stringify({
-              ...history,
-              [name]: !history[name] ? [value] : [value, ...history[name]].slice(0, 10)
+              ...oldConfigHistory,
+              [name]: !oldConfigHistory[name] ?
+                {
+                  type,
+                  history: [{time: new Date(), value}]
+                }
+                : {
+                  ...oldConfigHistory[name],
+                  history: [{time: new Date(), value}, ...oldConfigHistory[name].history]
+                }
             }));
           }
         },

--- a/src/dashboard/Data/Config/Config.react.js
+++ b/src/dashboard/Data/Config/Config.react.js
@@ -242,7 +242,7 @@ class Config extends TableView {
     return data;
   }
 
-  saveParam({ name, value, masterKeyOnly }) {
+  saveParam({ name, type, value, masterKeyOnly }) {
     this.props.config
       .dispatch(ActionTypes.SET, {
         param: name,
@@ -252,9 +252,10 @@ class Config extends TableView {
       .then(
         () => {
           this.setState({ modalOpen: false });
-
-          const configHistory = localStorage.getItem('configHistory')
-
+          if(type === 'File') {
+            return;
+          }
+          const configHistory = localStorage.getItem('configHistory');
           if(!configHistory) {
             localStorage.setItem('configHistory', JSON.stringify({
               [name]: [{time: new Date(), value}]
@@ -267,7 +268,7 @@ class Config extends TableView {
                 [{time: new Date(), value}]
                 : [{time: new Date(), value}, ...oldConfigHistory[name]]
             }));
-          }
+          };
         },
         () => {
           // Catch the error

--- a/src/dashboard/Data/Config/Config.react.js
+++ b/src/dashboard/Data/Config/Config.react.js
@@ -261,7 +261,7 @@ class Config extends TableView {
             const history = JSON.parse(configHistory)
             localStorage.setItem('configHistory', JSON.stringify({
               ...history,
-              [name]: !history[name] ? [value] : [value, ...history[name]].slice(0, 5)
+              [name]: !history[name] ? [value] : [value, ...history[name]].slice(0, 10)
             }));
           }
         },

--- a/src/dashboard/Data/Config/Config.react.js
+++ b/src/dashboard/Data/Config/Config.react.js
@@ -252,19 +252,19 @@ class Config extends TableView {
       .then(
         () => {
           this.setState({ modalOpen: false });
-          if(type === 'File') {
-            return;
-          }
-          let dateObject;
+          let transformedValue = value;
           if(type === 'Date') {
-            dateObject = {__type: 'Date', iso: value};
+            transformedValue = {__type: 'Date', iso: value};
+          }
+          if(type === 'File') {
+            transformedValue = {name: value._name, url: value._url};
           }
           const configHistory = localStorage.getItem('configHistory');
           if(!configHistory) {
             localStorage.setItem('configHistory', JSON.stringify({
               [name]: [{
                 time: new Date(),
-                value: dateObject ? dateObject : value
+                value: transformedValue
               }]
             }));
           } else {
@@ -272,8 +272,8 @@ class Config extends TableView {
             localStorage.setItem('configHistory', JSON.stringify({
               ...oldConfigHistory,
               [name]: !oldConfigHistory[name] ?
-                [{time: new Date(), value: dateObject ? dateObject : value}]
-                : [{time: new Date(), value: dateObject ? dateObject : value}, ...oldConfigHistory[name]]
+                [{time: new Date(), value: transformedValue}]
+                : [{time: new Date(), value: transformedValue}, ...oldConfigHistory[name]]
             }));
           }
         },

--- a/src/dashboard/Data/Config/ConfigDialog.react.js
+++ b/src/dashboard/Data/Config/ConfigDialog.react.js
@@ -17,6 +17,7 @@ import Parse from 'parse';
 import React from 'react';
 import TextInput from 'components/TextInput/TextInput.react';
 import Toggle from 'components/Toggle/Toggle.react';
+import Button from 'components/Button/Button.react';
 import validateNumeric from 'lib/validateNumeric';
 import styles from 'dashboard/Data/Browser/Browser.scss';
 import semver from 'semver/preload.js';
@@ -190,6 +191,9 @@ export default class ConfigDialog extends React.Component {
         ))}
       </Dropdown>
     );
+    const configHistory = localStorage.getItem('configHistory')
+    const history = configHistory && JSON.parse(configHistory)[this.state.name]
+
     return (
       <Modal
         type={Modal.Types.INFO}
@@ -252,6 +256,30 @@ export default class ConfigDialog extends React.Component {
                 className={styles.addColumnToggleWrapper}
               />
             ) : null
+        }
+        {
+          !newParam && history &&
+          <Field
+            label={
+              <Label
+                text="Previous values"
+                description="Previously selected values. Click on a value to apply."
+              />
+            }
+            input={
+              <div className={styles.history}>
+                {history.slice(1).map((value, i) =>
+                  <Button
+                    key={i}
+                    primary
+                    value={value}
+                    onClick={()=> this.setState({ value })}
+                  />
+                )}
+              </div>
+            }
+            className={styles.addColumnToggleWrapper}
+          />
         }
       </Modal>
     );

--- a/src/dashboard/Data/Config/ConfigDialog.react.js
+++ b/src/dashboard/Data/Config/ConfigDialog.react.js
@@ -282,7 +282,7 @@ export default class ConfigDialog extends React.Component {
             }
             input={
               <Dropdown
-                value={JSON.stringify(history[1].value)}
+                value={this.state.value}
                 onChange={value => this.setState({ value })}>
                 {history.slice(1).map((value, i) =>
                   <Option key={i} value={JSON.stringify(value.value)}>

--- a/src/dashboard/Data/Config/ConfigDialog.react.js
+++ b/src/dashboard/Data/Config/ConfigDialog.react.js
@@ -200,6 +200,16 @@ export default class ConfigDialog extends React.Component {
         return;
       }
       let value = configHistory[index].value;
+      if(this.state.type === 'File'){
+        const fileJSON = {
+          __type: 'File',
+          name: value.name,
+          url: value.url
+        };
+        const file = Parse.File.fromJSON(fileJSON);
+        this.setState({ selectedIndex: index, value: file });
+        return;
+      }
       if(typeof value === 'object'){
         value = JSON.stringify(value);
       }

--- a/src/dashboard/Data/Config/ConfigDialog.react.js
+++ b/src/dashboard/Data/Config/ConfigDialog.react.js
@@ -279,12 +279,15 @@ export default class ConfigDialog extends React.Component {
               <Dropdown
                 value={this.state.selectedIndex}
                 onChange={value => {
+                  if(this.state.type === 'Date'){
+                    return;
+                  }
                   let val = configHistory[value].value;
                   if(typeof val === 'object'){
                     val = JSON.stringify(val);
                   }
                   this.setState({ selectedIndex: value, value : val });
-              }}>
+                }}>
                 {configHistory.map((value, i) =>
                   <Option key={i} value={i}>
                     {new Intl.DateTimeFormat('en-GB', dateOptions).format(new Date(value.time))}

--- a/src/dashboard/Data/Config/ConfigDialog.react.js
+++ b/src/dashboard/Data/Config/ConfigDialog.react.js
@@ -17,8 +17,7 @@ import Parse from 'parse';
 import React from 'react';
 import TextInput from 'components/TextInput/TextInput.react';
 import Toggle from 'components/Toggle/Toggle.react';
-import Button from 'components/Button/Button.react';
-import Icon from 'components/Icon/Icon.react';
+import Tooltip from 'components/Tooltip/Tooltip.react';
 import validateNumeric from 'lib/validateNumeric';
 import styles from 'dashboard/Data/Browser/Browser.scss';
 import semver from 'semver/preload.js';
@@ -282,28 +281,19 @@ export default class ConfigDialog extends React.Component {
               />
             }
             input={
-              <div className={styles.history}>
+              <Dropdown
+                value={JSON.stringify(history[1].value)}
+                onChange={value => this.setState({ value })}>
                 {history.slice(1).map((value, i) =>
-                  <div key={i} className={styles.entry}>
-                    <div>
-                      <button
-                        className={styles.historyButton}
-                        onClick={() => i !== this.state.selectedIndex ?
-                          this.setState({ selectedIndex: i })
-                          : this.setState({ selectedIndex: null })
-                      }>
-                        <Icon name="question-solid" width={20} height={20} fill="rgba(0,0,0,0.4)" />
-                      </button>
-                      <Button
-                        key={i}
-                        value={new Intl.DateTimeFormat('en-GB', dateOptions).format(new Date(value.time))}
-                        onClick={()=> this.setState({ value: JSON.stringify(value.value) })}
-                      />
+                  <Option key={i} value={JSON.stringify(value.value)}>
+                    <div className={styles.option}>
+                      <Tooltip value={<span>{JSON.stringify(value.value)}</span>}>
+                        <span className={styles.date}>{new Intl.DateTimeFormat('en-GB', dateOptions).format(new Date(value.time))}</span>
+                      </Tooltip>
                     </div>
-                    {i === this.state.selectedIndex && EDITORS[type](JSON.stringify(value.value))}
-                  </div>
+                  </Option>
                 )}
-              </div>
+              </Dropdown>
             }
             className={styles.addColumnToggleWrapper}
           />

--- a/src/dashboard/Data/Config/ConfigDialog.react.js
+++ b/src/dashboard/Data/Config/ConfigDialog.react.js
@@ -89,16 +89,6 @@ const GET_VALUE = {
   File: value => value,
 };
 
-const dateOptions = {
-  weekday: 'short',
-  day: 'numeric',
-  month: 'short',
-  year: 'numeric',
-  hour: 'numeric',
-  minute: '2-digit',
-  hour12: true,
-}
-
 export default class ConfigDialog extends React.Component {
   constructor(props) {
     super();
@@ -200,7 +190,15 @@ export default class ConfigDialog extends React.Component {
         ))}
       </Dropdown>
     );
-
+    const dateOptions = {
+      weekday: 'short',
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    };
     const configHistory = localStorage.getItem('configHistory') && JSON.parse(localStorage.getItem('configHistory'))[this.state.name];
 
     return (

--- a/src/dashboard/Data/Config/ConfigDialog.react.js
+++ b/src/dashboard/Data/Config/ConfigDialog.react.js
@@ -199,9 +199,10 @@ export default class ConfigDialog extends React.Component {
       year: 'numeric',
       hour: 'numeric',
       minute: '2-digit',
+      second: '2-digit',
       hour12: true,
     };
-    const configHistory = localStorage.getItem('configHistory') && JSON.parse(localStorage.getItem('configHistory'))[this.state.name];
+    const configHistory = localStorage.getItem('configHistory') && JSON.parse(localStorage.getItem('configHistory'))[this.state.name]?.slice(1);
 
     return (
       <Modal

--- a/src/dashboard/Data/Config/ConfigDialog.react.js
+++ b/src/dashboard/Data/Config/ConfigDialog.react.js
@@ -21,6 +21,7 @@ import validateNumeric from 'lib/validateNumeric';
 import styles from 'dashboard/Data/Browser/Browser.scss';
 import semver from 'semver/preload.js';
 import { dateStringUTC } from 'lib/DateUtils';
+import { CurrentApp } from 'context/currentApp';
 
 const PARAM_TYPES = ['Boolean', 'String', 'Number', 'Date', 'Object', 'Array', 'GeoPoint', 'File'];
 
@@ -91,6 +92,7 @@ const GET_VALUE = {
 };
 
 export default class ConfigDialog extends React.Component {
+  static contextType = CurrentApp;
   constructor(props) {
     super();
     this.state = {
@@ -194,7 +196,7 @@ export default class ConfigDialog extends React.Component {
         ))}
       </Dropdown>
     );
-    const configHistory = localStorage.getItem('configHistory') && JSON.parse(localStorage.getItem('configHistory'))[this.state.name];
+    const configHistory = localStorage.getItem(`${this.context.applicationId}_configHistory`) && JSON.parse(localStorage.getItem(`${this.context.applicationId}_configHistory`))[this.state.name];
     const handleIndexChange = index => {
       if(this.state.type === 'Date'){
         return;

--- a/src/dashboard/Data/Config/ConfigDialog.react.js
+++ b/src/dashboard/Data/Config/ConfigDialog.react.js
@@ -272,8 +272,8 @@ export default class ConfigDialog extends React.Component {
                   <Button
                     key={i}
                     primary
-                    value={value}
-                    onClick={()=> this.setState({ value })}
+                    value={JSON.stringify(value)}
+                    onClick={()=> this.setState({ value: JSON.stringify(value) })}
                   />
                 )}
               </div>

--- a/src/dashboard/Data/Config/ConfigDialog.react.js
+++ b/src/dashboard/Data/Config/ConfigDialog.react.js
@@ -97,6 +97,7 @@ export default class ConfigDialog extends React.Component {
       type: 'String',
       name: '',
       masterKeyOnly: false,
+      selectedIndex: -1,
     };
     if (props.param.length > 0) {
       this.state = {
@@ -169,6 +170,7 @@ export default class ConfigDialog extends React.Component {
   submit() {
     this.props.onConfirm({
       name: this.state.name,
+      type: this.state.type,
       value: GET_VALUE[this.state.type](this.state.value),
       masterKeyOnly: this.state.masterKeyOnly,
     });
@@ -275,10 +277,16 @@ export default class ConfigDialog extends React.Component {
             }
             input={
               <Dropdown
-                value={this.state.value}
-                onChange={value => this.setState({ value })}>
+                value={this.state.selectedIndex}
+                onChange={value => {
+                  let val = configHistory[value].value;
+                  if(typeof val === 'object'){
+                    val = JSON.stringify(val);
+                  }
+                  this.setState({ selectedIndex: value, value : val });
+              }}>
                 {configHistory.map((value, i) =>
-                  <Option key={i} value={typeof value.value === 'string' ? value.value : JSON.stringify(value.value)}>
+                  <Option key={i} value={i}>
                     {new Intl.DateTimeFormat('en-GB', dateOptions).format(new Date(value.time))}
                   </Option>
                 )}

--- a/src/dashboard/Data/Config/ConfigDialog.react.js
+++ b/src/dashboard/Data/Config/ConfigDialog.react.js
@@ -17,7 +17,6 @@ import Parse from 'parse';
 import React from 'react';
 import TextInput from 'components/TextInput/TextInput.react';
 import Toggle from 'components/Toggle/Toggle.react';
-import Tooltip from 'components/Tooltip/Tooltip.react';
 import validateNumeric from 'lib/validateNumeric';
 import styles from 'dashboard/Data/Browser/Browser.scss';
 import semver from 'semver/preload.js';
@@ -204,9 +203,7 @@ export default class ConfigDialog extends React.Component {
       </Dropdown>
     );
 
-    const configHistory = localStorage.getItem('configHistory')
-    const type = configHistory && JSON.parse(configHistory)[this.state.name]?.type
-    const history = configHistory && JSON.parse(configHistory)[this.state.name]?.history
+    const configHistory = localStorage.getItem('configHistory') && JSON.parse(localStorage.getItem('configHistory'))[this.state.name];
 
     return (
       <Modal
@@ -272,7 +269,7 @@ export default class ConfigDialog extends React.Component {
             ) : null
         }
         {
-          !newParam && history && history.length > 1 &&
+          !newParam && configHistory?.length > 0 &&
           <Field
             label={
               <Label
@@ -284,13 +281,9 @@ export default class ConfigDialog extends React.Component {
               <Dropdown
                 value={this.state.value}
                 onChange={value => this.setState({ value })}>
-                {history.slice(1).map((value, i) =>
-                  <Option key={i} value={JSON.stringify(value.value)}>
-                    <div className={styles.option}>
-                      <Tooltip value={<span>{JSON.stringify(value.value)}</span>}>
-                        <span className={styles.date}>{new Intl.DateTimeFormat('en-GB', dateOptions).format(new Date(value.time))}</span>
-                      </Tooltip>
-                    </div>
+                {configHistory.map((value, i) =>
+                  <Option key={i} value={typeof value.value === 'string' ? value.value : JSON.stringify(value.value)}>
+                    {new Intl.DateTimeFormat('en-GB', dateOptions).format(new Date(value.time))}
                   </Option>
                 )}
               </Dropdown>

--- a/src/dashboard/Data/Config/ConfigDialog.react.js
+++ b/src/dashboard/Data/Config/ConfigDialog.react.js
@@ -107,7 +107,6 @@ export default class ConfigDialog extends React.Component {
       type: 'String',
       name: '',
       masterKeyOnly: false,
-      selectedIndex: null,
     };
     if (props.param.length > 0) {
       this.state = {
@@ -180,7 +179,6 @@ export default class ConfigDialog extends React.Component {
   submit() {
     this.props.onConfirm({
       name: this.state.name,
-      type: this.state.type,
       value: GET_VALUE[this.state.type](this.state.value),
       masterKeyOnly: this.state.masterKeyOnly,
     });
@@ -269,7 +267,7 @@ export default class ConfigDialog extends React.Component {
             ) : null
         }
         {
-          !newParam && configHistory?.length > 0 &&
+          configHistory?.length > 0 &&
           <Field
             label={
               <Label

--- a/src/lib/ParseApp.js
+++ b/src/lib/ParseApp.js
@@ -49,7 +49,7 @@ export default class ParseApp {
     scripts,
     classPreference,
     enableSecurityChecks,
-    historylimit
+    cloudConfigHistoryLimit
   }) {
     this.name = appName;
     this.createdAt = created_at ? new Date(created_at) : new Date();
@@ -78,7 +78,7 @@ export default class ParseApp {
     this.columnPreference = columnPreference;
     this.scripts = scripts;
     this.enableSecurityChecks = !!enableSecurityChecks;
-    this.historylimit = historylimit;
+    this.cloudConfigHistoryLimit = cloudConfigHistoryLimit;
 
     if (!supportedPushLocales) {
       console.warn(

--- a/src/lib/ParseApp.js
+++ b/src/lib/ParseApp.js
@@ -48,7 +48,8 @@ export default class ParseApp {
     columnPreference,
     scripts,
     classPreference,
-    enableSecurityChecks
+    enableSecurityChecks,
+    historylimit
   }) {
     this.name = appName;
     this.createdAt = created_at ? new Date(created_at) : new Date();
@@ -77,6 +78,7 @@ export default class ParseApp {
     this.columnPreference = columnPreference;
     this.scripts = scripts;
     this.enableSecurityChecks = !!enableSecurityChecks;
+    this.historylimit = historylimit;
 
     if (!supportedPushLocales) {
       console.warn(


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [ ] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Adds recent config history using localstorage for better undo functionality


Closes: #2339 

### Approach
<!-- Add a description of the approach in this PR. -->
Every time the user updates a value in the config, it is saved to localstorage under the key `configHistory` .
For each parameter in the config, an array of values is stored in descending order to show the latest value first.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
