### PR TITLE
fix: AggregationPanel retains scroll position when loading from cache

### DIFF
--- a/src/components/AggregationPanel/AggregationPanel.js
+++ b/src/components/AggregationPanel/AggregationPanel.js
@@ -1,6 +1,6 @@
 import LoaderDots from 'components/LoaderDots/LoaderDots.react';
 import Parse from 'parse';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import styles from './AggregationPanel.scss';
 import {
   AudioElement,
@@ -31,6 +31,13 @@ const AggregationPanel = ({
   const [isExpanded, setIsExpanded] = useState(false);
   const [nestedData, setNestedData] = useState(null);
   const [isLoadingNested, setIsLoadingNested] = useState(false);
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    if (containerRef.current) {
+      containerRef.current.scrollTop = 0;
+    }
+  }, [data, selectedObjectId]);
 
   useEffect(() => {
     if (Object.keys(errorAggregatedData).length !== 0) {
@@ -191,7 +198,7 @@ const AggregationPanel = ({
   }
 
   return (
-    <div className={styles.aggregationPanel}>
+    <div className={styles.aggregationPanel} ref={containerRef}>
       {isLoadingInfoPanel ? (
         <div className={styles.center}>
           <LoaderDots />

--- a/src/components/AggregationPanel/AggregationPanel.js
+++ b/src/components/AggregationPanel/AggregationPanel.js
@@ -1,6 +1,6 @@
 import LoaderDots from 'components/LoaderDots/LoaderDots.react';
 import Parse from 'parse';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import styles from './AggregationPanel.scss';
 import {
   AudioElement,
@@ -31,13 +31,6 @@ const AggregationPanel = ({
   const [isExpanded, setIsExpanded] = useState(false);
   const [nestedData, setNestedData] = useState(null);
   const [isLoadingNested, setIsLoadingNested] = useState(false);
-  const containerRef = useRef(null);
-
-  useEffect(() => {
-    if (containerRef.current) {
-      containerRef.current.scrollTop = 0;
-    }
-  }, [data, selectedObjectId]);
 
   useEffect(() => {
     if (Object.keys(errorAggregatedData).length !== 0) {
@@ -198,7 +191,7 @@ const AggregationPanel = ({
   }
 
   return (
-    <div className={styles.aggregationPanel} ref={containerRef}>
+    <div className={styles.aggregationPanel}>
       {isLoadingInfoPanel ? (
         <div className={styles.center}>
           <LoaderDots />

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -132,6 +132,7 @@ export default class DataBrowser extends React.Component {
     this.setShowRowNumber = this.setShowRowNumber.bind(this);
     this.handleCellClick = this.handleCellClick.bind(this);
     this.saveOrderTimeout = null;
+    this.aggregationPanelRef = React.createRef();
   }
 
   componentWillReceiveProps(props) {
@@ -734,6 +735,9 @@ export default class DataBrowser extends React.Component {
     const { prefetchCache } = this.state;
     const { prefetchStale } = this.getPrefetchSettings();
     const cached = prefetchCache[objectId];
+    if (this.aggregationPanelRef.current) {
+      this.aggregationPanelRef.current.scrollTop = 0;
+    }
     if (
       cached &&
       (!prefetchStale || (Date.now() - cached.timestamp) / 1000 < prefetchStale)
@@ -902,7 +906,10 @@ export default class DataBrowser extends React.Component {
               resizeHandles={['w']}
               className={styles.resizablePanel}
             >
-              <div className={styles.aggregationPanelContainer}>
+              <div
+                className={styles.aggregationPanelContainer}
+                ref={this.aggregationPanelRef}
+              >
                 <AggregationPanel
                   data={this.props.AggregationPanelData}
                   isLoadingCloudFunction={this.props.isLoadingCloudFunction}

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -132,7 +132,6 @@ export default class DataBrowser extends React.Component {
     this.setShowRowNumber = this.setShowRowNumber.bind(this);
     this.handleCellClick = this.handleCellClick.bind(this);
     this.saveOrderTimeout = null;
-    this.aggregationPanelRef = React.createRef();
   }
 
   componentWillReceiveProps(props) {
@@ -735,9 +734,6 @@ export default class DataBrowser extends React.Component {
     const { prefetchCache } = this.state;
     const { prefetchStale } = this.getPrefetchSettings();
     const cached = prefetchCache[objectId];
-    if (this.aggregationPanelRef.current) {
-      this.aggregationPanelRef.current.scrollTop = 0;
-    }
     if (
       cached &&
       (!prefetchStale || (Date.now() - cached.timestamp) / 1000 < prefetchStale)
@@ -906,10 +902,7 @@ export default class DataBrowser extends React.Component {
               resizeHandles={['w']}
               className={styles.resizablePanel}
             >
-              <div
-                className={styles.aggregationPanelContainer}
-                ref={this.aggregationPanelRef}
-              >
+              <div className={styles.aggregationPanelContainer}>
                 <AggregationPanel
                   data={this.props.AggregationPanelData}
                   isLoadingCloudFunction={this.props.isLoadingCloudFunction}

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -223,7 +223,14 @@ export default class DataBrowser extends React.Component {
       this.state.isPanelVisible &&
       this.aggregationPanelRef?.current
     ) {
-      this.aggregationPanelRef.current.scrollTop = 0;
+      const panel = this.aggregationPanelRef.current;
+      panel.scrollTop = 0;
+      panel.style.overflowY = 'hidden';
+      setTimeout(() => {
+        if (panel === this.aggregationPanelRef.current) {
+          panel.style.overflowY = 'auto';
+        }
+      }, 0);
     }
   }
 

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -223,14 +223,7 @@ export default class DataBrowser extends React.Component {
       this.state.isPanelVisible &&
       this.aggregationPanelRef?.current
     ) {
-      const panel = this.aggregationPanelRef.current;
-      panel.scrollTop = 0;
-      panel.style.overflowY = 'hidden';
-      setTimeout(() => {
-        if (panel === this.aggregationPanelRef.current) {
-          panel.style.overflowY = 'auto';
-        }
-      }, 0);
+      this.aggregationPanelRef.current.scrollTop = 0;
     }
   }
 

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -132,6 +132,7 @@ export default class DataBrowser extends React.Component {
     this.setShowRowNumber = this.setShowRowNumber.bind(this);
     this.handleCellClick = this.handleCellClick.bind(this);
     this.saveOrderTimeout = null;
+    this.aggregationPanelRef = React.createRef();
   }
 
   componentWillReceiveProps(props) {
@@ -214,6 +215,15 @@ export default class DataBrowser extends React.Component {
       if (this.props.errorAggregatedData != {}) {
         this.props.setErrorAggregatedData({});
       }
+    }
+
+    if (
+      (this.props.AggregationPanelData !== prevProps.AggregationPanelData ||
+        this.state.selectedObjectId !== prevState.selectedObjectId) &&
+      this.state.isPanelVisible &&
+      this.aggregationPanelRef?.current
+    ) {
+      this.aggregationPanelRef.current.scrollTop = 0;
     }
   }
 
@@ -902,7 +912,10 @@ export default class DataBrowser extends React.Component {
               resizeHandles={['w']}
               className={styles.resizablePanel}
             >
-              <div className={styles.aggregationPanelContainer}>
+              <div
+                className={styles.aggregationPanelContainer}
+                ref={this.aggregationPanelRef}
+              >
                 <AggregationPanel
                   data={this.props.AggregationPanelData}
                   isLoadingCloudFunction={this.props.isLoadingCloudFunction}


### PR DESCRIPTION
## Summary
- reset the AggregationPanel scroll position when loading cached data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878f341055c832d8a72f833a9edf071

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The aggregation panel in the Data Browser now automatically scrolls to the top when its data or selected object changes, improving navigation and visibility of updated content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->