### PR TITLE
fix: Fails to generate MFA code with CLI command `parse-dashboard --createMFA`

### DIFF
--- a/Parse-Dashboard/CLI/mfa.js
+++ b/Parse-Dashboard/CLI/mfa.js
@@ -1,5 +1,8 @@
 const crypto = require('crypto');
-const inquirer = require('inquirer');
+let inquirer = require('inquirer');
+if (inquirer.default) {
+  inquirer = inquirer.default;
+}
 const OTPAuth = require('otpauth');
 const { copy } = require('./utils.js');
 const phrases = {


### PR DESCRIPTION
## Summary
- ensure `inquirer` default export is used when running MFA helper

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686e86bac03c832dba3d4cc0988ec2d3