### PR TITLE
feat: Add inclusive date filters "is on or after", "is on or before" in data browser

### DIFF
--- a/src/lib/Filters.js
+++ b/src/lib/Filters.js
@@ -76,14 +76,14 @@ export const Constraints = {
     composable: true,
     comparable: true,
   },
-  afterOrOn: {
-    name: 'is after or on',
+  onOrAfter: {
+    name: 'is on or after',
     field: 'Date',
     composable: true,
     comparable: true,
   },
-  beforeOrOn: {
-    name: 'is before or on',
+  onOrBefore: {
+    name: 'is on or before',
     field: 'Date',
     composable: true,
     comparable: true,
@@ -186,9 +186,9 @@ export const FieldConstraints = {
     'exists',
     'dne',
     'before',
-    'beforeOrOn',
+    'onOrBefore',
     'after',
-    'afterOrOn',
+    'onOrAfter',
     'unique',
   ],
   Object: [

--- a/src/lib/Filters.js
+++ b/src/lib/Filters.js
@@ -76,6 +76,18 @@ export const Constraints = {
     composable: true,
     comparable: true,
   },
+  afterOrOn: {
+    name: 'is after or on',
+    field: 'Date',
+    composable: true,
+    comparable: true,
+  },
+  beforeOrOn: {
+    name: 'is before or on',
+    field: 'Date',
+    composable: true,
+    comparable: true,
+  },
   containsString: {
     name: 'contains string',
     field: 'String',
@@ -170,7 +182,15 @@ export const FieldConstraints = {
   Boolean: ['exists', 'dne', 'eq', 'neq', 'unique'],
   Number: ['exists', 'dne', 'eq', 'neq', 'lt', 'lte', 'gt', 'gte', 'unique'],
   String: ['exists', 'dne', 'eq', 'neq', 'starts', 'ends', 'stringContainsString', 'unique'],
-  Date: ['exists', 'dne', 'before', 'after', 'unique'],
+  Date: [
+    'exists',
+    'dne',
+    'before',
+    'beforeOrOn',
+    'after',
+    'afterOrOn',
+    'unique',
+  ],
   Object: [
     'exists',
     'dne',

--- a/src/lib/queryFromFilters.js
+++ b/src/lib/queryFromFilters.js
@@ -127,12 +127,14 @@ function addConstraint(query, filter) {
       query.lessThan(filter.get('field'), filter.get('compareTo'));
       break;
     case 'lte':
+    case 'onOrBefore':
       query.lessThanOrEqualTo(filter.get('field'), filter.get('compareTo'));
       break;
     case 'gt':
       query.greaterThan(filter.get('field'), filter.get('compareTo'));
       break;
     case 'gte':
+    case 'onOrAfter':
       query.greaterThanOrEqualTo(filter.get('field'), filter.get('compareTo'));
       break;
     case 'starts':
@@ -152,14 +154,8 @@ function addConstraint(query, filter) {
     case 'before':
       query.lessThan(filter.get('field'), filter.get('compareTo'));
       break;
-    case 'beforeOrOn':
-      query.lessThanOrEqualTo(filter.get('field'), filter.get('compareTo'));
-      break;
     case 'after':
       query.greaterThan(filter.get('field'), filter.get('compareTo'));
-      break;
-    case 'afterOrOn':
-      query.greaterThanOrEqualTo(filter.get('field'), filter.get('compareTo'));
       break;
     case 'containsString':
     case 'containsNumber':

--- a/src/lib/queryFromFilters.js
+++ b/src/lib/queryFromFilters.js
@@ -152,8 +152,14 @@ function addConstraint(query, filter) {
     case 'before':
       query.lessThan(filter.get('field'), filter.get('compareTo'));
       break;
+    case 'beforeOrOn':
+      query.lessThanOrEqualTo(filter.get('field'), filter.get('compareTo'));
+      break;
     case 'after':
       query.greaterThan(filter.get('field'), filter.get('compareTo'));
+      break;
+    case 'afterOrOn':
+      query.greaterThanOrEqualTo(filter.get('field'), filter.get('compareTo'));
       break;
     case 'containsString':
     case 'containsNumber':


### PR DESCRIPTION
## Summary
- extend date filter options with `afterOrOn` and `beforeOrOn`
- apply new conditions when building queries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c098eda1c832d9dba42e24df154cf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for "before or on" and "after or on" constraints when filtering date fields, allowing more flexible and inclusive date range filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->