### PR TITLE
refactor: Move some dependencies to dev-dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "prop-types": "15.8.1",
         "qrcode": "1.5.1",
         "react": "16.14.0",
-        "react-ace": "10.1.0",
+        "react-ace": "11.0.1",
         "react-dnd": "10.0.2",
         "react-dnd-html5-backend": "10.0.2",
         "react-dom": "16.14.0",
@@ -43,9 +43,7 @@
         "react-json-view": "1.21.3",
         "react-popper-tooltip": "4.4.2",
         "react-router-dom": "6.4.1",
-        "regenerator-runtime": "0.13.11",
-        "semver": "7.5.2",
-        "typescript": "4.8.3"
+        "regenerator-runtime": "0.13.11"
       },
       "bin": {
         "parse-dashboard": "bin/parse-dashboard"
@@ -87,8 +85,10 @@
         "sass": "1.58.1",
         "sass-loader": "13.2.0",
         "semantic-release": "17.4.6",
+        "semver": "7.5.2",
         "style-loader": "3.3.1",
         "svg-prep": "1.0.4",
+        "typescript": "4.8.3",
         "webpack": "5.75.0",
         "webpack-cli": "5.0.1",
         "yaml": "1.10.0"
@@ -6583,9 +6583,9 @@
       }
     },
     "node_modules/ace-builds": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.5.0.tgz",
-      "integrity": "sha512-1BtEfIhFl/VDNRS9R1m9F8Kmeh2uJ98CxTeBE0kBjJpv5S5N2buTVWtc1BGXL9AromN7ekBjaEBaUl+ZPn4ciA=="
+      "version": "1.34.2",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.34.2.tgz",
+      "integrity": "sha512-wiOZYuxyOSYfZzDasQTe+ZWmRlYxXSJM/kMKZ/bSqO1VgrBl+PaaTz/Sc+y7hXCKAUj3syUdpwxQyvwv9vQe6w=="
     },
     "node_modules/acorn": {
       "version": "8.8.0",
@@ -17210,6 +17210,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/npm/node_modules/http-cache-semantics": {
+      "version": "4.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/npm/node_modules/http-proxy-agent": {
       "version": "4.0.1",
       "dev": true,
@@ -17716,9 +17722,7 @@
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -18328,9 +18332,7 @@
       }
     },
     "node_modules/npm/node_modules/qs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+      "version": "6.5.2",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -20392,15 +20394,15 @@
       }
     },
     "node_modules/react-ace": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-10.1.0.tgz",
-      "integrity": "sha512-VkvUjZNhdYTuKOKQpMIZi7uzZZVgzCjM7cLYu6F64V0mejY8a2XTyPUIMszC6A4trbeMIHbK5fYFcT/wkP/8VA==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-11.0.1.tgz",
+      "integrity": "sha512-ulk2851Fx2j59AAahZHTe7rmQ5bITW1xytskAt11F8dv3rPLtdwBXCyT2qSbRnJvOq8UpuAhWO4/JhKGqQBEDA==",
       "dependencies": {
-        "ace-builds": "^1.4.14",
+        "ace-builds": "^1.32.8",
         "diff-match-patch": "^1.0.5",
         "lodash.get": "^4.4.2",
         "lodash.isequal": "^4.5.0",
-        "prop-types": "^15.7.2"
+        "prop-types": "^15.8.1"
       },
       "peerDependencies": {
         "react": "^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0",
@@ -22857,6 +22859,7 @@
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
       "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "prop-types": "15.8.1",
     "qrcode": "1.5.1",
     "react": "16.14.0",
-    "react-ace": "10.1.0",
+    "react-ace": "11.0.1",
     "react-dnd": "10.0.2",
     "react-dnd-html5-backend": "10.0.2",
     "react-dom": "16.14.0",
@@ -69,9 +69,7 @@
     "react-json-view": "1.21.3",
     "react-popper-tooltip": "4.4.2",
     "react-router-dom": "6.4.1",
-    "regenerator-runtime": "0.13.11",
-    "semver": "7.5.2",
-    "typescript": "4.8.3"
+    "regenerator-runtime": "0.13.11"
   },
   "devDependencies": {
     "@actions/core": "1.9.1",
@@ -110,8 +108,10 @@
     "sass": "1.58.1",
     "sass-loader": "13.2.0",
     "semantic-release": "17.4.6",
+    "semver": "7.5.2",
     "style-loader": "3.3.1",
     "svg-prep": "1.0.4",
+    "typescript": "4.8.3",
     "webpack": "5.75.0",
     "webpack-cli": "5.0.1",
     "yaml": "1.10.0"


### PR DESCRIPTION
### New Pull Request Checklist

- [X] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [X] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues/2570).

### Issue Description

Clear some deps (typescript, semver, react-ace), and update react-ace that had a big size (changelog of the updated version : https://github.com/securingsincity/react-ace/releases/tag/v11.0.0)

Closes: https://github.com/parse-community/parse-dashboard/issues/2570
