### PR TITLE
fix: Incorrect table cell width in App Settings table

### DIFF
--- a/src/components/Field/Field.scss
+++ b/src/components/Field/Field.scss
@@ -29,8 +29,8 @@
   display: flex;
   align-items: center;
   flex-shrink: 0;
-  width: calc(var(--modal-min-width) * var(--modal-label-ratio));
-  max-width: calc(var(--modal-min-width) * var(--modal-label-ratio));
+  width: calc(var(--modal-min-width, 540px) * var(--modal-label-ratio, 0.5));
+  max-width: calc(var(--modal-min-width, 540px) * var(--modal-label-ratio, 0.5));
 }
 
 .right {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved layout reliability by adding default fallback values for modal width and label ratio, ensuring consistent appearance even if custom properties are not set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->