### PR TITLE
feat: Add dashboard configuration store on Parse Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,19 @@ For example:
 
 You can conveniently create a filter definition without having to write it by hand by first saving a filter in the data browser, then exporting the filter definition under *App Settings > Export Class Preferences*.
 
+### Saving Configuration of the server
+
+You can save the confiugration on the server by specifying `preferencesClassName`
+```json
+"apps": [
+  {
+    "preferencesClassName": "DashboardPreferences"
+  }
+]
+```
+
+Once this is set, you can visit `AppSettings > Dashboard` to save the current Column and Class settings.
+
 ### Scripts
 
 You can specify scripts to execute Cloud Functions with the `scripts` option:

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,6 +1,12 @@
 {
   "compilerOptions": {
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "baseUrl": "src",
+    "paths": {
+      "lib/*": ["lib/*"],
+      "components/*": ["components/*"],
+      "stylesheets/*": ["stylesheets/*"]
+    }
   },
   "typeAcquisition": {
       "include": [

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -204,6 +204,11 @@ class Browser extends DashboardView {
       this.action = new SidebarAction('Create a class', this.showCreateClass.bind(this));
     }
 
+    if (this.context.preferencesClassName) {
+      ColumnPreferences.load(this.context.preferencesClassName);
+      ClassPreferences.load(this.context.preferencesClassName);
+    }
+
     this.props.schema.dispatch(ActionTypes.FETCH).then(() => this.handleFetchedSchema());
     if (!this.props.params.className && this.props.schema.data.get('classes')) {
       this.redirectToFirstClass(this.props.schema.data.get('classes'));

--- a/src/dashboard/Settings/DashboardSettings/DashboardSettings.react.js
+++ b/src/dashboard/Settings/DashboardSettings/DashboardSettings.react.js
@@ -20,8 +20,11 @@ import * as ClassPreferences from 'lib/ClassPreferences';
 import bcrypt from 'bcryptjs';
 import * as OTPAuth from 'otpauth';
 import QRCode from 'qrcode';
+import Parse from 'parse';
+import { CurrentApp } from 'context/currentApp';
 
 export default class DashboardSettings extends DashboardView {
+  static contextType = CurrentApp;
   constructor() {
     super();
     this.section = 'App Settings';
@@ -49,6 +52,7 @@ export default class DashboardSettings extends DashboardView {
         show: false,
         mfa: '',
       },
+      showSavePreferences: !!this.context?.preferencesClassName,
     };
   }
 
@@ -63,6 +67,35 @@ export default class DashboardSettings extends DashboardView {
     });
   }
 
+  async saveColumns() {
+    const data = ColumnPreferences.getAllPreferences(this.context.applicationId);
+    let preferences = await new Parse.Query(this.context.preferencesClassName)
+      .equalTo('applicationId', this.context.applicationId)
+      .equalTo('key', 'columnPreferences')
+      .equalTo('user', Parse.User.current())
+      .first({ useMasterKey: true });
+
+    if (!preferences) {
+      preferences = new Parse.Object(this.context.preferencesClassName);
+      preferences.set('applicationId', this.context.applicationId);
+      preferences.set('key', 'columnPreferences');
+      preferences.set('user', Parse.User.current());
+      preferences.setACL(
+        new Parse.ACL(Parse.User.current())
+      );
+    }
+
+    preferences.set('value', JSON.stringify(data));
+
+    try {
+      await preferences.save(null, { useMasterKey: true });
+      this.showNote('Column preferences saved successfully');
+    } catch (error) {
+      this.showNote(`Error saving column preferences: ${error.message}`);
+    }
+
+  }
+
   getClasses() {
     const data = ClassPreferences.getAllPreferences(this.context.applicationId);
     this.setState({
@@ -72,6 +105,31 @@ export default class DashboardSettings extends DashboardView {
         type: 'Class Preferences',
       },
     });
+  }
+
+  async saveClasses() {
+    const data = ClassPreferences.getAllPreferences(this.context.applicationId);
+    let preferences = await new Parse.Query(this.context.preferencesClassName)
+      .equalTo('applicationId', this.context.applicationId)
+      .equalTo('key', 'classPreferences')
+      .equalTo('user', Parse.User.current())
+      .first({ useMasterKey: true });
+    if (!preferences) {
+      preferences = new Parse.Object(this.context.preferencesClassName);
+      preferences.set('applicationId', this.context.applicationId);
+      preferences.set('key', 'classPreferences');
+      preferences.set('user', Parse.User.current());
+      preferences.setACL(
+        new Parse.ACL(Parse.User.current())
+      );
+    }
+    preferences.set('value', JSON.stringify(data));
+    try {
+      await preferences.save(null, { useMasterKey: true });
+      this.showNote('Class preferences saved successfully');
+    } catch (error) {
+      this.showNote(`Error saving class preferences: ${error.message}`);
+    }
   }
 
   copy(data, label) {
@@ -367,10 +425,18 @@ export default class DashboardSettings extends DashboardView {
             label={<Label text="Export Column Preferences" />}
             input={<FormButton color="blue" value="Export" onClick={() => this.getColumns()} />}
           />
+          {this.state.showSavePreferences && <Field
+            label={<Label text="Save Column Preferences" />}
+            input={<FormButton color="blue" value="Save" onClick={() => this.saveColumns()} />}
+          />}
           <Field
             label={<Label text="Export Class Preferences" />}
             input={<FormButton color="blue" value="Export" onClick={() => this.getClasses()} />}
           />
+          {this.state.showSavePreferences && <Field
+            label={<Label text="Save Class Preferences" />}
+            input={<FormButton color="blue" value="Save" onClick={() => this.getClasses()} />}
+          />}
           <Field
             label={<Label text="Create New User" />}
             input={

--- a/src/dashboard/Settings/DashboardSettings/DashboardSettings.react.js
+++ b/src/dashboard/Settings/DashboardSettings/DashboardSettings.react.js
@@ -435,7 +435,7 @@ export default class DashboardSettings extends DashboardView {
           />
           {this.state.showSavePreferences && <Field
             label={<Label text="Save Class Preferences" />}
-            input={<FormButton color="blue" value="Save" onClick={() => this.getClasses()} />}
+            input={<FormButton color="blue" value="Save" onClick={() => this.saveClasses()} />}
           />}
           <Field
             label={<Label text="Create New User" />}

--- a/src/lib/ClassPreferences.js
+++ b/src/lib/ClassPreferences.js
@@ -3,9 +3,9 @@ import Parse from 'parse';
 
 export const load = async (preferencesClassName) => {
   const preferences = await new Parse.Query(preferencesClassName)
-        .equalTo('user', Parse.User.current())
-        .equalTo('key', 'classPreferences')
-        .first({ useMasterKey: true });
+    .equalTo('user', Parse.User.current())
+    .equalTo('key', 'classPreferences')
+    .first({ useMasterKey: true });
 
   if (preferences) {
     const prefs = preferences.get('value');
@@ -20,19 +20,19 @@ export function setClassPreferences(classPreference, appId) {
   }
 
   for (const className in classPreference) {
-          const preferences = getPreferences(appId, className) || { filters: [] };
-          const { filters } = classPreference[className];
-          for (const filter of filters) {
-            if (Array.isArray(filter.filter)) {
-              filter.filter = JSON.stringify(filter.filter);
-            }
-            if (preferences.filters.some(row => JSON.stringify(row) === JSON.stringify(filter))) {
-              continue;
-            }
-            preferences.filters.push(filter);
-          }
-          updatePreferences(preferences, appId, className);
-        }
+    const preferences = getPreferences(appId, className) || { filters: [] };
+    const { filters } = classPreference[className];
+    for (const filter of filters) {
+      if (Array.isArray(filter.filter)) {
+        filter.filter = JSON.stringify(filter.filter);
+      }
+      if (preferences.filters.some(row => JSON.stringify(row) === JSON.stringify(filter))) {
+        continue;
+      }
+      preferences.filters.push(filter);
+    }
+    updatePreferences(preferences, appId, className);
+  }
 }
 export function updatePreferences(prefs, appId, className) {
   try {

--- a/src/lib/ClassPreferences.js
+++ b/src/lib/ClassPreferences.js
@@ -1,4 +1,39 @@
 const VERSION = 1; // In case we ever need to invalidate these
+import Parse from 'parse';
+
+export const load = async (preferencesClassName) => {
+  const preferences = await new Parse.Query(preferencesClassName)
+        .equalTo('user', Parse.User.current())
+        .equalTo('key', 'classPreferences')
+        .first({ useMasterKey: true });
+
+  if (preferences) {
+    const prefs = preferences.get('value');
+    setClassPreferences(JSON.parse(prefs), Parse.applicationId);
+  }
+
+}
+
+export function setClassPreferences(classPreference, appId) {
+  if (!classPreference) {
+    return;
+  }
+
+  for (const className in classPreference) {
+          const preferences = getPreferences(appId, className) || { filters: [] };
+          const { filters } = classPreference[className];
+          for (const filter of filters) {
+            if (Array.isArray(filter.filter)) {
+              filter.filter = JSON.stringify(filter.filter);
+            }
+            if (preferences.filters.some(row => JSON.stringify(row) === JSON.stringify(filter))) {
+              continue;
+            }
+            preferences.filters.push(filter);
+          }
+          updatePreferences(preferences, appId, className);
+        }
+}
 export function updatePreferences(prefs, appId, className) {
   try {
     localStorage.setItem(path(appId, className), JSON.stringify(prefs));

--- a/src/lib/ColumnPreferences.js
+++ b/src/lib/ColumnPreferences.js
@@ -14,9 +14,9 @@ import Parse from 'parse';
 
 export const load = async (preferencesClassName) => {
   const preferences = await new Parse.Query(preferencesClassName)
-        .equalTo('user', Parse.User.current())
-        .equalTo('key', 'columnPreferences')
-        .first({ useMasterKey: true });
+    .equalTo('user', Parse.User.current())
+    .equalTo('key', 'columnPreferences')
+    .first({ useMasterKey: true });
 
   if (preferences) {
     const prefs = JSON.parse(preferences.get('value'));

--- a/src/lib/ColumnPreferences.js
+++ b/src/lib/ColumnPreferences.js
@@ -10,6 +10,24 @@ const DEFAULT_WIDTH = 150;
 const COLUMN_SORT = '__columnClassesSort'; // Used for storing classes sort field
 const DEFAULT_COLUMN_SORT = '-createdAt'; // Default column sorting
 const cache = {};
+import Parse from 'parse';
+
+export const load = async (preferencesClassName) => {
+  const preferences = await new Parse.Query(preferencesClassName)
+        .equalTo('user', Parse.User.current())
+        .equalTo('key', 'columnPreferences')
+        .first({ useMasterKey: true });
+
+  if (preferences) {
+    const prefs = JSON.parse(preferences.get('value'));
+    if (prefs) {
+      for (const className in prefs) {
+        updatePreferences(prefs[className], Parse.applicationId, className);
+      }
+    }
+  }
+
+}
 
 export function updatePreferences(prefs, appId, className) {
   try {

--- a/src/lib/ParseApp.js
+++ b/src/lib/ParseApp.js
@@ -8,7 +8,7 @@
 import * as AJAX from 'lib/AJAX';
 import encodeFormData from 'lib/encodeFormData';
 import Parse from 'parse';
-import { updatePreferences, getPreferences } from 'lib/ClassPreferences';
+import { setClassPreferences } from 'lib/ClassPreferences';
 
 function setEnablePushSource(setting, enable) {
   const path = `/apps/${this.slug}/update_push_notifications`;
@@ -50,6 +50,7 @@ export default class ParseApp {
     classPreference,
     enableSecurityChecks,
     cloudConfigHistoryLimit,
+    preferencesClassName
   }) {
     this.name = appName;
     this.createdAt = created_at ? new Date(created_at) : new Date();
@@ -79,6 +80,7 @@ export default class ParseApp {
     this.scripts = scripts;
     this.enableSecurityChecks = !!enableSecurityChecks;
     this.cloudConfigHistoryLimit = cloudConfigHistoryLimit;
+    this.preferencesClassName = preferencesClassName;
 
     if (!supportedPushLocales) {
       console.warn(
@@ -109,23 +111,7 @@ export default class ParseApp {
     };
 
     this.hasCheckedForMigraton = false;
-
-    if (classPreference) {
-      for (const className in classPreference) {
-        const preferences = getPreferences(appId, className) || { filters: [] };
-        const { filters } = classPreference[className];
-        for (const filter of filters) {
-          if (Array.isArray(filter.filter)) {
-            filter.filter = JSON.stringify(filter.filter);
-          }
-          if (preferences.filters.some(row => JSON.stringify(row) === JSON.stringify(filter))) {
-            continue;
-          }
-          preferences.filters.push(filter);
-        }
-        updatePreferences(preferences, appId, className);
-      }
-    }
+    setClassPreferences(classPreference, appId);
   }
 
   setParseKeys() {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Closes: #2555

### Approach
<!-- Add a description of the approach in this PR. -->

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability for users to save and load dashboard column and class preferences to the server, enabling persistent customization across sessions.
  - New "Save" buttons appear in the dashboard settings when server-side preferences are enabled.

- **Documentation**
  - Updated the README with instructions on enabling and using server-side dashboard configuration saving.

- **Chores**
  - Simplified import paths within the project for easier code maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->