### PR TITLE
fix: Logout bar layout not aligned with data browser navigation bar

### DIFF
--- a/src/components/Sidebar/Sidebar.react.js
+++ b/src/components/Sidebar/Sidebar.react.js
@@ -187,7 +187,7 @@ const Sidebar = ({
       {dashboardUser && (
         <div className={styles.footer}>
           <a href={`${mountPath}logout`} className={styles.more}>
-            <Icon height={24} width={24} name="logout" />
+            <Icon height={16} width={16} name="logout" />
             Logout
           </a>
         </div>

--- a/src/components/Sidebar/Sidebar.scss
+++ b/src/components/Sidebar/Sidebar.scss
@@ -53,7 +53,7 @@ $footerHeight: 36px;
   @include DosisFont;
   position: absolute;
   background: #05283c;
-  padding: 9px 0;
+  padding: 10px 0;
   text-align: center;
   bottom: 0;
   left: 0;


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description

The logout bar is higher than the data browser navigation bar. The logout bar height is also different than the placeholder bar that is displayed if no user is logged in to dashboard.

### Approach

Reduce the logout bar height and make the logout icon size a bit smaller as well.

