### PR TITLE
fix: Node 22 support missing in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "parse-dashboard": "./bin/parse-dashboard"
   },
   "engines": {
-    "node": ">=18.0.0 <21"
+    "node": ">=18.0.0 <21||22"
   },
   "main": "Parse-Dashboard/app.js",
   "jest": {

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "parse-dashboard": "./bin/parse-dashboard"
   },
   "engines": {
-    "node": ">=18.0.0 <21||22"
+    "node": ">=18.0.0 <21 || >=22.9.0 <23"
   },
   "main": "Parse-Dashboard/app.js",
   "jest": {


### PR DESCRIPTION
include 22

### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Closes: https://github.com/parse-community/parse-dashboard/issues/2614

### Approach
<!-- Add a description of the approach in this PR. -->

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->
