### PR TITLE
feat: Allow config parameter dialog to be resized in width

### DIFF
--- a/src/components/Modal/Modal.react.js
+++ b/src/components/Modal/Modal.react.js
@@ -13,6 +13,7 @@ import Position from 'lib/Position';
 import React from 'react';
 import PropTypes from 'lib/PropTypes';
 import styles from 'components/Modal/Modal.scss';
+import { useState, useEffect, useRef } from 'react';
 
 const origin = new Position(0, 0);
 const buttonColors = {
@@ -38,12 +39,55 @@ const Modal = ({
   progress = false,
   customFooter,
   textModal = false,
-  width,
+  width: initialWidth = 500,
   continueText,
   onContinue,
   showContinue,
   buttonsInCenter = React.Children.count(children) === 0,
 }) => {
+
+  const modalRef = useRef(null);
+
+  const [currentWidth, setCurrentWidth] = useState(initialWidth);
+  const resizing = useRef(false);
+
+  const handleMouseDown = (e) => {
+  e.preventDefault();
+  resizing.current = true;
+  if (modalRef.current) {
+    modalRef.current.classList.add(styles.noTransition);
+  }
+};
+
+const handleMouseMove = (e) => {
+  if (!resizing.current || !modalRef.current) {
+    return;
+  }
+
+  const modalLeft = modalRef.current.getBoundingClientRect().left;
+  const newWidth = e.clientX - modalLeft;
+
+  const clampedWidth = Math.min(window.innerWidth, Math.max(initialWidth, newWidth));
+  setCurrentWidth(clampedWidth);
+};
+
+const handleMouseUp = () => {
+  resizing.current = false;
+  if (modalRef.current) {
+    modalRef.current.classList.remove(styles.noTransition);
+  }
+};
+
+useEffect(() => {
+  document.addEventListener('mousemove', handleMouseMove);
+  document.addEventListener('mouseup', handleMouseUp);
+
+  return () => {
+    document.removeEventListener('mousemove', handleMouseMove);
+    document.removeEventListener('mouseup', handleMouseUp);
+  };
+}, []);
+
   if (children) {
     children = React.Children.map(children, c => {
       if (c && c.type === Field && c.props.label) {
@@ -81,7 +125,7 @@ const Modal = ({
 
   return (
     <Popover fadeIn={true} fixed={true} position={origin} modal={true} color="rgba(17,13,17,0.8)">
-      <div className={[styles.modal, styles[type]].join(' ')} style={{ width }}>
+      <div ref={modalRef} className={[styles.modal, styles[type]].join(' ')} style={{ width: currentWidth }}>
         <div className={styles.header}>
           <div
             style={{
@@ -100,6 +144,7 @@ const Modal = ({
         </div>
         {wrappedChildren}
         {footer}
+        <div className={styles.resizeHandle} onMouseDown={handleMouseDown} />
       </div>
     </Popover>
   );

--- a/src/components/Modal/Modal.react.js
+++ b/src/components/Modal/Modal.react.js
@@ -10,10 +10,9 @@ import Field from 'components/Field/Field.react';
 import Icon from 'components/Icon/Icon.react';
 import Popover from 'components/Popover/Popover.react';
 import Position from 'lib/Position';
-import React from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import PropTypes from 'lib/PropTypes';
 import styles from 'components/Modal/Modal.scss';
-import { useState, useEffect, useRef } from 'react';
 
 const origin = new Position(0, 0);
 const buttonColors = {
@@ -39,54 +38,56 @@ const Modal = ({
   progress = false,
   customFooter,
   textModal = false,
-  width: initialWidth = 500,
+  width,
+  initialWidth = width ?? 500,
   continueText,
   onContinue,
   showContinue,
   buttonsInCenter = React.Children.count(children) === 0,
 }) => {
-
   const modalRef = useRef(null);
-
   const [currentWidth, setCurrentWidth] = useState(initialWidth);
   const resizing = useRef(false);
 
-  const handleMouseDown = (e) => {
-  e.preventDefault();
-  resizing.current = true;
-  if (modalRef.current) {
-    modalRef.current.classList.add(styles.noTransition);
-  }
-};
-
-const handleMouseMove = (e) => {
-  if (!resizing.current || !modalRef.current) {
-    return;
-  }
-
-  const modalLeft = modalRef.current.getBoundingClientRect().left;
-  const newWidth = e.clientX - modalLeft;
-
-  const clampedWidth = Math.min(window.innerWidth, Math.max(initialWidth, newWidth));
-  setCurrentWidth(clampedWidth);
-};
-
-const handleMouseUp = () => {
-  resizing.current = false;
-  if (modalRef.current) {
-    modalRef.current.classList.remove(styles.noTransition);
-  }
-};
-
-useEffect(() => {
-  document.addEventListener('mousemove', handleMouseMove);
-  document.addEventListener('mouseup', handleMouseUp);
-
-  return () => {
-    document.removeEventListener('mousemove', handleMouseMove);
-    document.removeEventListener('mouseup', handleMouseUp);
+  const handleMouseDown = e => {
+    e.preventDefault();
+    resizing.current = true;
+    if (modalRef.current) {
+      modalRef.current.classList.add(styles.noTransition);
+    }
   };
-}, []);
+
+  const handleMouseMove = useCallback(
+    e => {
+      if (!resizing.current || !modalRef.current) {
+        return;
+      }
+
+      const modalLeft = modalRef.current.getBoundingClientRect().left;
+      const newWidth = e.clientX - modalLeft;
+
+      const clampedWidth = Math.min(window.innerWidth, Math.max(initialWidth, newWidth));
+      setCurrentWidth(clampedWidth);
+    },
+    [initialWidth]
+  );
+
+  const handleMouseUp = useCallback(() => {
+    resizing.current = false;
+    if (modalRef.current) {
+      modalRef.current.classList.remove(styles.noTransition);
+    }
+  }, []);
+
+  useEffect(() => {
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
+
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [handleMouseMove, handleMouseUp]);
 
   if (children) {
     children = React.Children.map(children, c => {
@@ -125,7 +126,11 @@ useEffect(() => {
 
   return (
     <Popover fadeIn={true} fixed={true} position={origin} modal={true} color="rgba(17,13,17,0.8)">
-      <div ref={modalRef} className={[styles.modal, styles[type]].join(' ')} style={{ width: currentWidth }}>
+      <div
+        ref={modalRef}
+        className={[styles.modal, styles[type]].join(' ')}
+        style={{ width: currentWidth }}
+      >
         <div className={styles.header}>
           <div
             style={{
@@ -178,7 +183,8 @@ Modal.propTypes = {
   progress: PropTypes.bool.describe('Passed to the confirm button.'),
   customFooter: PropTypes.node.describe('used to fill any custom footer use case.'),
   textModal: PropTypes.bool.describe('Used for modals that contain only text to pad the text.'),
-  width: PropTypes.number.describe('custom width of modal.'),
+  width: PropTypes.number.describe('custom width of modal (legacy prop, prefer initialWidth).'),
+  initialWidth: PropTypes.number.describe('custom width of modal.'),
   buttonsInCenter: PropTypes.bool.describe(
     'If true, the buttons will appear in the center of the modal, instead of to the right. By default, the buttons appear on the right unless the modal contains no children, in which case they appear in the center.'
   ),

--- a/src/components/Modal/Modal.react.js
+++ b/src/components/Modal/Modal.react.js
@@ -54,7 +54,9 @@ const Modal = ({
 
   const handleMouseDown = (side) => (e) => {
     e.preventDefault();
-    if (!modalRef.current) return;
+    if (!modalRef.current) {
+      return;
+    }
     resizing.current = {
       active: true,
       side,
@@ -66,7 +68,9 @@ const Modal = ({
 
   const handleMouseMove = useCallback(
     (e) => {
-      if (!resizing.current.active || !modalRef.current) return;
+      if (!resizing.current.active || !modalRef.current) {
+        return;
+      }
       const { side, startX, startWidth } = resizing.current;
       if (side === 'right') {
         let newWidth = startWidth + 2 * (e.clientX - startX);

--- a/src/components/Modal/Modal.react.js
+++ b/src/components/Modal/Modal.react.js
@@ -47,33 +47,42 @@ const Modal = ({
 }) => {
   const modalRef = useRef(null);
   const [currentWidth, setCurrentWidth] = useState(initialWidth);
-  const resizing = useRef(false);
+  const resizing = useRef({ active: false, side: null, startX: 0, startWidth: 0 });
 
-  const handleMouseDown = e => {
+  // Helper to get min width
+  const minWidth = initialWidth;
+
+  const handleMouseDown = (side) => (e) => {
     e.preventDefault();
-    resizing.current = true;
-    if (modalRef.current) {
-      modalRef.current.classList.add(styles.noTransition);
-    }
+    if (!modalRef.current) return;
+    resizing.current = {
+      active: true,
+      side,
+      startX: e.clientX,
+      startWidth: currentWidth,
+    };
+    modalRef.current.classList.add(styles.noTransition);
   };
 
   const handleMouseMove = useCallback(
-    e => {
-      if (!resizing.current || !modalRef.current) {
-        return;
+    (e) => {
+      if (!resizing.current.active || !modalRef.current) return;
+      const { side, startX, startWidth } = resizing.current;
+      if (side === 'right') {
+        let newWidth = startWidth + 2 * (e.clientX - startX);
+        newWidth = Math.max(minWidth, newWidth);
+        setCurrentWidth(newWidth);
+      } else if (side === 'left') {
+        let newWidth = startWidth - 2 * (e.clientX - startX);
+        newWidth = Math.max(minWidth, newWidth);
+        setCurrentWidth(newWidth);
       }
-
-      const modalLeft = modalRef.current.getBoundingClientRect().left;
-      const newWidth = e.clientX - modalLeft;
-
-      const clampedWidth = Math.min(window.innerWidth, Math.max(initialWidth, newWidth));
-      setCurrentWidth(clampedWidth);
     },
-    [initialWidth]
+    [minWidth]
   );
 
   const handleMouseUp = useCallback(() => {
-    resizing.current = false;
+    resizing.current = { active: false, side: null, startX: 0, startWidth: 0 };
     if (modalRef.current) {
       modalRef.current.classList.remove(styles.noTransition);
     }
@@ -82,7 +91,6 @@ const Modal = ({
   useEffect(() => {
     document.addEventListener('mousemove', handleMouseMove);
     document.addEventListener('mouseup', handleMouseUp);
-
     return () => {
       document.removeEventListener('mousemove', handleMouseMove);
       document.removeEventListener('mouseup', handleMouseUp);
@@ -129,8 +137,22 @@ const Modal = ({
       <div
         ref={modalRef}
         className={[styles.modal, styles[type]].join(' ')}
-        style={{ width: currentWidth }}
+        style={{
+          width: currentWidth,
+        }}
       >
+        {/* Left resize handle */}
+        <div
+          className={styles.resizeHandleLeft}
+          style={{ position: 'absolute', left: 0, top: 0, width: 8, height: '100%', cursor: 'ew-resize', zIndex: 10 }}
+          onMouseDown={handleMouseDown('left')}
+        />
+        {/* Right resize handle */}
+        <div
+          className={styles.resizeHandleRight}
+          style={{ position: 'absolute', right: 0, top: 0, width: 8, height: '100%', cursor: 'ew-resize', zIndex: 10 }}
+          onMouseDown={handleMouseDown('right')}
+        />
         <div className={styles.header}>
           <div
             style={{
@@ -149,7 +171,6 @@ const Modal = ({
         </div>
         {wrappedChildren}
         {footer}
-        <div className={styles.resizeHandle} onMouseDown={handleMouseDown} />
       </div>
     </Popover>
   );

--- a/src/components/Modal/Modal.scss
+++ b/src/components/Modal/Modal.scss
@@ -99,3 +99,18 @@
 }
 
 @include modalKeyframes();
+
+.resizeHandle {
+  width: 16px;
+  height: 16px;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  cursor: se-resize;
+  background: rgba(255, 255, 255, 0.5);
+  z-index: 10;
+}
+
+.noTransition {
+  transition: none !important;
+}


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Closes: #1879

### Approach
<!-- Add a description of the approach in this PR. -->

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The modal window can now be dynamically resized in width by dragging new resize handles on its left and right edges.

- **Style**
  - Added visual styling for the resize handles and improved modal transition handling during resizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->