### PR TITLE
fix: Info panel reloads despite prefetched data on cell click

### DIFF
--- a/README.md
+++ b/README.md
@@ -1185,7 +1185,7 @@ To reduce the time for info panel data to appear, data can be prefetched.
 | `infoPanel[*].prefetchObjects` | Number | yes      | `0`     | `2`     | Number of next rows to prefetch when browsing sequential rows. For example, `2` means the next 2 rows will be fetched in advance. |
 | `infoPanel[*].prefetchStale`   | Number | yes      | `0`     | `10`    | Duration in seconds after which prefetched data is discarded as stale.                                                            |
 
-Prefetching is particularly useful when navigating through lists of objects. To optimize performance and avoid unnecessary data loading, prefetching is triggered only after the user has moved through 3 consecutive rows using the keyboard down-arrow key.
+Prefetching is particularly useful when navigating through lists of objects. To optimize performance and avoid unnecessary data loading, prefetching is triggered only after the user has moved through 3 consecutive rows using the keyboard down-arrow key or by mouse click.
 
 ### Freeze Columns
 

--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -567,8 +567,6 @@ export default class BrowserCell extends Component {
       current,
       onEditChange,
       setCopyableValue,
-      selectedObjectId,
-      isPanelVisible,
       onPointerCmdClick,
       row,
       col,

--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -568,8 +568,6 @@ export default class BrowserCell extends Component {
       onEditChange,
       setCopyableValue,
       selectedObjectId,
-      setSelectedObjectId,
-      callCloudFunction,
       isPanelVisible,
       onPointerCmdClick,
       row,
@@ -580,7 +578,6 @@ export default class BrowserCell extends Component {
       markRequiredFieldRow,
       handleCellClick,
       selectedCells,
-      setShowAggregatedData,
     } = this.props;
 
     const classes = [...this.state.classes];
@@ -653,18 +650,7 @@ export default class BrowserCell extends Component {
             onPointerCmdClick(value);
           } else {
             setCopyableValue(hidden ? undefined : this.copyableValue);
-            if (selectedObjectId !== this.props.objectId) {
-              setShowAggregatedData(true);
-              setSelectedObjectId(this.props.objectId);
-              if (
-                this.props.objectId &&
-                isPanelVisible &&
-                ((e.shiftKey && !this.props.firstSelectedCell) || !e.shiftKey)
-              ) {
-                callCloudFunction(this.props.objectId, this.props.className, this.props.appId);
-              }
-            }
-            handleCellClick(e, row, col);
+            handleCellClick(e, row, col, this.props.objectId);
           }
         }}
         onDoubleClick={() => {

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -756,9 +756,25 @@ export default class DataBrowser extends React.Component {
     });
   }
 
-  handleCellClick(event, row, col) {
+  handleCellClick(event, row, col, objectId) {
     const { firstSelectedCell } = this.state;
     const clickedCellKey = `${row}-${col}`;
+
+    if (this.state.selectedObjectId !== objectId) {
+      this.setShowAggregatedData(true);
+      this.setSelectedObjectId(objectId);
+      if (
+        objectId &&
+        this.state.isPanelVisible &&
+        ((event.shiftKey && !firstSelectedCell) || !event.shiftKey)
+      ) {
+        this.handleCallCloudFunction(
+          objectId,
+          this.props.className,
+          this.props.app.applicationId
+        );
+      }
+    }
 
     if (event.shiftKey && firstSelectedCell) {
       const [firstRow, firstCol] = firstSelectedCell.split('-').map(Number);


### PR DESCRIPTION
## Summary
- avoid direct info panel calls from `BrowserCell`
- delegate info panel loading to DataBrowser's prefetch-aware handler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878e1042f94832db222899d935f4c27