### PR TITLE
feat: Make sidebar width adjustable

### DIFF
--- a/src/components/CategoryList/CategoryList.scss
+++ b/src/components/CategoryList/CategoryList.scss
@@ -13,10 +13,10 @@
   border-left: 1px solid #3e87b2;
 
   a {
-    display: block;
+    display: flex;
+    align-items: center;
     padding-left: 12px;
     height: 20px;
-    line-height: 20px;
     color: #8fb9cf;
     font-size: 12px;
 
@@ -33,12 +33,11 @@
 
       &:first-of-type {
         @include DosisFont;
-        float: right;
-        width: 50px;
+        flex: 0 0 50px;
         text-align: right;
       }
       &:last-of-type {
-        margin-right: 50px;
+        flex: 1 1 auto;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;

--- a/src/components/CategoryList/CategoryList.scss
+++ b/src/components/CategoryList/CategoryList.scss
@@ -13,10 +13,10 @@
   border-left: 1px solid #3e87b2;
 
   a {
-    display: flex;
-    align-items: center;
+    display: block;
     padding-left: 12px;
     height: 20px;
+    line-height: 20px;
     color: #8fb9cf;
     font-size: 12px;
 
@@ -33,11 +33,12 @@
 
       &:first-of-type {
         @include DosisFont;
-        flex: 0 0 50px;
+        float: right;
+        width: 50px;
         text-align: right;
       }
       &:last-of-type {
-        flex: 1 1 auto;
+        margin-right: 50px;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;

--- a/src/components/FlowFooter/FlowFooter.scss
+++ b/src/components/FlowFooter/FlowFooter.scss
@@ -10,7 +10,7 @@
 .footer {
   @include animation('footer-enter 0.5s cubic-bezier(0.165, 0.84, 0.44, 1)');
   position: fixed;
-  left: 300px;
+  left: var(--sidebar-width, 300px);
   right: 0;
   bottom: 0;
   background: #fbfbfc;

--- a/src/components/Sidebar/Sidebar.scss
+++ b/src/components/Sidebar/Sidebar.scss
@@ -330,9 +330,6 @@ a.subitem {
   color: white;
 
   > *:first-child {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    width: 100%;
     position: absolute;
     letter-spacing: 2px;
     line-height: 12px;

--- a/src/components/Sidebar/Sidebar.scss
+++ b/src/components/Sidebar/Sidebar.scss
@@ -330,6 +330,9 @@ a.subitem {
   color: white;
 
   > *:first-child {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    width: 100%;
     position: absolute;
     letter-spacing: 2px;
     line-height: 12px;

--- a/src/components/Sidebar/Sidebar.scss
+++ b/src/components/Sidebar/Sidebar.scss
@@ -14,13 +14,23 @@ $footerHeight: 36px;
 
 .sidebar {
   position: fixed;
-  width: 300px;
+  width: var(--sidebar-width, 300px);
   top: 0;
   left: 0;
   bottom: 0;
   background: #0c5582;
   color: #fff;
   z-index: 100;
+
+  .resizeHandle {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: 5px;
+    cursor: col-resize;
+    user-select: none;
+  }
 
   &.collapsed {
     left: 0;
@@ -161,7 +171,7 @@ $footerHeight: 36px;
 .appsMenu {
   overflow: auto;
   background: #094162;
-  width: 300px;
+  width: var(--sidebar-width, 300px);
 
   .menuRow:hover {
     background: #0c5582;

--- a/src/components/Toolbar/Toolbar.scss
+++ b/src/components/Toolbar/Toolbar.scss
@@ -11,7 +11,7 @@
   position: fixed;
   top: 0;
   right: 0;
-  left: 300px;
+  left: var(--sidebar-width, 300px);
   background: #353446;
   height: 96px;
   color: white;

--- a/src/dashboard/Dashboard.scss
+++ b/src/dashboard/Dashboard.scss
@@ -8,7 +8,7 @@
 @import 'stylesheets/globals.scss';
 
 .content {
-  margin-left: 300px;
+  margin-left: var(--sidebar-width, 300px);
   overflow: auto;
   max-height: 100vh;
 }

--- a/src/dashboard/Data/Browser/Browser.scss
+++ b/src/dashboard/Data/Browser/Browser.scss
@@ -10,7 +10,7 @@
 .browser {
   position: fixed;
   top: 96px;
-  left: 300px;
+  left: var(--sidebar-width, 300px);
   right: 0;
   bottom: 36px;
   overflow: auto;
@@ -24,7 +24,7 @@ body:global(.expanded) {
 
 .empty {
   position: fixed;
-  left: 300px;
+  left: var(--sidebar-width, 300px);
   top: 0;
   bottom: 0;
   right: 0;

--- a/src/dashboard/Data/Browser/BrowserFooter.scss
+++ b/src/dashboard/Data/Browser/BrowserFooter.scss
@@ -2,7 +2,7 @@
 
 .footer {
   position: absolute;
-  width: calc(100% - 300px);
+  width: calc(100% - var(--sidebar-width, 300px));
   bottom: 0;
   gap: 10px;
   padding: 0px 15px;

--- a/src/dashboard/TableView.scss
+++ b/src/dashboard/TableView.scss
@@ -10,7 +10,7 @@
 .headers {
   position: fixed;
   top: 96px;
-  left: 300px;
+  left: var(--sidebar-width, 300px);
   right: 0;
   background: #66637A;
   height: 30px;

--- a/src/parse-interface-guide/PIG.scss
+++ b/src/parse-interface-guide/PIG.scss
@@ -11,7 +11,7 @@
 .sidebar {
   position: fixed;
   background: white;
-  width: 300px;
+  width: var(--sidebar-width, 300px);
   padding: 10px;
   border-right: 1px solid #b0b8bf;
   top: 0;
@@ -53,7 +53,7 @@
 }
 
 .content {
-  margin-left: 300px;
+  margin-left: var(--sidebar-width, 300px);
   padding: 20px 10px 10px 10px;
   min-height: 100vh;
 }

--- a/src/stylesheets/base.scss
+++ b/src/stylesheets/base.scss
@@ -7,6 +7,10 @@
  */
 @import 'globals.scss';
 
+:root {
+  --sidebar-width: 300px;
+}
+
 html, body {
   min-height: 100vh;
 }


### PR DESCRIPTION
## Summary
- add global CSS variable for sidebar width
- adjust layout styles to use `--sidebar-width`
- add resize handle and logic to sidebar 
- install dependencies to run tests

## Testing
- `npm test` *(fails: Cannot read properties of undefined (reading 'statusCode'))*

------
https://chatgpt.com/codex/tasks/task_e_686bb3991f68832dbaacc10d547636ca

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability for users to resize the sidebar by dragging a handle, with the chosen width saved for future sessions.

* **Style**
  * Updated various interface elements (sidebar, toolbar, footers, content areas) to dynamically adjust their position and size based on the sidebar’s width.
  * Introduced a CSS variable for sidebar width, enabling consistent and flexible layout adjustments throughout the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->