### PR TITLE
fix: Warning dialog is shown after executing script on selected rows

### DIFF
--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -1721,7 +1721,10 @@ class Browser extends DashboardView {
           totalErrorCount > 0
         );
       }
-      this.refresh();
+      this.setState(
+        { selection: {}, showExecuteScriptRowsDialog: false },
+        () => this.refresh()
+      );
     } catch (e) {
       this.showNote(e.message, true);
       console.log(`Could not run ${script.title}: ${e}`);


### PR DESCRIPTION
## Summary
- avoid warning on auto-refresh after executing a script on selected rows

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687443c05ac8832d92d8112ad4cd0155

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the execution flow when running scripts on selected rows, ensuring the selection is cleared and dialogs are closed before refreshing the data. This provides a smoother and more predictable user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->