### PR TITLE
fix: Pagination does not reset to page 1 when clicking on class or filter

### DIFF
--- a/src/components/CategoryList/CategoryList.react.js
+++ b/src/components/CategoryList/CategoryList.react.js
@@ -122,7 +122,7 @@ export default class CategoryList extends React.Component {
           return (
             <div key={id}>
               <div className={styles.link}>
-                <Link title={c.name} to={{ pathname: link }} className={className} key={id}>
+                <Link title={c.name} to={{ pathname: link }} className={className} key={id} onClick={() => this.props.classClicked()}>
                   <span>{count}</span>
                   <span>{c.name}</span>
                 </Link>

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -1883,8 +1883,28 @@ class Browser extends DashboardView {
         current={current}
         params={this.props.location?.search}
         linkPrefix={'browser/'}
-        filterClicked={url => this.props.navigate(generatePath(this.context, url))}
-        removeFilter={filter => this.removeFilter(filter)}
+        filterClicked={url => {
+          // Reset to page 1
+          this.setState({
+            skip: 0,
+          });
+
+          this.props.navigate(generatePath(this.context, url));
+        }}
+        removeFilter={filter => {
+          // Reset to page 1
+          this.setState({
+            skip: 0,
+          });
+
+          this.removeFilter(filter)
+        }}
+        classClicked={() => {
+          // Reset to page 1
+          this.setState({
+            skip: 0,
+          });
+        }}
         categories={allCategories}
       />
     );


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description

Pagination does not reset to page 1 when clicking on class or filter

### Approach

Reset to page 1 on:
- click on class
- delete filter
- click on filter



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Clicking on a category now triggers an additional action, enhancing interactivity in the category list.

- **Bug Fixes**
  - Pagination is automatically reset to the first page whenever a filter or category is selected or removed, ensuring users always start from the beginning after changing filters or categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->