### PR TITLE
fix: Clicking linked pointer with Cmd key in view table doesn't open page in new browser tab

### DIFF
--- a/src/dashboard/Data/Views/Views.react.js
+++ b/src/dashboard/Data/Views/Views.react.js
@@ -328,7 +328,18 @@ class Views extends TableView {
             );
           }
           return (
-            <td key={name} className={classes.join(' ')}>
+            <td
+              key={name}
+              className={classes.join(' ')}
+              onClick={e => {
+                if (hasPill && e.metaKey) {
+                  this.handlePointerCmdClick({
+                    className: value.className,
+                    id: value.objectId,
+                  });
+                }
+              }}
+            >
               {cellContent}
             </td>
           );
@@ -579,6 +590,18 @@ class Views extends TableView {
       `browser/${className}?filters=${encodeURIComponent(filters)}`
     );
     this.props.navigate(path);
+  }
+
+  handlePointerCmdClick({ className, id, field = 'objectId' }) {
+    const filters = JSON.stringify([{ field, constraint: 'eq', compareTo: id }]);
+    window.open(
+      generatePath(
+        this.context,
+        `browser/${className}?filters=${encodeURIComponent(filters)}`,
+        true
+      ),
+      '_blank'
+    );
   }
 
   handleValueClick(value) {


### PR DESCRIPTION
## Summary
- handle cmd-click on view pointers like Browser pointers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687592a259d4832d954b01aac0357176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to Cmd+click pointer cells in data views to open the referenced object in a new browser tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->