### PR TITLE
feat: Support numeric constraints for date filters

### DIFF
--- a/src/components/ExplorerQueryComposer/ExplorerFilter.js
+++ b/src/components/ExplorerQueryComposer/ExplorerFilter.js
@@ -14,22 +14,18 @@ export const Constraints = {
   },
   $lt: {
     name: 'less than',
-    field: 'Number',
     composable: true,
   },
   $le: {
     name: 'less than or equal',
-    field: 'Number',
     composable: true,
   },
   $gt: {
     name: 'greater than',
-    field: 'Number',
     composable: true,
   },
   $ge: {
     name: 'greater than or equal',
-    field: 'Number',
     composable: true,
   },
   $contains: {

--- a/src/lib/Filters.js
+++ b/src/lib/Filters.js
@@ -28,25 +28,21 @@ export const Constraints = {
   },
   lt: {
     name: 'less than',
-    field: 'Number',
     composable: true,
     comparable: true,
   },
   lte: {
     name: 'less than or equal',
-    field: 'Number',
     composable: true,
     comparable: true,
   },
   gt: {
     name: 'greater than',
-    field: 'Number',
     composable: true,
     comparable: true,
   },
   gte: {
     name: 'greater than or equal',
-    field: 'Number',
     composable: true,
     comparable: true,
   },
@@ -170,7 +166,7 @@ export const FieldConstraints = {
   Boolean: ['exists', 'dne', 'eq', 'neq', 'unique'],
   Number: ['exists', 'dne', 'eq', 'neq', 'lt', 'lte', 'gt', 'gte', 'unique'],
   String: ['exists', 'dne', 'eq', 'neq', 'starts', 'ends', 'stringContainsString', 'unique'],
-  Date: ['exists', 'dne', 'before', 'after', 'unique'],
+  Date: ['exists', 'dne', 'before', 'after', 'lt', 'lte', 'gt', 'gte', 'unique'],
   Object: [
     'exists',
     'dne',


### PR DESCRIPTION
## Summary
- allow lt, lte, gt and gte constraints on date fields
- use date input for these constraints in query composer

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687b4f606f14832d9ae111777ae8b7ef

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for numeric comparison constraints (`lt`, `lte`, `gt`, `gte`) to date filters.

* **Refactor**
  * Updated internal handling of comparison constraints for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->