### PR TITLE
fix: Selecting a saved filter in data browser may highlight a different filter

### DIFF
--- a/src/components/CategoryList/CategoryList.react.js
+++ b/src/components/CategoryList/CategoryList.react.js
@@ -137,7 +137,7 @@ export default class CategoryList extends React.Component {
                 )}
               </div>
               {this.state.openClasses.includes(id) &&
-                c.filters.sort((a, b) => a.name.localeCompare(b.name)).map((filterData, index) => {
+                c.filters.map((filterData, index) => {
                   const { name, filter } = filterData;
                   const url = `${this.props.linkPrefix}${c.name}?filters=${encodeURIComponent(
                     filter

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -1873,7 +1873,8 @@ class Browser extends DashboardView {
         this.context.applicationId,
         row.name
       );
-      row.filters = filters;
+      // Set filters sorted alphabetically
+      row.filters = filters.sort((a, b) => a.name.localeCompare(b.name));
       allCategories.push(row);
     }
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description

Selecting a saved filter in data browser may visually highlight a different filter.

### Approach

Move sorting of filter alphabetically to earlier stage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated filter lists to display in their original order in one area and in alphabetical order in another, ensuring a more consistent and intuitive user experience across different parts of the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->