### PR TITLE
fix: Info panel item `panel` calls Cloud Code with parameter `objectId` instead of `Parse.Object` and without `masterKey`

### DIFF
--- a/src/components/AggregationPanel/AggregationPanel.js
+++ b/src/components/AggregationPanel/AggregationPanel.js
@@ -1,7 +1,7 @@
 import LoaderDots from 'components/LoaderDots/LoaderDots.react';
+import Parse from 'parse';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import styles from './AggregationPanel.scss';
-import Parse from 'parse';
 import {
   AudioElement,
   ButtonElement,
@@ -21,6 +21,7 @@ const AggregationPanel = ({
   showNote,
   setSelectedObjectId,
   selectedObjectId,
+  className,
   appName,
   depth = 0,
   cloudCodeFunction = null,
@@ -52,8 +53,13 @@ const AggregationPanel = ({
   const fetchNestedData = useCallback(async () => {
     setIsLoadingNested(true);
     try {
-      const params = { objectId: selectedObjectId };
-      const result = await Parse.Cloud.run(cloudCodeFunction, params);
+      const params = {
+        object: Parse.Object.extend(className).createWithoutData(selectedObjectId).toPointer(),
+      };
+      const options = {
+        useMasterKey: true,
+      };
+      const result = await Parse.Cloud.run(cloudCodeFunction, params, options);
       if (result?.panel?.segments) {
         setNestedData(result);
       } else {
@@ -113,6 +119,7 @@ const AggregationPanel = ({
                     showNote={showNote}
                     setSelectedObjectId={setSelectedObjectId}
                     selectedObjectId={selectedObjectId}
+                    className={className}
                     depth={depth + 1}
                     cloudCodeFunction={item.cloudCodeFunction}
                     panelTitle={item.title}

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -273,7 +273,7 @@ class Browser extends DashboardView {
     };
     const options = {
       useMasterKey: true,
-    }
+    };
     const appName = this.props.params.appId;
     const cloudCodeFunction = this.state.classwiseCloudFunctions[`${appId}${appName}`]?.[className][0].cloudCodeFunction;
     Parse.Cloud.run(cloudCodeFunction, params, options).then(

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -610,6 +610,7 @@ export default class DataBrowser extends React.Component {
                   setSelectedObjectId={this.setSelectedObjectId}
                   selectedObjectId={this.state.selectedObjectId}
                   appName = {this.props.appName}
+                  className = {this.props.className}
                 />
               </div>
             </ResizableBox>


### PR DESCRIPTION
These issues have already been fixed on the root info panel:

- https://github.com/parse-community/parse-dashboard/pull/2643
- https://github.com/parse-community/parse-dashboard/pull/2641

This PR fixes these issues also on the sub-panel Cloud Code calls.