### PR TITLE
TimeZone Toggle Feature for Date Display

### DIFF
--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -7,7 +7,7 @@
  */
 import * as Filters from 'lib/Filters';
 import { List, Map } from 'immutable';
-import { dateStringUTC } from 'lib/DateUtils';
+import { yearMonthDayTimeFormatter } from 'lib/DateUtils';
 import getFileName from 'lib/getFileName';
 import Parse from 'parse';
 import Pill from 'components/Pill/Pill.react';
@@ -152,7 +152,11 @@ export default class BrowserCell extends Component {
       } else if (typeof value === 'string') {
         this.props.value = new Date(this.props.value);
       }
-      this.copyableValue = content = dateStringUTC(this.props.value);
+      if (this.props.useLocalTime) {
+        this.copyableValue = content = yearMonthDayTimeFormatter(this.props.value, false);
+      } else {
+        this.copyableValue = content = this.props.value.toISOString();
+      }
     } else if (this.props.type === 'Boolean') {
       this.copyableValue = content = this.props.value ? 'True' : 'False';
     } else if (this.props.type === 'Object' || this.props.type === 'Bytes') {
@@ -221,6 +225,9 @@ export default class BrowserCell extends Component {
       this.props.value?._previousSave
         ?.then(() => this.renderCellContent())
         ?.catch(err => console.log(err));
+    }
+    if (this.props.useLocalTime !== prevProps.useLocalTime && this.props.type === 'Date') {
+      this.renderCellContent();
     }
     if (this.props.current) {
       if (prevProps.selectedCells === this.props.selectedCells) {

--- a/src/components/BrowserRow/BrowserRow.react.js
+++ b/src/components/BrowserRow/BrowserRow.react.js
@@ -1,6 +1,7 @@
 import Parse from 'parse';
 import encode from 'parse/lib/browser/encode';
 import React, { Component } from 'react';
+import { formatDateTime } from 'lib/DateUtils';
 
 import BrowserCell from 'components/BrowserCell/BrowserCell.react';
 import styles from 'dashboard/Data/Browser/Browser.scss';
@@ -17,6 +18,18 @@ export default class BrowserRow extends Component {
     const { obj: nextObj } = nextProps;
     const isRefDifferent = obj !== nextObj;
     return isRefDifferent ? JSON.stringify(obj) !== JSON.stringify(nextObj) : isRefDifferent;
+  }
+
+  renderField(name, type, value, targetClass) {
+    if (!value) {
+      return '';
+    }
+    
+    switch(type) {
+      case 'Date':
+        return formatDateTime(value, this.props.useLocalTime);
+      // ... 其他 case
+    }
   }
 
   render() {
@@ -159,6 +172,7 @@ export default class BrowserRow extends Component {
               setShowAggregatedData={this.props.setShowAggregatedData}
               setErrorAggregatedData={this.props.setErrorAggregatedData}
               firstSelectedCell={this.props.firstSelectedCell}
+              useLocalTime={this.props.useLocalTime}
             />
           );
         })}

--- a/src/components/BrowserRow/BrowserRow.react.js
+++ b/src/components/BrowserRow/BrowserRow.react.js
@@ -28,7 +28,7 @@ export default class BrowserRow extends Component {
     switch(type) {
       case 'Date':
         return formatDateTime(value, this.props.useLocalTime);
-      // ... 其他 case
+      // ... other cases
     }
   }
 

--- a/src/components/DateTimeEditor/DateTimeEditor.react.js
+++ b/src/components/DateTimeEditor/DateTimeEditor.react.js
@@ -9,42 +9,23 @@ import DateTimePicker from 'components/DateTimePicker/DateTimePicker.react';
 import hasAncestor from 'lib/hasAncestor';
 import React from 'react';
 import styles from 'components/DateTimeEditor/DateTimeEditor.scss';
+import { yearMonthDayTimeFormatter } from 'lib/DateUtils';
 
 export default class DateTimeEditor extends React.Component {
   constructor(props) {
-    super();
-
+    super(props);
     this.state = {
-      open: false,
-      position: null,
       value: props.value,
       text: props.value.toISOString(),
+      open: false
     };
-
-    this.checkExternalClick = this.checkExternalClick.bind(this);
-    this.handleKey = this.handleKey.bind(this);
-    this.inputRef = React.createRef();
     this.editorRef = React.createRef();
-  }
-
-  componentWillReceiveProps(props) {
-    this.setState({ value: props.value, text: props.value.toISOString() });
+    this.inputRef = React.createRef();
   }
 
   componentDidMount() {
-    document.body.addEventListener('click', this.checkExternalClick);
-    this.inputRef.current.addEventListener('keypress', this.handleKey);
-  }
-
-  componentWillUnmount() {
-    document.body.removeEventListener('click', this.checkExternalClick);
-    this.inputRef.current.removeEventListener('keypress', this.handleKey);
-  }
-
-  checkExternalClick(e) {
-    if (!hasAncestor(e.target, this.editorRef.current)) {
-      this.props.onCommit(this.state.value);
-    }
+    this.inputRef.current.focus();
+    this.inputRef.current.select();
   }
 
   handleKey(e) {
@@ -70,25 +51,21 @@ export default class DateTimeEditor extends React.Component {
     if (isNaN(date.getTime())) {
       this.setState({
         value: this.props.value,
-        text: this.props.value.toISOString(),
+        text: this.props.value.toISOString()
       });
     } else {
-      if (this.state.text.endsWith('Z')) {
-        this.setState({ value: date });
-      } else {
-        const utc = new Date(
-          Date.UTC(
-            date.getFullYear(),
-            date.getMonth(),
-            date.getDate(),
-            date.getHours(),
-            date.getMinutes(),
-            date.getSeconds(),
-            date.getMilliseconds()
-          )
-        );
-        this.setState({ value: utc });
-      }
+      const utc = new Date(
+        Date.UTC(
+          date.getFullYear(),
+          date.getMonth(),
+          date.getDate(),
+          date.getHours(),
+          date.getMinutes(),
+          date.getSeconds(),
+          date.getMilliseconds()
+        )
+      );
+      this.setState({ value: utc });
     }
   }
 
@@ -100,10 +77,11 @@ export default class DateTimeEditor extends React.Component {
           <DateTimePicker
             value={this.state.value}
             width={240}
-            onChange={value => this.setState({ value: value, text: value.toISOString() })}
-            close={() =>
-              this.setState({ open: false }, () => this.props.onCommit(this.state.value))
-            }
+            local={false}
+            onChange={value => this.setState({ value, text: value.toISOString() })}
+            close={() => {
+              this.setState({ open: false }, () => this.props.onCommit(this.state.value));
+            }}
           />
         </div>
       );
@@ -120,6 +98,7 @@ export default class DateTimeEditor extends React.Component {
           onClick={this.toggle.bind(this)}
           onChange={this.inputDate.bind(this)}
           onBlur={this.commitDate.bind(this)}
+          onKeyDown={this.handleKey.bind(this)}
         />
         {popover}
       </div>

--- a/src/components/TimeZoneToggle/TimeZoneToggle.react.js
+++ b/src/components/TimeZoneToggle/TimeZoneToggle.react.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import styles from './TimeZoneToggle.scss';
+
+const TimeZoneToggle = ({ value, onChange }) => {
+  const switchStyle = {
+    backgroundColor: value ? 'rgb(0, 219, 124)' : 'rgb(204, 204, 204)',
+    transition: 'background-color 0.15s ease-out'
+  };
+
+  return (
+    <div className={styles.container} onClick={() => onChange(!value)}>
+      <div className={`${styles.switch} ${value ? styles.right : styles.left}`} style={switchStyle}>
+        <span className={styles.option}>{value ? 'Local' : 'UTC'}</span>
+        <span className={styles.slider} />
+      </div>
+    </div>
+  );
+};
+
+export default TimeZoneToggle; 

--- a/src/components/TimeZoneToggle/TimeZoneToggle.scss
+++ b/src/components/TimeZoneToggle/TimeZoneToggle.scss
@@ -1,0 +1,49 @@
+.container {
+  display: inline-block;
+  cursor: pointer;
+  height: 30px;
+  line-height: 30px;
+}
+
+.switch {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 50px;
+  height: 18px;
+  border-radius: 12px;
+  margin: 6px 8px 0 8px;
+}
+
+.option {
+  position: absolute;
+  width: 30px;
+  text-align: center;
+  color: white;
+  font-size: 10px;
+  z-index: 1;
+  line-height: 18px;
+}
+
+.left .option {
+  left: 18px;
+}
+
+.right .option {
+  left: 2px;
+}
+
+.slider {
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  background: white;
+  border-radius: 50%;
+  left: 2px;
+  transition: transform 0.15s ease-out;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+.right .slider {
+  transform: translateX(30px);
+}

--- a/src/components/TimeZoneToggle/TimeZoneToggle.test.js
+++ b/src/components/TimeZoneToggle/TimeZoneToggle.test.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import TimeZoneToggle from '../TimeZoneToggle.react';
+
+describe('TimeZoneToggle', () => {
+  it('should render UTC text when value is false', () => {
+    const wrapper = mount(<TimeZoneToggle value={false} onChange={() => {}} />);
+    expect(wrapper.find('.option').text()).toBe('UTC');
+    expect(wrapper.find('.switch').hasClass('left')).toBe(true);
+  });
+
+  it('should render Local text when value is true', () => {
+    const wrapper = mount(<TimeZoneToggle value={true} onChange={() => {}} />);
+    expect(wrapper.find('.option').text()).toBe('Local');
+    expect(wrapper.find('.switch').hasClass('right')).toBe(true);
+  });
+
+  it('should call onChange with opposite value when clicked', () => {
+    const onChange = jest.fn();
+    const wrapper = mount(<TimeZoneToggle value={false} onChange={onChange} />);
+    
+    wrapper.find('.container').simulate('click');
+    expect(onChange).toHaveBeenCalledWith(true);
+
+    wrapper.setProps({ value: true });
+    wrapper.find('.container').simulate('click');
+    expect(onChange).toHaveBeenCalledWith(false);
+  });
+
+  it('should have correct background color based on value', () => {
+    const wrapper = mount(<TimeZoneToggle value={false} onChange={() => {}} />);
+    expect(wrapper.find('.switch').prop('style').backgroundColor).toBe('rgb(204, 204, 204)');
+
+    wrapper.setProps({ value: true });
+    expect(wrapper.find('.switch').prop('style').backgroundColor).toBe('rgb(0, 219, 124)');
+  });
+}); 

--- a/src/dashboard/Data/Browser/BrowserTable.react.js
+++ b/src/dashboard/Data/Browser/BrowserTable.react.js
@@ -16,6 +16,7 @@ import React from 'react';
 import styles from 'dashboard/Data/Browser/Browser.scss';
 import Button from 'components/Button/Button.react';
 import { CurrentApp } from 'context/currentApp';
+import { formatDateTime } from 'lib/DateUtils';
 
 const MAX_ROWS = 200; // Number of rows to render at any time
 const ROWS_OFFSET = 160;
@@ -218,6 +219,7 @@ export default class BrowserTable extends React.Component {
                     setShowAggregatedData={this.props.setShowAggregatedData}
                     setErrorAggregatedData={this.props.setErrorAggregatedData}
                     firstSelectedCell={this.props.firstSelectedCell}
+                    useLocalTime={this.props.useLocalTime}
                   />
                   <Button
                     value="Clone"
@@ -298,6 +300,7 @@ export default class BrowserTable extends React.Component {
               setShowAggregatedData={this.props.setShowAggregatedData}
               setErrorAggregatedData={this.props.setErrorAggregatedData}
               firstSelectedCell={this.props.firstSelectedCell}
+              useLocalTime={this.props.useLocalTime}
             />
             <Button
               value="Add"
@@ -387,6 +390,7 @@ export default class BrowserTable extends React.Component {
             setShowAggregatedData={this.props.setShowAggregatedData}
             setErrorAggregatedData={this.props.setErrorAggregatedData}
             firstSelectedCell={this.props.firstSelectedCell}
+            useLocalTime={this.props.useLocalTime}
           />
         );
       }

--- a/src/dashboard/Data/Browser/BrowserToolbar.react.js
+++ b/src/dashboard/Data/Browser/BrowserToolbar.react.js
@@ -19,6 +19,7 @@ import ColumnsConfiguration from 'components/ColumnsConfiguration/ColumnsConfigu
 import SecureFieldsDialog from 'dashboard/Data/Browser/SecureFieldsDialog.react';
 import LoginDialog from 'dashboard/Data/Browser/LoginDialog.react';
 import Toggle from 'components/Toggle/Toggle.react';
+import TimeZoneToggle from 'components/TimeZoneToggle/TimeZoneToggle.react';
 
 const BrowserToolbar = ({
   className,
@@ -79,7 +80,10 @@ const BrowserToolbar = ({
 
   togglePanel,
   isPanelVisible,
-  classwiseCloudFunctions
+  classwiseCloudFunctions,
+
+  useLocalTime,
+  onToggleTimeZone
 }) => {
   const selectionLength = Object.keys(selection).length;
   const isPendingEditCloneRows = editCloneRows && editCloneRows.length > 0;
@@ -439,6 +443,11 @@ const BrowserToolbar = ({
           <MenuItem text={'Cancel all pending rows'} onClick={onCancelPendingEditRows} />
         </BrowserMenu>
       )}
+       <div className={styles.toolbarSeparator} />
+      <div style={{ display: 'inline-flex', alignItems: 'center', marginRight: '10px' }}>
+<span style={{ marginRight: '8px', fontSize: '12px', color: '#ffffff' }}>TimeZone</span>
+<TimeZoneToggle value={useLocalTime} onChange={onToggleTimeZone} />
+</div>
     </Toolbar>
   );
 };

--- a/src/dashboard/Data/Browser/DataBrowser.test.js
+++ b/src/dashboard/Data/Browser/DataBrowser.test.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import DataBrowser from '../DataBrowser.react';
+
+describe('DataBrowser TimeZone Feature', () => {
+  let wrapper;
+  const mockLocalStorage = {
+    getItem: jest.fn(),
+    setItem: jest.fn(),
+  };
+
+  beforeEach(() => {
+    global.localStorage = mockLocalStorage;
+  });
+
+  it('should initialize with stored timezone preference', () => {
+    mockLocalStorage.getItem.mockReturnValue('true');
+    wrapper = mount(<DataBrowser {...defaultProps} />);
+    expect(wrapper.state().useLocalTime).toBe(true);
+  });
+
+  it('should toggle timezone and save preference', () => {
+    wrapper = mount(<DataBrowser {...defaultProps} />);
+    
+    wrapper.instance().toggleTimeZone();
+    expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
+      'parse_dashboard_useLocalTime',
+      'true'
+    );
+    expect(wrapper.state().useLocalTime).toBe(true);
+
+    wrapper.instance().toggleTimeZone();
+    expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
+      'parse_dashboard_useLocalTime',
+      'false'
+    );
+    expect(wrapper.state().useLocalTime).toBe(false);
+  });
+}); 

--- a/src/lib/DateUtils.js
+++ b/src/lib/DateUtils.js
@@ -141,19 +141,20 @@ export function yearMonthDayFormatter(date) {
   });
 }
 
-export function yearMonthDayTimeFormatter(date, timeZone) {
+export function yearMonthDayTimeFormatter(date, useUTC) {
   const options = {
     year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
     hour12: false,
+    timeZone: useUTC ? 'UTC' : undefined
   };
-  if (timeZone) {
-    options.timeZoneName = 'short';
-  }
-  return date.toLocaleDateString('en-US', options);
+  return date.toLocaleString('en-US', options)
+    .replace(',', '')  // 移除日期和时间之间的逗号
+    .replace(/(\d+)\/(\d+)\/(\d+)/, '$3-$1-$2'); // 转换为 yyyy-MM-dd 格式
 }
 
 export function getDateMethod(local, methodName) {
@@ -170,4 +171,23 @@ export function pad(number) {
     r = '0' + r;
   }
   return r;
+}
+
+export function formatDateTime(date, useLocalTime = false) {
+  if (!date) return '';
+  
+  const d = new Date(date);
+  
+  // 根据useLocalTime决定使用本地时间还是UTC时间
+  const year = useLocalTime ? d.getFullYear() : d.getUTCFullYear();
+  const month = (useLocalTime ? d.getMonth() : d.getUTCMonth()) + 1;
+  const day = useLocalTime ? d.getDate() : d.getUTCDate();
+  const hours = useLocalTime ? d.getHours() : d.getUTCHours();
+  const minutes = useLocalTime ? d.getMinutes() : d.getUTCMinutes();
+  const seconds = useLocalTime ? d.getSeconds() : d.getUTCSeconds();
+
+  // 补零函数
+  const pad = (num) => String(num).padStart(2, '0');
+
+  return `${year}-${pad(month)}-${pad(day)} ${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
 }

--- a/src/lib/DateUtils.js
+++ b/src/lib/DateUtils.js
@@ -153,8 +153,8 @@ export function yearMonthDayTimeFormatter(date, useUTC) {
     timeZone: useUTC ? 'UTC' : undefined
   };
   return date.toLocaleString('en-US', options)
-    .replace(',', '')  // 移除日期和时间之间的逗号
-    .replace(/(\d+)\/(\d+)\/(\d+)/, '$3-$1-$2'); // 转换为 yyyy-MM-dd 格式
+    .replace(',', '')  // Remove comma between date and time
+    .replace(/(\d+)\/(\d+)\/(\d+)/, '$3-$1-$2'); // Convert to yyyy-MM-dd format
 }
 
 export function getDateMethod(local, methodName) {
@@ -178,7 +178,7 @@ export function formatDateTime(date, useLocalTime = false) {
   
   const d = new Date(date);
   
-  // 根据useLocalTime决定使用本地时间还是UTC时间
+  // Determine whether to use local time or UTC time based on useLocalTime flag
   const year = useLocalTime ? d.getFullYear() : d.getUTCFullYear();
   const month = (useLocalTime ? d.getMonth() : d.getUTCMonth()) + 1;
   const day = useLocalTime ? d.getDate() : d.getUTCDate();
@@ -186,7 +186,7 @@ export function formatDateTime(date, useLocalTime = false) {
   const minutes = useLocalTime ? d.getMinutes() : d.getUTCMinutes();
   const seconds = useLocalTime ? d.getSeconds() : d.getUTCSeconds();
 
-  // 补零函数
+  // Pad numbers with leading zeros
   const pad = (num) => String(num).padStart(2, '0');
 
   return `${year}-${pad(month)}-${pad(day)} ${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;

--- a/src/lib/tests/DateUtils.test.js
+++ b/src/lib/tests/DateUtils.test.js
@@ -65,3 +65,45 @@ describe('daysInMonth', () => {
     expect(DateUtils.daysInMonth(new Date(2015, 8))).toBe(30);
   });
 });
+
+describe('DateUtils', () => {
+  describe('formatDateTime', () => {
+    const testDate = new Date('2024-03-21T08:00:00.000Z');
+
+    it('should format date in UTC time when useLocalTime is false', () => {
+      const result = DateUtils.formatDateTime(testDate, false);
+      expect(result).toBe('2024-03-21 08:00:00');
+    });
+
+    it('should format date in local time when useLocalTime is true', () => {
+      // 假设本地时区是 UTC+8
+      const result = DateUtils.formatDateTime(testDate, true);
+      expect(result).toBe('2024-03-21 16:00:00');
+    });
+
+    it('should handle null date', () => {
+      const result = DateUtils.formatDateTime(null, false);
+      expect(result).toBe('');
+    });
+
+    it('should handle invalid date', () => {
+      const result = DateUtils.formatDateTime('invalid date', false);
+      expect(result).toBe('');
+    });
+  });
+
+  describe('yearMonthDayTimeFormatter', () => {
+    const testDate = new Date('2024-03-21T08:00:00.000Z');
+
+    it('should format date in UTC format', () => {
+      const result = DateUtils.yearMonthDayTimeFormatter(testDate, true);
+      expect(result).toBe('2024-03-21 08:00:00');
+    });
+
+    it('should format date in local format', () => {
+      const result = DateUtils.yearMonthDayTimeFormatter(testDate, false);
+      // 假设本地时区是 UTC+8
+      expect(result).toBe('2024-03-21 16:00:00');
+    });
+  });
+});


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [ ] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Add timezone toggle feature to allow switching between UTC and local time display for date fields in the data browser. Currently, dates are always displayed in UTC format which can be confusing for users working in different timezones.

Closes: n/a

### Approach
<!-- Add a description of the approach in this PR. -->
1. Added new TimeZoneToggle component:
   - Simple toggle switch with visual feedback (grey/green)
   - Persists user preference in localStorage
   - Displays UTC/Local indicator

2. Modified date handling:
   - Updated DateTimeEditor to consistently use UTC format during editing
   - Added formatDateTime utility for consistent date formatting
   - Implemented timezone conversion in BrowserRow component

3. UI Integration:
   - Added timezone toggle to BrowserToolbar
   - Maintained UTC format in edit mode for data consistency
   - Added useLocalTime prop propagation through component hierarchy
### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
####Before
![image](https://github.com/user-attachments/assets/4c4b18ed-2e6d-46d7-863e-671f2b475e89)
####After
![image](https://github.com/user-attachments/assets/528dd15f-1a0c-4628-9e4a-97f2a519e883)

I am in china. so the local time = utc + 8 hour
