### PR TITLE
fix: Saving new filter in data browser overwrites filters added in other dashboard instances

### DIFF
--- a/src/lib/ClassPreferences.js
+++ b/src/lib/ClassPreferences.js
@@ -1,3 +1,4 @@
+const VERSION = 1; // In case we ever need to invalidate these
 export function updatePreferences(prefs, appId, className) {
   try {
     localStorage.setItem(path(appId, className), JSON.stringify(prefs));

--- a/src/lib/ClassPreferences.js
+++ b/src/lib/ClassPreferences.js
@@ -1,19 +1,12 @@
-const VERSION = 1; // In case we ever need to invalidate these
-const cache = {};
 export function updatePreferences(prefs, appId, className) {
   try {
     localStorage.setItem(path(appId, className), JSON.stringify(prefs));
   } catch {
     // Fails in Safari private browsing
   }
-  cache[appId] = cache[appId] || {};
-  cache[appId][className] = prefs;
 }
 
 export function getPreferences(appId, className) {
-  if (cache[appId] && cache[appId][className]) {
-    return cache[appId][className];
-  }
   let entry;
   try {
     entry =
@@ -29,10 +22,7 @@ export function getPreferences(appId, className) {
     return null;
   }
   try {
-    const prefs = JSON.parse(entry);
-    cache[appId] = cache[appId] || {};
-    cache[appId][className] = prefs;
-    return prefs;
+    return JSON.parse(entry);
   } catch {
     return null;
   }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Closes: #2711

### Approach
<!-- Add a description of the approach in this PR. -->

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved preference management by removing in-memory caching. Preferences are now always read directly from local storage, ensuring the most up-to-date information is used. No changes to the way you interact with preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->