### PR TITLE
feat: Display filter list in data browser sorted alphabetically

### DIFF
--- a/src/components/CategoryList/CategoryList.react.js
+++ b/src/components/CategoryList/CategoryList.react.js
@@ -5,12 +5,12 @@
  * This source code is licensed under the license found in the LICENSE file in
  * the root directory of this source tree.
  */
+import styles from 'components/CategoryList/CategoryList.scss';
+import { CurrentApp } from 'context/currentApp';
+import generatePath from 'lib/generatePath';
 import PropTypes from 'lib/PropTypes';
 import React from 'react';
-import styles from 'components/CategoryList/CategoryList.scss';
 import { Link } from 'react-router-dom';
-import generatePath from 'lib/generatePath';
-import { CurrentApp } from 'context/currentApp';
 
 export default class CategoryList extends React.Component {
   static contextType = CurrentApp;
@@ -137,7 +137,7 @@ export default class CategoryList extends React.Component {
                 )}
               </div>
               {this.state.openClasses.includes(id) &&
-                c.filters.map((filterData, index) => {
+                c.filters.sort((a, b) => a.name.localeCompare(b.name)).map((filterData, index) => {
                   const { name, filter } = filterData;
                   const url = `${this.props.linkPrefix}${c.name}?filters=${encodeURIComponent(
                     filter


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description

Filter list is currently sorted by date added. Since the list order cannot be manually changed, a long list of filters becomes difficult to navigate.

### Approach

Sort filters alphabetically so that they can be "grouped" by adding a name prefix.