### PR TITLE
refactor: Optimize latest package version check

### DIFF
--- a/Parse-Dashboard/app.js
+++ b/Parse-Dashboard/app.js
@@ -1,27 +1,34 @@
 'use strict';
+
 const express = require('express');
 const path = require('path');
-const packageJson = require('package-json');
 const csrf = require('csurf');
 const Authentication = require('./Authentication.js');
 const fs = require('fs');
 const ConfigKeyCache = require('./configKeyCache.js');
-
 const currentVersionFeatures = require('../package.json').parseDashboardFeatures;
 
 let newFeaturesInLatestVersion = [];
-packageJson('parse-dashboard', { version: 'latest', fullMetadata: true })
-  .then(latestPackage => {
+
+/**
+ * Gets the new features in the latest version of Parse Dashboard.
+ */
+async function getNewFeaturesInLatestVersion() {
+  // Get latest version
+  const packageJson = (await import('package-json')).default;
+  const latestPackage = await packageJson('parse-dashboard', { version: 'latest', fullMetadata: true });
+
+  try {
     if (latestPackage.parseDashboardFeatures instanceof Array) {
       newFeaturesInLatestVersion = latestPackage.parseDashboardFeatures.filter(feature => {
         return currentVersionFeatures.indexOf(feature) === -1;
       });
     }
-  })
-  .catch(() => {
-    // In case of a failure make sure the final value is an empty array
+  } catch {
     newFeaturesInLatestVersion = [];
-  });
+  }
+}
+getNewFeaturesInLatestVersion()
 
 function getMount(mountPath) {
   mountPath = mountPath || '';


### PR DESCRIPTION
No real reason for this refactor other than I tried to upgrade [package-json](https://github.com/sindresorhus/package-json) to 8+ which is now pure ESM, but that failed even with `await import`, likely because the module is using `import` internally. So I at least keep the refactor.