### PR TITLE
fix: Hyperlink in Views table ignores `urlQuery` key

### DIFF
--- a/src/dashboard/Data/Views/Views.react.js
+++ b/src/dashboard/Data/Views/Views.react.js
@@ -326,7 +326,7 @@ class Views extends TableView {
               url = '#';
             } else {
               url = value.isRelativeUrl
-                ? `apps/${this.context.slug}/${url}${value.query ? `?${new URLSearchParams(value.urlQuery).toString()}` : ''}`
+                ? `apps/${this.context.slug}/${url}${value.urlQuery ? `?${new URLSearchParams(value.urlQuery).toString()}` : ''}`
                 : url;
             }
             // Sanitize text


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected URL construction for link cells to ensure query parameters are properly appended only when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->