### PR TITLE
fix: Data browser does not cancel obsolete long-loading request on sorting field change

### DIFF
--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -54,7 +54,7 @@ class Browser extends DashboardView {
     this.section = 'Core';
     this.subsection = 'Browser';
     this.noteTimeout = null;
-    this.currentQuery = null; // Track current query
+    this.currentQuery = null;
     const limit = window.localStorage?.getItem('browserLimit');
 
     this.state = {

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -54,6 +54,7 @@ class Browser extends DashboardView {
     this.section = 'Core';
     this.subsection = 'Browser';
     this.noteTimeout = null;
+    this.currentQuery = null; // Track current query
     const limit = window.localStorage?.getItem('browserLimit');
 
     this.state = {
@@ -221,6 +222,9 @@ class Browser extends DashboardView {
   }
 
   componentWillUnmount() {
+    if (this.currentQuery) {
+      this.currentQuery.cancel();
+    }
     this.removeLocation();
     window.removeEventListener('mouseup', this.onMouseUpRowCheckBox);
   }
@@ -897,6 +901,10 @@ class Browser extends DashboardView {
   }
 
   async fetchParseData(source, filters) {
+    if (this.currentQuery) {
+      this.currentQuery.cancel();
+    }
+
     const { useMasterKey, skip, limit } = this.state;
     this.setState({
       data: null,
@@ -916,6 +924,7 @@ class Browser extends DashboardView {
     localStorage?.setItem('browserLimit', limit);
 
     this.excludeFields(query, source);
+    this.currentQuery = query;
     let promise = query.find({ useMasterKey });
     let isUnique = false;
     let uniqueField = null;


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [ ] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [ ] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Closes: #2820

### Approach
<!-- Add a description of the approach in this PR. -->

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved data loading reliability by ensuring that only one data request is active at a time and cancelling any ongoing requests when navigating away from the data browser. This prevents potential issues with overlapping or stale data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->