### PR TITLE
fix: Info panel Cloud Code call sends `objectId` instead of `Parse.Object`

### DIFF
--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -269,7 +269,7 @@ class Browser extends DashboardView {
       isLoading: true,
     });
     const params = {
-      objectId: objectId,
+      object: Parse.Object.extend(className).createWithoutData(objectId).toPointer(),
     };
     const options = {
       useMasterKey: true,


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Closes: https://github.com/parse-community/parse-dashboard/issues/2642

### Approach
<!-- Add a description of the approach in this PR. -->

Send `Parse.Object` instead of `objectId` in Cloud Call params.


