### PR TITLE
fix: Descriptive statistics for number cells in data browser not showing

### DIFF
--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -1834,7 +1834,7 @@ class Browser extends DashboardView {
   }
 
   onMouseUpRowCheckBox() {
-    this.setState({
+    this.state.rowCheckboxDragging && this.setState({
       rowCheckboxDragging: false,
       draggedRowSelection: false,
     });
@@ -1961,7 +1961,6 @@ class Browser extends DashboardView {
             setRelation={this.setRelation}
             onAddColumn={this.showAddColumn}
             onAddRow={this.addRow}
-            onAbortAddRow={this.abortAddRow}
             onAddRowWithModal={this.addRowWithModal}
             onAddClass={this.showCreateClass}
             showNote={this.showNote}


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues/2574).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

As described here: https://github.com/parse-community/parse-dashboard/issues/2574
Broken by: https://github.com/parse-community/parse-dashboard/pull/2548
Closes: #2574

### Approach
For some reason setting the state in `Browser.onMouseUpRowCheckBox` function (which is executed on every mouse up event) results in `DataBrowser.componentWillReceiveProps` call, where cells selection is wiped.
I have not managed to find out why, so I changed the logic to set the state only if dragging actually started.


### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->
n/a
