### PR TITLE
feat: Add support for "not equal to" filter for Boolean values in data browser and analytics explorer

### DIFF
--- a/src/components/ExplorerQueryComposer/ExplorerFilter.js
+++ b/src/components/ExplorerQueryComposer/ExplorerFilter.js
@@ -45,7 +45,7 @@ export const Constraints = {
 };
 
 export const FieldConstraints = {
-  Boolean: ['$eq'],
+  Boolean: ['$eq', '$ne'],
   Number: ['$eq', '$ne', '$lt', '$le', '$gt', '$ge'],
   String: ['$eq', '$ne', '$contains'],
   Date: ['$eq', '$ne', '$lt', '$le', '$gt', '$ge'],

--- a/src/lib/Filters.js
+++ b/src/lib/Filters.js
@@ -167,7 +167,7 @@ export const Constraints = {
 
 export const FieldConstraints = {
   Pointer: ['exists', 'dne', 'eq', 'neq', 'starts', 'unique'],
-  Boolean: ['exists', 'dne', 'eq', 'unique'],
+  Boolean: ['exists', 'dne', 'eq', 'neq', 'unique'],
   Number: ['exists', 'dne', 'eq', 'neq', 'lt', 'lte', 'gt', 'gte', 'unique'],
   String: ['exists', 'dne', 'eq', 'neq', 'starts', 'ends', 'stringContainsString', 'unique'],
   Date: ['exists', 'dne', 'before', 'after', 'unique'],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the "does not equal" constraint when filtering Boolean fields. Users can now filter Boolean values using both "equals" and "does not equal" options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->