### PR TITLE
feat: Allow freeform text view resizing in modal dialogs

### DIFF
--- a/changelogs/CHANGELOG_alpha.md
+++ b/changelogs/CHANGELOG_alpha.md
@@ -5,6 +5,10 @@
 
 * Persist info panel visibility when navigating across classes in data browser ([#2908](https://github.com/parse-community/parse-dashboard/issues/2908)) ([1a3610a](https://github.com/parse-community/parse-dashboard/commit/1a3610a4632be78353db4f511781ca7757a12361))
 
+### Bug Fixes
+
+* Allow freeform resizing of text area in config modal
+
 # [7.3.0-alpha.15](https://github.com/parse-community/parse-dashboard/compare/7.3.0-alpha.14...7.3.0-alpha.15) (2025-07-15)
 
 

--- a/changelogs/CHANGELOG_alpha.md
+++ b/changelogs/CHANGELOG_alpha.md
@@ -5,10 +5,6 @@
 
 * Persist info panel visibility when navigating across classes in data browser ([#2908](https://github.com/parse-community/parse-dashboard/issues/2908)) ([1a3610a](https://github.com/parse-community/parse-dashboard/commit/1a3610a4632be78353db4f511781ca7757a12361))
 
-### Bug Fixes
-
-* Allow freeform resizing of text area in config modal
-
 # [7.3.0-alpha.15](https://github.com/parse-community/parse-dashboard/compare/7.3.0-alpha.14...7.3.0-alpha.15) (2025-07-15)
 
 

--- a/src/components/Field/Field.react.js
+++ b/src/components/Field/Field.react.js
@@ -23,7 +23,13 @@ const Field = ({ label, input, labelWidth = 50, labelPadding, height, className 
   }
   return (
     <div className={classes.join(' ')}>
-      <div className={styles.left} style={{ width: labelWidth + '% ', height: height }}>
+      <div
+        className={styles.left}
+        style={{
+          height: height,
+          '--modal-label-ratio': labelWidth / 100,
+        }}
+      >
         {label}
       </div>
       <div className={styles.right} style={{ height: height }}>

--- a/src/components/Field/Field.scss
+++ b/src/components/Field/Field.scss
@@ -28,6 +28,7 @@
 .left {
   display: flex;
   align-items: center;
+  flex-shrink: 0;
 }
 
 .right {

--- a/src/components/Field/Field.scss
+++ b/src/components/Field/Field.scss
@@ -29,7 +29,6 @@
   display: flex;
   align-items: center;
   flex-shrink: 0;
-  min-width: calc(var(--modal-min-width, 540px) * var(--modal-label-ratio, 0.5));
   width: calc(var(--modal-min-width, 540px) * var(--modal-label-ratio, 0.5));
   max-width: calc(var(--modal-min-width, 540px) * var(--modal-label-ratio, 0.5));
 }
@@ -43,7 +42,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  flex: 1 0 auto;
+  flex: 1;
 }
 
 

--- a/src/components/Field/Field.scss
+++ b/src/components/Field/Field.scss
@@ -29,6 +29,8 @@
   display: flex;
   align-items: center;
   flex-shrink: 0;
+  width: calc(var(--modal-min-width, 540px) * var(--modal-label-ratio, 0.5));
+  max-width: calc(var(--modal-min-width, 540px) * var(--modal-label-ratio, 0.5));
 }
 
 .right {

--- a/src/components/Field/Field.scss
+++ b/src/components/Field/Field.scss
@@ -43,7 +43,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  flex: 1
+  flex: 1 0 auto;
 }
 
 

--- a/src/components/Field/Field.scss
+++ b/src/components/Field/Field.scss
@@ -29,6 +29,7 @@
   display: flex;
   align-items: center;
   flex-shrink: 0;
+  min-width: calc(var(--modal-min-width, 540px) * var(--modal-label-ratio, 0.5));
   width: calc(var(--modal-min-width, 540px) * var(--modal-label-ratio, 0.5));
   max-width: calc(var(--modal-min-width, 540px) * var(--modal-label-ratio, 0.5));
 }

--- a/src/components/Modal/Modal.scss
+++ b/src/components/Modal/Modal.scss
@@ -8,16 +8,16 @@
 @import 'stylesheets/globals.scss';
 
 .modal {
-  @include modalAnimation();
   --modal-min-width: 540px;
   position: absolute;
   top: 50%;
-  left: 50%;
+  left: calc(50% - var(--modal-min-width) / 2);
   width: auto;
   min-width: var(--modal-min-width);
   background: white;
   border-radius: 5px;
   overflow: hidden;
+  transform: translateY(-50%);
 
   > *:not(:first-child):not(:last-child) {
     border-color: $borderGrey;

--- a/src/components/Modal/Modal.scss
+++ b/src/components/Modal/Modal.scss
@@ -12,7 +12,8 @@
   position: absolute;
   top: 50%;
   left: 50%;
-  width: 540px;
+  width: auto;
+  min-width: 540px;
   background: white;
   border-radius: 5px;
   overflow: hidden;

--- a/src/components/Modal/Modal.scss
+++ b/src/components/Modal/Modal.scss
@@ -18,7 +18,6 @@
   background: white;
   border-radius: 5px;
   overflow: hidden;
-  transition: width 0.5s cubic-bezier(1, 0, 0, 1);
 
   > *:not(:first-child):not(:last-child) {
     border-color: $borderGrey;

--- a/src/components/Modal/Modal.scss
+++ b/src/components/Modal/Modal.scss
@@ -18,6 +18,7 @@
   background: white;
   border-radius: 5px;
   overflow: hidden;
+  transition: width 0.5s cubic-bezier(1, 0, 0, 1);
 
   > *:not(:first-child):not(:last-child) {
     border-color: $borderGrey;

--- a/src/components/Modal/Modal.scss
+++ b/src/components/Modal/Modal.scss
@@ -8,6 +8,7 @@
 @import 'stylesheets/globals.scss';
 
 .modal {
+  @include modalAnimation();
   --modal-min-width: 540px;
   position: absolute;
   top: 50%;
@@ -17,7 +18,6 @@
   background: white;
   border-radius: 5px;
   overflow: hidden;
-  transform: translate(-50%, -50%);
 
   > *:not(:first-child):not(:last-child) {
     border-color: $borderGrey;

--- a/src/components/Modal/Modal.scss
+++ b/src/components/Modal/Modal.scss
@@ -9,11 +9,12 @@
 
 .modal {
   @include modalAnimation();
+  --modal-min-width: 540px;
   position: absolute;
   top: 50%;
   left: 50%;
   width: auto;
-  min-width: 540px;
+  min-width: var(--modal-min-width);
   background: white;
   border-radius: 5px;
   overflow: hidden;

--- a/src/components/Modal/Modal.scss
+++ b/src/components/Modal/Modal.scss
@@ -11,13 +11,13 @@
   --modal-min-width: 540px;
   position: absolute;
   top: 50%;
-  left: calc(50% - var(--modal-min-width) / 2);
+  left: 50%;
   width: auto;
   min-width: var(--modal-min-width);
   background: white;
   border-radius: 5px;
   overflow: hidden;
-  transform: translateY(-50%);
+  transform: translate(-50%, -50%);
 
   > *:not(:first-child):not(:last-child) {
     border-color: $borderGrey;

--- a/src/components/TextInput/TextInput.scss
+++ b/src/components/TextInput/TextInput.scss
@@ -15,6 +15,7 @@
   font-size: 16px;
   width: 100%;
   min-width: 100%;
+  min-height: 100%;
   padding: 6px;
   vertical-align: top;
   resize: both;

--- a/src/components/TextInput/TextInput.scss
+++ b/src/components/TextInput/TextInput.scss
@@ -14,6 +14,7 @@
   background: $inputBackgroundColor;
   font-size: 16px;
   width: 100%;
+  min-width: 100%;
   padding: 6px;
   vertical-align: top;
   resize: both;

--- a/src/components/TextInput/TextInput.scss
+++ b/src/components/TextInput/TextInput.scss
@@ -16,7 +16,7 @@
   width: 100%;
   padding: 6px;
   vertical-align: top;
-  resize: vertical;
+  resize: both;
 
   &:focus {
     @include placeholder {


### PR DESCRIPTION
## Summary
- let modals expand horizontally
- allow resizing text views horizontally as well
- document change in the alpha changelog

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6877e3a0583c832da0d111e2ba26b7a5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Modal windows now have a flexible width that can expand beyond 540px while maintaining a minimum width.
  * Text input fields are now resizable both horizontally and vertically and cannot shrink below their container size.
  * Left-aligned fields maintain a fixed proportional width and no longer shrink in flexible layouts.
  * Label widths in fields are now controlled by CSS variables for consistent proportional sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->