### PR TITLE
fix: Modal text input can be resized smaller than its cell in Safari browser

### DIFF
--- a/src/components/Field/Field.react.js
+++ b/src/components/Field/Field.react.js
@@ -22,12 +22,14 @@ const Field = ({ label, input, labelWidth = 50, labelPadding, height, className 
     });
   }
   return (
-    <div className={classes.join(' ')}>
+    <div
+      className={classes.join(' ')}
+      style={{ '--modal-label-ratio': labelWidth / 100 }}
+    >
       <div
         className={styles.left}
         style={{
           height: height,
-          '--modal-label-ratio': labelWidth / 100,
         }}
       >
         {label}

--- a/src/components/Field/Field.scss
+++ b/src/components/Field/Field.scss
@@ -29,13 +29,14 @@
   display: flex;
   align-items: center;
   flex-shrink: 0;
-  width: calc(var(--modal-min-width, 540px) * var(--modal-label-ratio, 0.5));
-  max-width: calc(var(--modal-min-width, 540px) * var(--modal-label-ratio, 0.5));
+  width: calc(var(--modal-min-width) * var(--modal-label-ratio));
+  max-width: calc(var(--modal-min-width) * var(--modal-label-ratio));
 }
 
 .right {
+  --modal-row-min-height: 80px;
   position: relative;
-  min-height: 80px;
+  min-height: var(--modal-row-min-height);
   text-align: right;
   padding: 0;
   background: #f6fafb;

--- a/src/components/TextInput/TextInput.scss
+++ b/src/components/TextInput/TextInput.scss
@@ -14,9 +14,11 @@
   background: $inputBackgroundColor;
   font-size: 16px;
   width: 100%;
-  min-width: calc(
-    var(--modal-min-width, 540px) * (1 - var(--modal-label-ratio, 0.5))
+  min-width: max(
+    100%,
+    calc(var(--modal-min-width, 540px) * (1 - var(--modal-label-ratio, 0.5)))
   );
+  min-height: 100%;
   padding: 6px;
   vertical-align: top;
   resize: both;

--- a/src/components/TextInput/TextInput.scss
+++ b/src/components/TextInput/TextInput.scss
@@ -14,8 +14,6 @@
   background: $inputBackgroundColor;
   font-size: 16px;
   width: 100%;
-  min-width: 100%;
-  min-height: 100%;
   padding: 6px;
   vertical-align: top;
   resize: both;

--- a/src/components/TextInput/TextInput.scss
+++ b/src/components/TextInput/TextInput.scss
@@ -14,11 +14,8 @@
   background: $inputBackgroundColor;
   font-size: 16px;
   width: 100%;
-  min-width: max(
-    100%,
-    calc(var(--modal-min-width, 540px) * (1 - var(--modal-label-ratio, 0.5)))
-  );
-  min-height: 100%;
+  min-width: calc(var(--modal-min-width) * (1 - var(--modal-label-ratio)));
+  min-height: var(--modal-row-min-height);
   padding: 6px;
   vertical-align: top;
   resize: both;

--- a/src/components/TextInput/TextInput.scss
+++ b/src/components/TextInput/TextInput.scss
@@ -14,6 +14,9 @@
   background: $inputBackgroundColor;
   font-size: 16px;
   width: 100%;
+  min-width: calc(
+    var(--modal-min-width, 540px) * (1 - var(--modal-label-ratio, 0.5))
+  );
   padding: 6px;
   vertical-align: top;
   resize: both;


### PR DESCRIPTION
## Summary
- allow TextInput to shrink after being enlarged

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687b44fd7a44832d9b5e0204057f841b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved text input responsiveness by adjusting minimum width and height using dynamic CSS variables.
  * Enhanced label styling consistency by refining CSS variable application and removing fallback values for cleaner styling.
  * Introduced a new CSS variable to standardize minimum row height across components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->