### PR TITLE
feat: Add quick-add button to array parameter in Cloud Config

### DIFF
--- a/src/dashboard/Data/Config/AddArrayEntryDialog.react.js
+++ b/src/dashboard/Data/Config/AddArrayEntryDialog.react.js
@@ -57,6 +57,7 @@ export default class AddArrayEntryDialog extends React.Component {
           }
           input={
             <TextInput
+              placeholder={'Enter value'}
               ref={this.inputRef}
               value={this.state.value}
               onChange={value => this.setState({ value })}

--- a/src/dashboard/Data/Config/AddArrayEntryDialog.react.js
+++ b/src/dashboard/Data/Config/AddArrayEntryDialog.react.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2016-present, Parse, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+import Field from 'components/Field/Field.react';
+import Label from 'components/Label/Label.react';
+import Modal from 'components/Modal/Modal.react';
+import React from 'react';
+import TextInput from 'components/TextInput/TextInput.react';
+
+export default class AddArrayEntryDialog extends React.Component {
+  constructor() {
+    super();
+    this.state = { value: '' };
+  }
+
+  valid() {
+    return this.state.value !== '';
+  }
+
+  getValue() {
+    try {
+      return JSON.parse(this.state.value);
+    } catch {
+      return this.state.value;
+    }
+  }
+
+  render() {
+    return (
+      <Modal
+        type={Modal.Types.INFO}
+        icon="plus-solid"
+        title="Add entry"
+        confirmText="Add"
+        cancelText="Cancel"
+        onCancel={this.props.onCancel}
+        onConfirm={() => this.props.onConfirm(this.getValue())}
+        disabled={!this.valid()}
+      >
+        <Field
+          label={<Label text="Value" />}
+          input={<TextInput autofocus={true} value={this.state.value} onChange={value => this.setState({ value })} />}
+        />
+      </Modal>
+    );
+  }
+}

--- a/src/dashboard/Data/Config/AddArrayEntryDialog.react.js
+++ b/src/dashboard/Data/Config/AddArrayEntryDialog.react.js
@@ -42,14 +42,19 @@ export default class AddArrayEntryDialog extends React.Component {
         type={Modal.Types.INFO}
         icon="plus-solid"
         title="Add entry"
-        confirmText="Add"
+        confirmText="Add Unique"
         cancelText="Cancel"
         onCancel={this.props.onCancel}
         onConfirm={() => this.props.onConfirm(this.getValue())}
         disabled={!this.valid()}
       >
         <Field
-          label={<Label text="Value" />}
+          label={
+            <Label
+              text="Value"
+              description="The type is determined based on the entered value. Use quotation marks to enforce string type."
+            />
+          }
           input={
             <TextInput
               ref={this.inputRef}

--- a/src/dashboard/Data/Config/AddArrayEntryDialog.react.js
+++ b/src/dashboard/Data/Config/AddArrayEntryDialog.react.js
@@ -15,6 +15,13 @@ export default class AddArrayEntryDialog extends React.Component {
   constructor() {
     super();
     this.state = { value: '' };
+    this.inputRef = React.createRef();
+  }
+
+  componentDidMount() {
+    if (this.inputRef.current) {
+      this.inputRef.current.focus();
+    }
   }
 
   valid() {
@@ -43,7 +50,13 @@ export default class AddArrayEntryDialog extends React.Component {
       >
         <Field
           label={<Label text="Value" />}
-          input={<TextInput autofocus={true} value={this.state.value} onChange={value => this.setState({ value })} />}
+          input={
+            <TextInput
+              ref={this.inputRef}
+              value={this.state.value}
+              onChange={value => this.setState({ value })}
+            />
+          }
         />
       </Modal>
     );

--- a/src/dashboard/Data/Config/Config.react.js
+++ b/src/dashboard/Data/Config/Config.react.js
@@ -278,7 +278,7 @@ class Config extends TableView {
         <td style={columnStyleAction}>
           {type === 'Array' && (
             <a
-              className={configStyles.actionIcon}
+              className={configStyles.configActionIcon}
               onClick={() => this.openAddEntryDialog(data.param)}
             >
               <Icon width={18} height={18} name="plus-solid" />

--- a/src/dashboard/Data/Config/Config.react.js
+++ b/src/dashboard/Data/Config/Config.react.js
@@ -497,6 +497,8 @@ class Config extends TableView {
   async addArrayEntry(param, value) {
     try {
       this.setState({ loading: true });
+      const masterKeyOnlyMap = this.props.config.data.get('masterKeyOnly');
+      const masterKeyOnly = masterKeyOnlyMap?.get(param) || false;
       await Parse._request(
         'PUT',
         'config',
@@ -504,6 +506,7 @@ class Config extends TableView {
           params: {
             [param]: { __op: 'AddUnique', objects: [Parse._encode(value)] },
           },
+          masterKeyOnly: { [param]: masterKeyOnly },
         },
         { useMasterKey: true }
       );

--- a/src/dashboard/Data/Config/Config.react.js
+++ b/src/dashboard/Data/Config/Config.react.js
@@ -9,6 +9,7 @@ import { ActionTypes } from 'lib/stores/ConfigStore';
 import Button from 'components/Button/Button.react';
 import ConfigDialog from 'dashboard/Data/Config/ConfigDialog.react';
 import DeleteParameterDialog from 'dashboard/Data/Config/DeleteParameterDialog.react';
+import AddArrayEntryDialog from 'dashboard/Data/Config/AddArrayEntryDialog.react';
 import EmptyState from 'components/EmptyState/EmptyState.react';
 import Icon from 'components/Icon/Icon.react';
 import { isDate } from 'lib/DateUtils';
@@ -44,6 +45,8 @@ class Config extends TableView {
       confirmModalOpen: false,
       lastError: null,
       lastNote: null,
+      showAddEntryDialog: false,
+      addEntryParam: '',
     };
     this.noteTimeout = null;
   }
@@ -109,6 +112,15 @@ class Config extends TableView {
           param={this.state.modalParam}
           onCancel={() => this.setState({ showDeleteParameterDialog: false })}
           onConfirm={this.deleteParam.bind(this, this.state.modalParam)}
+        />
+      );
+    } else if (this.state.showAddEntryDialog) {
+      extras = (
+        <AddArrayEntryDialog
+          onCancel={this.closeAddEntryDialog.bind(this)}
+          onConfirm={value =>
+            this.addArrayEntry(this.state.addEntryParam, value)
+          }
         />
       );
     }
@@ -235,7 +247,8 @@ class Config extends TableView {
     // Define column styles
     const columnStyleLarge = { width: '30%', cursor: 'pointer' };
     const columnStyleSmall = { width: '15%', cursor: 'pointer' };
-    const columnStyleAction = { width: '10%', textAlign: 'center' };
+    const columnStyleValue = { width: '25%', cursor: 'pointer' };
+    const columnStyleAction = { width: '10%' };
 
     const openModalValueColumn = () => {
       if (data.value instanceof Parse.File) {
@@ -258,12 +271,12 @@ class Config extends TableView {
         <td style={columnStyleSmall} onClick={openModal}>
           {type}
         </td>
-        <td style={columnStyleLarge} onClick={openModalValueColumn}>
+        <td style={columnStyleValue} onClick={openModalValueColumn}>
           {value}
         </td>
         <td style={columnStyleAction}>
           {type === 'Array' && (
-            <a onClick={() => this.addArrayEntry(data.param)}>
+            <a onClick={() => this.openAddEntryDialog(data.param)}>
               <Icon width={16} height={16} name="plus-solid" />
             </a>
           )}
@@ -271,7 +284,7 @@ class Config extends TableView {
         <td style={columnStyleSmall} onClick={openModal}>
           {data.masterKeyOnly.toString()}
         </td>
-        <td style={{ textAlign: 'center' }}>
+        <td style={{ textAlign: 'center', width: '5%' }}>
           <a onClick={openDeleteParameterDialog}>
             <Icon width={16} height={16} name="trash-solid" fill="#ff395e" />
           </a>
@@ -473,17 +486,15 @@ class Config extends TableView {
     }, 3500);
   }
 
-  async addArrayEntry(param) {
-    const input = window.prompt('New array entry (JSON supported)');
-    if (input === null) {
-      return;
-    }
-    let value;
-    try {
-      value = JSON.parse(input);
-    } catch (e) {
-      value = input;
-    }
+  openAddEntryDialog(param) {
+    this.setState({ showAddEntryDialog: true, addEntryParam: param });
+  }
+
+  closeAddEntryDialog() {
+    this.setState({ showAddEntryDialog: false, addEntryParam: '' });
+  }
+
+  async addArrayEntry(param, value) {
     try {
       this.setState({ loading: true });
       await Parse._request(
@@ -503,6 +514,7 @@ class Config extends TableView {
     } finally {
       this.setState({ loading: false });
     }
+    this.closeAddEntryDialog();
   }
 }
 

--- a/src/dashboard/Data/Config/Config.react.js
+++ b/src/dashboard/Data/Config/Config.react.js
@@ -23,6 +23,7 @@ import browserStyles from 'dashboard/Data/Browser/Browser.scss';
 import { CurrentApp } from 'context/currentApp';
 import Modal from 'components/Modal/Modal.react';
 import equal from 'fast-deep-equal';
+import Notification from 'dashboard/Data/Browser/Notification.react';
 
 @subscribeTo('Config', 'config')
 class Config extends TableView {
@@ -41,7 +42,10 @@ class Config extends TableView {
       modalMasterKeyOnly: false,
       loading: false,
       confirmModalOpen: false,
+      lastError: null,
+      lastNote: null,
     };
+    this.noteTimeout = null;
   }
 
   componentWillMount() {
@@ -127,12 +131,24 @@ class Config extends TableView {
           }}
         >
           <div className={[browserStyles.confirmConfig]}>
-            This parameter changed while you were editing it. If you continue, the latest changes will be lost and replaced with your version. Do you want to proceed?
+            This parameter changed while you were editing it. If you continue, the latest changes
+            will be lost and replaced with your version. Do you want to proceed?
           </div>
         </Modal>
       );
     }
-    return extras;
+    let notification = null;
+    if (this.state.lastError) {
+      notification = <Notification note={this.state.lastError} isErrorNote={true} />;
+    } else if (this.state.lastNote) {
+      notification = <Notification note={this.state.lastNote} isErrorNote={false} />;
+    }
+    return (
+      <>
+        {extras}
+        {notification}
+      </>
+    );
   }
 
   parseValueForModal(dataValue) {
@@ -186,7 +202,6 @@ class Config extends TableView {
      * Opens the modal dialog to edit the Config parameter.
      */
     const openModal = async () => {
-
       // Show dialog
       this.setState({
         loading: true,
@@ -203,7 +218,8 @@ class Config extends TableView {
       // Get latest param values
       const fetchedParams = this.props.config.data.get('params');
       const fetchedValue = fetchedParams.get(this.state.modalParam);
-      const fetchedMasterKeyOnly = this.props.config.data.get('masterKeyOnly')?.get(this.state.modalParam) || false;
+      const fetchedMasterKeyOnly =
+        this.props.config.data.get('masterKeyOnly')?.get(this.state.modalParam) || false;
 
       // Parse fetched data
       const { modalValue: fetchedModalValue } = this.parseValueForModal(fetchedValue);
@@ -219,6 +235,7 @@ class Config extends TableView {
     // Define column styles
     const columnStyleLarge = { width: '30%', cursor: 'pointer' };
     const columnStyleSmall = { width: '15%', cursor: 'pointer' };
+    const columnStyleAction = { width: '10%', textAlign: 'center' };
 
     const openModalValueColumn = () => {
       if (data.value instanceof Parse.File) {
@@ -244,6 +261,13 @@ class Config extends TableView {
         <td style={columnStyleLarge} onClick={openModalValueColumn}>
           {value}
         </td>
+        <td style={columnStyleAction}>
+          {type === 'Array' && (
+            <a onClick={() => this.addArrayEntry(data.param)}>
+              <Icon width={16} height={16} name="plus-solid" />
+            </a>
+          )}
+        </td>
         <td style={columnStyleSmall} onClick={openModal}>
           {data.masterKeyOnly.toString()}
         </td>
@@ -264,8 +288,11 @@ class Config extends TableView {
       <TableHeader key="type" width={15}>
         Type
       </TableHeader>,
-      <TableHeader key="value" width={30}>
+      <TableHeader key="value" width={25}>
         Value
+      </TableHeader>,
+      <TableHeader key="action" width={10}>
+        Action
       </TableHeader>,
       <TableHeader key="masterKeyOnly" width={15}>
         Master key only
@@ -429,6 +456,53 @@ class Config extends TableView {
       modalValue: '',
       modalMasterKeyOnly: false,
     });
+  }
+
+  showNote(message, isError) {
+    if (!message) {
+      return;
+    }
+    clearTimeout(this.noteTimeout);
+    if (isError) {
+      this.setState({ lastError: message, lastNote: null });
+    } else {
+      this.setState({ lastNote: message, lastError: null });
+    }
+    this.noteTimeout = setTimeout(() => {
+      this.setState({ lastError: null, lastNote: null });
+    }, 3500);
+  }
+
+  async addArrayEntry(param) {
+    const input = window.prompt('New array entry (JSON supported)');
+    if (input === null) {
+      return;
+    }
+    let value;
+    try {
+      value = JSON.parse(input);
+    } catch (e) {
+      value = input;
+    }
+    try {
+      this.setState({ loading: true });
+      await Parse._request(
+        'PUT',
+        'config',
+        {
+          params: {
+            [param]: { __op: 'AddUnique', objects: [Parse._encode(value)] },
+          },
+        },
+        { useMasterKey: true }
+      );
+      await this.props.config.dispatch(ActionTypes.FETCH);
+      this.showNote('Entry added');
+    } catch (e) {
+      this.showNote(`Failed to add entry: ${e.message}`, true);
+    } finally {
+      this.setState({ loading: false });
+    }
   }
 }
 

--- a/src/dashboard/Data/Config/Config.react.js
+++ b/src/dashboard/Data/Config/Config.react.js
@@ -281,7 +281,7 @@ class Config extends TableView {
               className={configStyles.actionIcon}
               onClick={() => this.openAddEntryDialog(data.param)}
             >
-              <Icon width={16} height={16} name="plus-solid" />
+              <Icon width={18} height={18} name="plus-solid" />
             </a>
           )}
         </td>

--- a/src/dashboard/Data/Config/Config.react.js
+++ b/src/dashboard/Data/Config/Config.react.js
@@ -281,7 +281,7 @@ class Config extends TableView {
               className={configStyles.actionIcon}
               onClick={() => this.openAddEntryDialog(data.param)}
             >
-              <Icon width={12} height={12} name="plus-solid" />
+              <Icon width={16} height={16} name="plus-solid" />
             </a>
           )}
         </td>

--- a/src/dashboard/Data/Config/Config.react.js
+++ b/src/dashboard/Data/Config/Config.react.js
@@ -511,6 +511,40 @@ class Config extends TableView {
         { useMasterKey: true }
       );
       await this.props.config.dispatch(ActionTypes.FETCH);
+
+      // Update config history
+      const limit = this.context.cloudConfigHistoryLimit;
+      const applicationId = this.context.applicationId;
+      const params = this.props.config.data.get('params');
+      const updatedValue = params.get(param);
+      const configHistory = localStorage.getItem(`${applicationId}_configHistory`);
+      const newHistoryEntry = {
+        time: new Date(),
+        value: updatedValue,
+      };
+
+      if (!configHistory) {
+        localStorage.setItem(
+          `${applicationId}_configHistory`,
+          JSON.stringify({
+            [param]: [newHistoryEntry],
+          })
+        );
+      } else {
+        const oldConfigHistory = JSON.parse(configHistory);
+        const updatedHistory = !oldConfigHistory[param]
+          ? [newHistoryEntry]
+          : [newHistoryEntry, ...oldConfigHistory[param]].slice(0, limit || 100);
+
+        localStorage.setItem(
+          `${applicationId}_configHistory`,
+          JSON.stringify({
+            ...oldConfigHistory,
+            [param]: updatedHistory,
+          })
+        );
+      }
+
       this.showNote('Entry added');
     } catch (e) {
       this.showNote(`Failed to add entry: ${e.message}`, true);

--- a/src/dashboard/Data/Config/Config.react.js
+++ b/src/dashboard/Data/Config/Config.react.js
@@ -21,6 +21,7 @@ import TableHeader from 'components/Table/TableHeader.react';
 import TableView from 'dashboard/TableView.react';
 import Toolbar from 'components/Toolbar/Toolbar.react';
 import browserStyles from 'dashboard/Data/Browser/Browser.scss';
+import configStyles from 'dashboard/Data/Config/Config.scss';
 import { CurrentApp } from 'context/currentApp';
 import Modal from 'components/Modal/Modal.react';
 import equal from 'fast-deep-equal';
@@ -276,8 +277,11 @@ class Config extends TableView {
         </td>
         <td style={columnStyleAction}>
           {type === 'Array' && (
-            <a onClick={() => this.openAddEntryDialog(data.param)}>
-              <Icon width={16} height={16} name="plus-solid" />
+            <a
+              className={configStyles.actionIcon}
+              onClick={() => this.openAddEntryDialog(data.param)}
+            >
+              <Icon width={12} height={12} name="plus-solid" />
             </a>
           )}
         </td>

--- a/src/dashboard/Data/Config/Config.scss
+++ b/src/dashboard/Data/Config/Config.scss
@@ -1,6 +1,13 @@
 @import 'stylesheets/globals.scss';
 
 .actionIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  vertical-align: middle;
+  width: 25px;
+  height: 25px;
+  cursor: pointer;
   svg {
     fill: $darkBlue;
   }

--- a/src/dashboard/Data/Config/Config.scss
+++ b/src/dashboard/Data/Config/Config.scss
@@ -1,16 +1,8 @@
 @import 'stylesheets/globals.scss';
 
 .actionIcon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  background-color: $lightBlue;
-
   svg {
-    fill: $darkBlue;
+    fill: $lightBlue;
   }
 }
 

--- a/src/dashboard/Data/Config/Config.scss
+++ b/src/dashboard/Data/Config/Config.scss
@@ -9,7 +9,8 @@
   height: 25px;
   cursor: pointer;
   svg {
-    fill: $darkBlue;
+    fill: currentColor;
+    color: $darkBlue;
   }
 }
 

--- a/src/dashboard/Data/Config/Config.scss
+++ b/src/dashboard/Data/Config/Config.scss
@@ -2,7 +2,7 @@
 
 .actionIcon {
   svg {
-    fill: $lightBlue;
+    fill: $darkBlue;
   }
 }
 

--- a/src/dashboard/Data/Config/Config.scss
+++ b/src/dashboard/Data/Config/Config.scss
@@ -1,0 +1,16 @@
+@import 'stylesheets/globals.scss';
+
+.actionIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background-color: $lightBlue;
+
+  svg {
+    fill: $darkBlue;
+  }
+}
+

--- a/src/dashboard/Data/Config/Config.scss
+++ b/src/dashboard/Data/Config/Config.scss
@@ -1,6 +1,6 @@
 @import 'stylesheets/globals.scss';
 
-.actionIcon {
+.configActionIcon {
   display: inline-flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- show notifications on Config page
- allow adding unique entry to array Config parameters
- add Action column in Config table

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint/config')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b1b37db54832d89ef6887e264b889

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user notifications for success and error messages when performing configuration actions.
  * Introduced an action button to add entries to array-type configuration parameters, supporting JSON input.

* **Style**
  * Updated table layout to include a new "Action" column and improved column alignment.
  * Added styles for the new action button with icon and hover effects.

* **Documentation**
  * Enhanced modal confirmation text formatting for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->