### PR TITLE
fix: Dashboard crashes when setting `unique` filter on pointer field in data browser

### DIFF
--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -68,7 +68,8 @@ export default class BrowserCell extends Component {
         this.props.appId,
         this.props.value.className
       );
-      let dataValue = this.props.value.id;
+      let value = this.props.value; 
+      let dataValue = this.props.value.id || this.props.value.objectId;
       if (defaultPointerKey !== 'objectId') {
         dataValue = this.props.value.get(defaultPointerKey);
         if (dataValue && typeof dataValue === 'object') {
@@ -94,13 +95,13 @@ export default class BrowserCell extends Component {
       if (this.props.value && this.props.value.__type) {
         const object = new Parse.Object(this.props.value.className);
         object.id = this.props.value.objectId;
-        this.props.value = object;
+        value = object;
       }
 
       content = this.props.onPointerClick ? (
         <Pill
           value={dataValue}
-          onClick={this.props.onPointerClick.bind(undefined, this.props.value)}
+          onClick={this.props.onPointerClick.bind(undefined, value)}
           followClick={true}
           shrinkablePill
         />

--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -68,7 +68,7 @@ export default class BrowserCell extends Component {
         this.props.appId,
         this.props.value.className
       );
-      let value = this.props.value; 
+      let value = this.props.value;
       let dataValue = this.props.value.id || this.props.value.objectId;
       if (defaultPointerKey !== 'objectId') {
         dataValue = this.props.value.get(defaultPointerKey);


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Closes: #2657

### Approach
<!-- Add a description of the approach in this PR. -->

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
