### PR TITLE
fix: Crash after setting filter using context menu and opening filters panel

### DIFF
--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -506,7 +506,7 @@ export default class BrowserCell extends Component {
 
   pickFilter(constraint, addToExistingFilter) {
     const definition = Filters.Constraints[constraint];
-    const { filters, type, value, field } = this.props;
+    const { filters, type, value, field, className } = this.props;
     const newFilters = addToExistingFilter ? filters : new List();
     let compareTo;
     if (definition.comparable) {
@@ -535,6 +535,7 @@ export default class BrowserCell extends Component {
           field,
           constraint,
           compareTo,
+          class: className
         })
       )
     );

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -310,7 +310,12 @@ class Browser extends DashboardView {
     const query = new URLSearchParams(props.location.search);
     if (query.has('filters')) {
       const queryFilters = JSON.parse(query.get('filters'));
-      queryFilters.forEach(filter => (filters = filters.push(new Map(filter))));
+      queryFilters.forEach(
+        filter =>
+          (filters = filters.push(
+            new Map({ ...filter, class: filter.class || props.params.className })
+          ))
+      );
     }
     return filters;
   }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues/2578).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Fixes: https://github.com/parse-community/parse-dashboard/issues/2578

### Approach
Seems that filter now have additional property: `class`. When setting filter using context menu this property was not provided. This was causing an issue when binding filters. I did following:
1. Setting 'class' on filter when using context menu filters
2. In addition, when parsing filters from query strings, setting `class` if it's missing; this should provide some backward compatibility  

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->