### PR TITLE
fix: Notifications fade out erratically when executing a script on large number of rows

### DIFF
--- a/src/dashboard/Data/Browser/Notification.react.js
+++ b/src/dashboard/Data/Browser/Notification.react.js
@@ -29,7 +29,6 @@ export default class Notification extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     if (this.state.lastNote !== nextProps.note) {
-      clearTimeout(this.timeout);
       if (this.state.hiding) {
         this.setState({
           lastNote: nextProps.note,
@@ -46,6 +45,7 @@ export default class Notification extends React.Component {
     if (!nextProps.note) {
       return;
     }
+    clearTimeout(this.timeout);
     this.timeout = setTimeout(() => {
       this.setState({ hiding: true });
       this.timeout = setTimeout(() => {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Notifications fade out erratically when executing a script on large number of rows 

### Approach

Remove delayed fade-out timeout on multiple notifications.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of notification hiding by ensuring timers are managed more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->