### PR TITLE
feat: Add type mismatch warning when quick-adding entry to Cloud Config array parameter

### DIFF
--- a/src/dashboard/Data/Config/AddArrayEntryDialog.react.js
+++ b/src/dashboard/Data/Config/AddArrayEntryDialog.react.js
@@ -126,8 +126,12 @@ export default class AddArrayEntryDialog extends React.Component {
           <Field
             label={
               <Label
-                text="Confirm type"
-                description={`Previous item is ${this.props.lastType}, new entry is ${this.state.parsedType}.`}
+                text="⚠️ Ignore type mismatch"
+                description={
+                  <>
+                    Previous item type is <strong>{this.props.lastType}</strong>, new entry type is <strong>{this.state.parsedType}</strong>.
+                  </>
+                }
               />
             }
             input={

--- a/src/dashboard/Data/Config/AddArrayEntryDialog.react.js
+++ b/src/dashboard/Data/Config/AddArrayEntryDialog.react.js
@@ -56,11 +56,18 @@ export default class AddArrayEntryDialog extends React.Component {
 
     if (lastType && entryType !== lastType) {
       if (!this.state.showMismatchRow) {
-        this.setState({
-          showMismatchRow: true,
-          mismatchConfirmed: false,
-          parsedType: entryType,
-        });
+        this.setState(
+          {
+            showMismatchRow: true,
+            mismatchConfirmed: false,
+            parsedType: entryType,
+          },
+          () => {
+            if (document.activeElement instanceof HTMLElement) {
+              document.activeElement.blur();
+            }
+          }
+        );
         return;
       }
       if (!this.state.mismatchConfirmed) {

--- a/src/dashboard/Data/Config/AddArrayEntryDialog.react.js
+++ b/src/dashboard/Data/Config/AddArrayEntryDialog.react.js
@@ -10,11 +10,17 @@ import Label from 'components/Label/Label.react';
 import Modal from 'components/Modal/Modal.react';
 import React from 'react';
 import TextInput from 'components/TextInput/TextInput.react';
+import Checkbox from 'components/Checkbox/Checkbox.react';
 
 export default class AddArrayEntryDialog extends React.Component {
   constructor() {
     super();
-    this.state = { value: '', showWarning: false, parsedValue: null, parsedType: '' };
+    this.state = {
+      value: '',
+      showMismatchRow: false,
+      mismatchConfirmed: false,
+      parsedType: '',
+    };
     this.inputRef = React.createRef();
   }
 
@@ -25,7 +31,13 @@ export default class AddArrayEntryDialog extends React.Component {
   }
 
   valid() {
-    return this.state.value !== '';
+    if (this.state.value === '') {
+      return false;
+    }
+    if (this.state.showMismatchRow && !this.state.mismatchConfirmed) {
+      return false;
+    }
+    return true;
   }
 
   getValue() {
@@ -50,12 +62,28 @@ export default class AddArrayEntryDialog extends React.Component {
     const parsed = this.getValue();
     const entryType = this.getType(parsed);
     const lastType = this.props.lastType;
-    if (lastType && entryType !== lastType && !this.state.showWarning) {
-      this.setState({ showWarning: true, parsedValue: parsed, parsedType: entryType });
-      return;
+
+    if (lastType && entryType !== lastType) {
+      if (!this.state.showMismatchRow) {
+        this.setState({
+          showMismatchRow: true,
+          mismatchConfirmed: false,
+          parsedType: entryType,
+        });
+        return;
+      }
+      if (!this.state.mismatchConfirmed) {
+        return;
+      }
     }
+
     this.props.onConfirm(parsed);
-    this.setState({ showWarning: false, parsedValue: null, parsedType: '' });
+    this.setState({
+      value: '',
+      showMismatchRow: false,
+      mismatchConfirmed: false,
+      parsedType: '',
+    });
   }
 
   render() {
@@ -82,34 +110,35 @@ export default class AddArrayEntryDialog extends React.Component {
               placeholder={'Enter value'}
               ref={this.inputRef}
               value={this.state.value}
-              onChange={value => this.setState({ value })}
+              onChange={value =>
+                this.setState({
+                  value,
+                  showMismatchRow: false,
+                  mismatchConfirmed: false,
+                })
+              }
             />
           }
         />
+        {this.state.showMismatchRow && (
+          <Field
+            label={
+              <Label
+                text="Confirm type"
+                description={`Previous item is ${this.props.lastType}, new entry is ${this.state.parsedType}.`}
+              />
+            }
+            input={
+              <Checkbox
+                checked={this.state.mismatchConfirmed}
+                onChange={checked => this.setState({ mismatchConfirmed: checked })}
+              />
+            }
+          />
+        )}
       </Modal>
     );
 
-    const warningModal = this.state.showWarning ? (
-      <Modal
-        type={Modal.Types.WARNING}
-        icon="warn-outline"
-        title="Type Mismatch"
-        confirmText="Add"
-        cancelText="Cancel"
-        onCancel={() => this.setState({ showWarning: false })}
-        onConfirm={() => this.handleConfirm()}
-      >
-        <div>
-          The type of the previous item (<strong>{this.props.lastType}</strong>) does not correspond to the type of the entry (<strong>{this.state.parsedType}</strong>). Do you want to proceed?
-        </div>
-      </Modal>
-    ) : null;
-
-    return (
-      <>
-        {addEntryModal}
-        {warningModal}
-      </>
-    );
+    return addEntryModal;
   }
 }

--- a/src/dashboard/Data/Config/AddArrayEntryDialog.react.js
+++ b/src/dashboard/Data/Config/AddArrayEntryDialog.react.js
@@ -30,15 +30,6 @@ export default class AddArrayEntryDialog extends React.Component {
     }
   }
 
-  valid() {
-    if (this.state.value === '') {
-      return false;
-    }
-    if (this.state.showMismatchRow && !this.state.mismatchConfirmed) {
-      return false;
-    }
-    return true;
-  }
 
   getValue() {
     try {
@@ -87,6 +78,10 @@ export default class AddArrayEntryDialog extends React.Component {
   }
 
   render() {
+    const confirmDisabled =
+      this.state.value === '' ||
+      (this.state.showMismatchRow && !this.state.mismatchConfirmed);
+
     const addEntryModal = (
       <Modal
         type={Modal.Types.INFO}
@@ -96,7 +91,7 @@ export default class AddArrayEntryDialog extends React.Component {
         cancelText="Cancel"
         onCancel={this.props.onCancel}
         onConfirm={this.handleConfirm.bind(this)}
-        disabled={!this.valid()}
+        disabled={confirmDisabled}
       >
         <Field
           label={

--- a/src/dashboard/Data/Config/AddArrayEntryDialog.react.js
+++ b/src/dashboard/Data/Config/AddArrayEntryDialog.react.js
@@ -14,7 +14,7 @@ import TextInput from 'components/TextInput/TextInput.react';
 export default class AddArrayEntryDialog extends React.Component {
   constructor() {
     super();
-    this.state = { value: '' };
+    this.state = { value: '', showWarning: false, parsedValue: null, parsedType: '' };
     this.inputRef = React.createRef();
   }
 
@@ -36,8 +36,30 @@ export default class AddArrayEntryDialog extends React.Component {
     }
   }
 
+  getType(value) {
+    if (Array.isArray(value)) {
+      return 'array';
+    }
+    if (value === null) {
+      return 'null';
+    }
+    return typeof value;
+  }
+
+  handleConfirm() {
+    const parsed = this.getValue();
+    const entryType = this.getType(parsed);
+    const lastType = this.props.lastType;
+    if (lastType && entryType !== lastType && !this.state.showWarning) {
+      this.setState({ showWarning: true, parsedValue: parsed, parsedType: entryType });
+      return;
+    }
+    this.props.onConfirm(parsed);
+    this.setState({ showWarning: false, parsedValue: null, parsedType: '' });
+  }
+
   render() {
-    return (
+    const addEntryModal = (
       <Modal
         type={Modal.Types.INFO}
         icon="plus-solid"
@@ -45,7 +67,7 @@ export default class AddArrayEntryDialog extends React.Component {
         confirmText="Add Unique"
         cancelText="Cancel"
         onCancel={this.props.onCancel}
-        onConfirm={() => this.props.onConfirm(this.getValue())}
+        onConfirm={this.handleConfirm.bind(this)}
         disabled={!this.valid()}
       >
         <Field
@@ -65,6 +87,29 @@ export default class AddArrayEntryDialog extends React.Component {
           }
         />
       </Modal>
+    );
+
+    const warningModal = this.state.showWarning ? (
+      <Modal
+        type={Modal.Types.WARNING}
+        icon="warn-outline"
+        title="Type Mismatch"
+        confirmText="Add"
+        cancelText="Cancel"
+        onCancel={() => this.setState({ showWarning: false })}
+        onConfirm={() => this.handleConfirm()}
+      >
+        <div>
+          The type of the previous item (<strong>{this.props.lastType}</strong>) does not correspond to the type of the entry (<strong>{this.state.parsedType}</strong>). Do you want to proceed?
+        </div>
+      </Modal>
+    ) : null;
+
+    return (
+      <>
+        {addEntryModal}
+        {warningModal}
+      </>
     );
   }
 }

--- a/src/dashboard/Data/Config/Config.react.js
+++ b/src/dashboard/Data/Config/Config.react.js
@@ -48,6 +48,7 @@ class Config extends TableView {
       lastNote: null,
       showAddEntryDialog: false,
       addEntryParam: '',
+      addEntryLastType: null,
     };
     this.noteTimeout = null;
   }
@@ -122,6 +123,7 @@ class Config extends TableView {
           onConfirm={value =>
             this.addArrayEntry(this.state.addEntryParam, value)
           }
+          lastType={this.state.addEntryLastType}
         />
       );
     }
@@ -205,6 +207,16 @@ class Config extends TableView {
       modalValue: modalValue,
       type: type,
     };
+  }
+
+  getEntryType(value) {
+    if (Array.isArray(value)) {
+      return 'array';
+    }
+    if (value === null) {
+      return 'null';
+    }
+    return typeof value;
   }
 
   renderRow(data) {
@@ -491,11 +503,25 @@ class Config extends TableView {
   }
 
   openAddEntryDialog(param) {
-    this.setState({ showAddEntryDialog: true, addEntryParam: param });
+    const params = this.props.config.data.get('params');
+    const arr = params?.get(param);
+    let lastType = null;
+    if (Array.isArray(arr) && arr.length > 0) {
+      lastType = this.getEntryType(arr[arr.length - 1]);
+    }
+    this.setState({
+      showAddEntryDialog: true,
+      addEntryParam: param,
+      addEntryLastType: lastType,
+    });
   }
 
   closeAddEntryDialog() {
-    this.setState({ showAddEntryDialog: false, addEntryParam: '' });
+    this.setState({
+      showAddEntryDialog: false,
+      addEntryParam: '',
+      addEntryLastType: null,
+    });
   }
 
   async addArrayEntry(param, value) {


### PR DESCRIPTION
## Summary
- determine the last array element type when opening the add-entry dialog
- warn the user if the entered value type differs from the last element

## Testing
- `npm test` *(fails: dashboard e2e test requires network)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686db1a92488832d822746877e20f412

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a warning prompt when adding an array entry with a type different from the previous one, requiring user confirmation.
  * The "Add Array Entry" dialog now displays the type of the last array entry for improved context and consistency.

* **Bug Fixes**
  * Enhanced validation to prevent accidental confirmation of type mismatched entries, reducing data inconsistency risks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->