### PR TITLE
fix: Data browser not scrolling to top when changing filter while cell selected

### DIFF
--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -1904,30 +1904,39 @@ class Browser extends DashboardView {
         params={this.props.location?.search}
         linkPrefix={'browser/'}
         filterClicked={url => {
-          // Reset to page 1
-          this.setState({
-            skip: 0,
-          });
-
+          this.resetPage();
           this.props.navigate(generatePath(this.context, url));
         }}
         removeFilter={filter => {
-          // Reset to page 1
-          this.setState({
-            skip: 0,
-          });
-
+          this.resetPage();
           this.removeFilter(filter)
         }}
         classClicked={() => {
-          // Reset to page 1
-          this.setState({
-            skip: 0,
-          });
+          this.resetPage();
         }}
         categories={allCategories}
       />
     );
+  }
+
+  /**
+   * Resets the page to the first page of results and scrolls to the top.
+   */
+  resetPage() {
+    // Unselect any currently selected cell and cancel editing action
+    this.dataBrowserRef.current.setCurrent(null);
+    this.dataBrowserRef.current.setEditing(false);
+
+    // Scroll to top
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth'
+    });
+
+    // Reset pagination to page 1
+    this.setState({
+      skip: 0,
+    });
   }
 
   showNote(message, isError) {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description

Data browser not scrolling to top when changing filter while cell selected

### Approach

When filter is applied or removed then scroll to top.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved user experience when changing filters or classes by automatically scrolling to the top of the page and clearing any cell selection or editing state.
  - Pagination now reliably resets to the first page when filters or classes are changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->