### PR TITLE
fix: Dashboard crashes on login due to `passport` upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "otpauth": "8.0.3",
         "package-json": "7.0.0",
         "parse": "3.5.1",
-        "passport": "0.7.0",
+        "passport": "0.5.3",
         "passport-local": "1.0.0",
         "prismjs": "1.30.0",
         "prop-types": "15.8.1",
@@ -19118,14 +19118,12 @@
       }
     },
     "node_modules/passport": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
-      "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
-      "license": "MIT",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.5.3.tgz",
+      "integrity": "sha512-gGc+70h4gGdBWNsR3FuV3byLDY6KBTJAIExGFXTpQaYfbbcHCBlRRKx7RBQSpqEqc5Hh2qVzRs7ssvSfOpkUEA==",
       "dependencies": {
         "passport-strategy": "1.x.x",
-        "pause": "0.0.1",
-        "utils-merge": "^1.0.1"
+        "pause": "0.0.1"
       },
       "engines": {
         "node": ">= 0.4.0"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "otpauth": "8.0.3",
     "package-json": "7.0.0",
     "parse": "3.5.1",
-    "passport": "0.7.0",
+    "passport": "0.5.3",
     "passport-local": "1.0.0",
     "prismjs": "1.30.0",
     "prop-types": "15.8.1",


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description

Dashboard crashes on login due to passport upgrade from 0.5.3 to 0.7.0.

### Approach

Revert to passport 0.5.3; needs in investigation why it crashes with 0.7.0.
