### PR TITLE
fix: Display ISO string for date objects in views

### DIFF
--- a/src/dashboard/Data/Views/Views.react.js
+++ b/src/dashboard/Data/Views/Views.react.js
@@ -129,8 +129,10 @@ class Views extends TableView {
         const columns = {};
         const computeWidth = str => {
           let text = str;
-          if (str && typeof str === 'object') {
-            text = str.__type === 'Date' && str.iso ? str.iso : JSON.stringify(str);
+          if (text === undefined) {
+            text = '';
+          } else if (text && typeof text === 'object') {
+            text = text.__type === 'Date' && text.iso ? text.iso : JSON.stringify(text);
           }
           text = String(text);
           if (typeof document !== 'undefined') {
@@ -304,6 +306,8 @@ class Views extends TableView {
             content = JSON.stringify(value);
           } else if (type === 'Date') {
             content = value && value.iso ? value.iso : String(value);
+          } else if (value === undefined) {
+            content = '';
           } else {
             content = String(value);
           }

--- a/src/dashboard/Data/Views/Views.react.js
+++ b/src/dashboard/Data/Views/Views.react.js
@@ -128,7 +128,11 @@ class Views extends TableView {
       .then(results => {
         const columns = {};
         const computeWidth = str => {
-          const text = typeof str === 'object' && str !== null ? JSON.stringify(str) : String(str);
+          let text = str;
+          if (str && typeof str === 'object') {
+            text = str.__type === 'Date' && str.iso ? str.iso : JSON.stringify(str);
+          }
+          text = String(text);
           if (typeof document !== 'undefined') {
             const canvas =
               computeWidth._canvas || (computeWidth._canvas = document.createElement('canvas'));
@@ -298,6 +302,8 @@ class Views extends TableView {
             );
           } else if (type === 'Object') {
             content = JSON.stringify(value);
+          } else if (type === 'Date') {
+            content = value && value.iso ? value.iso : String(value);
           } else {
             content = String(value);
           }


### PR DESCRIPTION
## Summary
- ensure computeWidth handles date objects correctly
- show the ISO value for Date objects in Views table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687303642844832d985b4ea4b4344226