### PR TITLE
feat: Add clipboard icon to copy value of key-value element in info panel

### DIFF
--- a/src/components/AggregationPanel/AggregationPanel.js
+++ b/src/components/AggregationPanel/AggregationPanel.js
@@ -101,7 +101,15 @@ const AggregationPanel = ({
             case 'text':
               return <TextElement key={idx} text={item.text} style={item.style} />;
             case 'keyValue':
-              return <KeyValueElement key={idx} item={item} appName={appName} style={item.style} />;
+              return (
+                <KeyValueElement
+                  key={idx}
+                  item={item}
+                  appName={appName}
+                  showNote={showNote}
+                  style={item.style}
+                />
+              );
             case 'table':
               return <TableElement key={idx} columns={item.columns} rows={item.rows} style={item.style} />;
             case 'image':

--- a/src/components/AggregationPanel/AggregationPanel.scss
+++ b/src/components/AggregationPanel/AggregationPanel.scss
@@ -27,6 +27,8 @@
         display: none;
         cursor: pointer;
         margin-left: 4px;
+        color: inherit;
+        opacity: 0.6;
     }
 
     &:hover .copyIcon {

--- a/src/components/AggregationPanel/AggregationPanel.scss
+++ b/src/components/AggregationPanel/AggregationPanel.scss
@@ -21,6 +21,17 @@
     font-size: 14px;
     display: flex;
     gap: 10px;
+    align-items: center;
+
+    .copyIcon {
+        display: none;
+        cursor: pointer;
+        margin-left: 4px;
+    }
+
+    &:hover .copyIcon {
+        display: inline-block;
+    }
 }
 
 .video {

--- a/src/components/AggregationPanel/AggregationPanelComponents.js
+++ b/src/components/AggregationPanel/AggregationPanelComponents.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import copy from 'copy-to-clipboard';
+import Icon from 'components/Icon/Icon.react';
 import styles from './AggregationPanel.scss';
 
 // Text Element Component
@@ -9,18 +11,30 @@ export const TextElement = ({ text, style}) => (
 );
 
 // Key-Value Element Component
-export const KeyValueElement = ({ item, appName, style }) => (
-  <div className={styles.keyValue} style={style}>
-    {item.key}:
-    {item.url ? (
-      <a href={item.isRelativeUrl ? `apps/${appName}/${item.url}` : item.url} target="_blank" rel="noreferrer">
-        {item.value}
-      </a>
-    ) : (
-      <span>{item.value}</span>
-    )}
-  </div>
-);
+export const KeyValueElement = ({ item, appName, style, showNote }) => {
+  const handleCopy = () => {
+    copy(String(item.value));
+    if (showNote) {
+      showNote('Value copied to clipboard', false);
+    }
+  };
+
+  return (
+    <div className={styles.keyValue} style={style}>
+      {item.key}:
+      {item.url ? (
+        <a href={item.isRelativeUrl ? `apps/${appName}/${item.url}` : item.url} target="_blank" rel="noreferrer">
+          {item.value}
+        </a>
+      ) : (
+        <span>{item.value}</span>
+      )}
+      <span className={styles.copyIcon} onClick={handleCopy}>
+        <Icon name="clone-icon" width={12} height={12} />
+      </span>
+    </div>
+  );
+};
 
 // Table Element Component
 export const TableElement = ({ columns, rows, style }) => (

--- a/src/components/AggregationPanel/AggregationPanelComponents.js
+++ b/src/components/AggregationPanel/AggregationPanelComponents.js
@@ -30,7 +30,7 @@ export const KeyValueElement = ({ item, appName, style, showNote }) => {
         <span>{item.value}</span>
       )}
       <span className={styles.copyIcon} onClick={handleCopy}>
-        <Icon name="clone-icon" width={12} height={12} />
+        <Icon name="clone-icon" width={12} height={12} fill="currentColor" />
       </span>
     </div>
   );


### PR DESCRIPTION
## Summary
- show copy icon in info panel values
- allow copying of KeyValueElement values

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find module 'eslint/config')*

------
https://chatgpt.com/codex/tasks/task_e_686ba5f9d250832dab77f9cd8c029c44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a copy-to-clipboard icon to key-value items, allowing users to easily copy values with one click.
  * Display of a notification message when a value is copied (if enabled).

* **Style**
  * Improved alignment and hover effects for key-value items, including showing the copy icon only on hover for a cleaner interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->