### PR TITLE
fix: Pagination footer bar hides rows in data browser

### DIFF
--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -235,10 +235,12 @@ export default class BrowserCell extends Component {
 
         // BrowserToolbar + DataBrowserHeader height
         const topBoundary = 126;
+        // Account for BrowserFooter height when checking the bottom boundary
+        const bottomBoundary = window.innerHeight - 36;
 
         if (left < leftBoundary || right > window.innerWidth) {
           node.scrollIntoView({ block: 'nearest', inline: 'start' });
-        } else if (top < topBoundary || bottom > window.innerHeight) {
+        } else if (top < topBoundary || bottom > bottomBoundary) {
           node.scrollIntoView({ block: 'nearest', inline: 'nearest' });
         }
       }


### PR DESCRIPTION
## Summary
- ensure cells are scrolled into view before hitting BrowserFooter

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find module 'eslint/config')*

------
https://chatgpt.com/codex/tasks/task_e_686e76052c40832db1eaa717673e5a14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scrolling behavior to ensure that cells are not hidden behind the footer when brought into view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->