### PR TITLE
feat: Add hyperlink support in Views table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1264,7 +1264,7 @@ This feature will take either selected rows or all rows of an individual class a
 Views are saved queries that display aggregated data from your classes. Create a view by providing a name, selecting a class and defining an aggregation pipeline. Optionally enable the object counter to show how many items match the view. Saved views appear in the sidebar, where you can select, edit, or delete them.
 
 > [!Caution]
-> Values are generally rendered without sanitization in the resulting data table. If rendered values come from user input or untrusted data, make sure to remove potentially dangerous HTML or JavaScript, to prevent an attacker from injecting malicious code, to exploit vulnerabilities like Cross-Site-Scripting (XSS).
+> Values are generally rendered without sanitization in the resulting data table. If rendered values come from user input or untrusted data, make sure to remove potentially dangerous HTML or JavaScript, to prevent an attacker from injecting malicious code, to exploit vulnerabilities like Cross-Site Scripting (XSS).
 
 ### View Table
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ Parse Dashboard is a standalone dashboard for managing your [Parse Server](https
     - [Limitations](#limitations)
   - [CSV Export](#csv-export)
   - [Views](#views)
+    - [View Table](#view-table)
+      - [Pointer](#pointer)
+      - [Link](#link)
 - [Contributing](#contributing)
 
 # Getting Started
@@ -1253,12 +1256,53 @@ This feature allows you to change how a pointer is represented in the browser. B
 This feature will take either selected rows or all rows of an individual class and saves them to a CSV file, which is then downloaded. CSV headers are added to the top of the file matching the column names.
 
 > ⚠️ There is currently a 10,000 row limit when exporting all data. If more than 10,000 rows are present in the class, the CSV file will only contain 10,000 rows.
+
 ## Views
 
 ▶️ *Core > Views*
 
 Views are saved queries that display aggregated data from your classes. Create a view by providing a name, selecting a class and defining an aggregation pipeline. Optionally enable the object counter to show how many items match the view. Saved views appear in the sidebar, where you can select, edit, or delete them.
 
+### View Table
+
+When designing the aggregation pipeline, consider that some values are rendered specially in the output table.
+
+#### Pointer
+
+Parse Object pointers are automatically displayed as links to the target object.
+
+Example:
+
+```json
+{ "__type": "Pointer", "className": "_User", "objectId": "xWMyZ4YEGZ" }
+```
+
+#### Link
+
+Links are rendered as hyperlinks that open in a new browser tab.
+
+Example:
+
+```json
+{
+  "__type": "Link",
+  "url": "https://example.com",
+  "text": "Link"
+}
+```
+
+Set `isRelativeUrl: true` when linking to another dashboard page, in which case the base URL for the relative URL will be `<PROTOCOL>://<HOST>/<MOUNT_PATH>/apps/<APP_NAME>/`. The key `isRelativeUrl` is optional and `false` by default.
+
+Example:
+
+```json
+{
+  "__type": "Link",
+  "url": "browser/_Installation?filters=%5B%7B%22field%22%3A%22objectId%22%2C%22constraint%22%3A%22eq%22%2C%22compareTo%22%3A%22xWMyZ4YEGZ%22%2C%22class%22%3A%22_Installation%22%7D%5D",
+  "isRelativeUrl": true,
+  "text": "Link"
+}
+```
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -1307,7 +1307,7 @@ Example:
 }
 ```
 
-A query part of the URL can be easily added using the `urlQuery` key which will automatically escape the quey string.
+A query part of the URL can be easily added using the `urlQuery` key which will automatically escape the query string.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -1263,6 +1263,9 @@ This feature will take either selected rows or all rows of an individual class a
 
 Views are saved queries that display aggregated data from your classes. Create a view by providing a name, selecting a class and defining an aggregation pipeline. Optionally enable the object counter to show how many items match the view. Saved views appear in the sidebar, where you can select, edit, or delete them.
 
+> [!Caution]
+> Values are generally rendered without sanitization in the resulting data table. If rendered values come from user input or untrusted data, make sure to remove potentially dangerous HTML or JavaScript, to prevent an attacker from injecting malicious code, to exploit vulnerabilities like Cross-Site-Scripting (XSS).
+
 ### View Table
 
 When designing the aggregation pipeline, consider that some values are rendered specially in the output table.
@@ -1298,10 +1301,30 @@ Example:
 ```json
 {
   "__type": "Link",
-  "url": "browser/_Installation?filters=%5B%7B%22field%22%3A%22objectId%22%2C%22constraint%22%3A%22eq%22%2C%22compareTo%22%3A%22xWMyZ4YEGZ%22%2C%22class%22%3A%22_Installation%22%7D%5D",
+  "url": "browser/_Installation",
   "isRelativeUrl": true,
   "text": "Link"
 }
+```
+
+A query part of the URL can be easily added using the `urlQuery` key which will automatically escape the quey string.
+
+Example:
+
+```json
+{
+  "__type": "Link",
+  "url": "browser/_Installation",
+  "urlQuery": "filters=[{\"field\":\"objectId\",\"constraint\":\"eq\",\"compareTo\":\"xWMyZ4YEGZ\",\"class\":\"_Installation\"}]",
+  "isRelativeUrl": true,
+  "text": "Link"
+}
+```
+
+In the example above, the query string will be escaped and added to the url, resulting in the complete URL:
+
+```js
+"browser/_Installation?filters=%5B%7B%22field%22%3A%22objectId%22%2C%22constraint%22%3A%22eq%22%2C%22compareTo%22%3A%22xWMyZ4YEGZ%22%2C%22class%22%3A%22_Installation%22%7D%5D"
 ```
 
 # Contributing

--- a/src/dashboard/Data/Views/Views.react.js
+++ b/src/dashboard/Data/Views/Views.react.js
@@ -317,12 +317,31 @@ class Views extends TableView {
           } else if (type === 'Date') {
             content = value && value.iso ? value.iso : String(value);
           } else if (type === 'Link') {
-            const url = value.isRelativeUrl
-              ? `apps/${this.context.slug}/${value.url}`
-              : value.url;
+            // Sanitize URL
+            let url = value.url;
+            if (
+              url.match(/javascript/i) ||
+              url.match(/<script/i)
+            ) {
+              url = '#';
+            } else {
+              url = value.isRelativeUrl
+                ? `apps/${this.context.slug}/${url}${value.query ? `?${new URLSearchParams(value.urlQuery).toString()}` : ''}`
+                : url;
+            }
+            // Sanitize text
+            let text = value.text;
+            if (
+              text.match(/javascript/i) ||
+              text.match(/<script/i) ||
+              !text ||
+              text.trim() === ''
+            ) {
+              text = 'Link';
+            }
             content = (
               <a href={url} target="_blank" rel="noreferrer">
-                {value.text}
+                {text}
               </a>
             );
           } else if (value === undefined) {

--- a/src/dashboard/Data/Views/Views.react.js
+++ b/src/dashboard/Data/Views/Views.react.js
@@ -132,7 +132,13 @@ class Views extends TableView {
           if (text === undefined) {
             text = '';
           } else if (text && typeof text === 'object') {
-            text = text.__type === 'Date' && text.iso ? text.iso : JSON.stringify(text);
+            if (text.__type === 'Date' && text.iso) {
+              text = text.iso;
+            } else if (text.__type === 'Link' && text.text) {
+              text = text.text;
+            } else {
+              text = JSON.stringify(text);
+            }
           }
           text = String(text);
           if (typeof document !== 'undefined') {
@@ -166,6 +172,8 @@ class Views extends TableView {
                 type = 'File';
               } else if (val.__type === 'GeoPoint') {
                 type = 'GeoPoint';
+              } else if (val.__type === 'Link') {
+                type = 'Link';
               } else {
                 type = 'Object';
               }
@@ -285,6 +293,8 @@ class Views extends TableView {
               type = 'File';
             } else if (value.__type === 'GeoPoint') {
               type = 'GeoPoint';
+            } else if (value.__type === 'Link') {
+              type = 'Link';
             } else {
               type = 'Object';
             }
@@ -306,6 +316,15 @@ class Views extends TableView {
             content = JSON.stringify(value);
           } else if (type === 'Date') {
             content = value && value.iso ? value.iso : String(value);
+          } else if (type === 'Link') {
+            const url = value.isRelativeUrl
+              ? `apps/${this.context.slug}/${value.url}`
+              : value.url;
+            content = (
+              <a href={url} target="_blank" rel="noreferrer">
+                {value.text}
+              </a>
+            );
           } else if (value === undefined) {
             content = '';
           } else {


### PR DESCRIPTION
## Summary
- handle `Link` objects when calculating column widths
- display link values as `<a>` elements in Views

## Testing
- `npm run lint`
- `npm test` *(fails: dashboard e2e › can keep mount path on redirect)*

------
https://chatgpt.com/codex/tasks/task_e_687ae204a51c832d93b1723d6a625462

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for displaying `Link` data types as clickable links in data tables.
  * Links open in a new tab and handle both relative and absolute URLs for improved navigation.

* **Enhancements**
  * Improved display of `Link` values by showing user-friendly text instead of raw objects.

* **Documentation**
  * Updated README to explain rendering of `Link` and `Pointer` types in view tables, including examples for relative and absolute URLs.
  * Added guidance on sanitizing data to prevent XSS vulnerabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->