### PR TITLE
fix: Navigation bar in data browser is transparent and partly covers info panel

### DIFF
--- a/src/dashboard/Data/Browser/BrowserFooter.scss
+++ b/src/dashboard/Data/Browser/BrowserFooter.scss
@@ -14,4 +14,5 @@
   font-size: 12px;
   font-family: "Noto Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
   border-top: 1px solid lightgrey;
+  background-color: #f1f5f9;
 }

--- a/src/dashboard/Data/Browser/Databrowser.scss
+++ b/src/dashboard/Data/Browser/Databrowser.scss
@@ -2,7 +2,7 @@
     position: fixed;
     top: 96px;
     right: 0;
-    bottom: 0px;
+    bottom: 36px;
     :global(.react-resizable-handle) {
         position: absolute;
         left: 0;


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description

- Nav bar at the bottom is transparent, showing the background cells when scrolling.
- Nav bar at the bottom covers the bottom part of the info panel.

### Approach

- Add background color.
- Add info panel bottom margin.

### TODOs before merging

n/a