### PR TITLE
feat: Add nested info panel menu in settings

### DIFF
--- a/src/components/BrowserMenu/BrowserMenu.react.js
+++ b/src/components/BrowserMenu/BrowserMenu.react.js
@@ -35,10 +35,7 @@ export default class BrowserMenu extends React.Component {
           position={position}
           onExternalClick={() => this.setState({ open: false })}
         >
-          <div
-            className={styles.menu}
-            onMouseLeave={isSubmenu ? () => this.setState({ open: false }) : undefined}
-          >
+          <div className={styles.menu}>
             {!isSubmenu && (
               <div
                 className={titleStyle.join(' ')}

--- a/src/components/BrowserMenu/BrowserMenu.react.js
+++ b/src/components/BrowserMenu/BrowserMenu.react.js
@@ -24,13 +24,7 @@ export default class BrowserMenu extends React.Component {
     let menu = null;
     const isSubmenu = !!this.props.parentClose;
     if (this.state.open) {
-      let position = Position.inDocument(this.wrapRef.current);
-      if (isSubmenu) {
-        const offset = this.state.openToLeft
-          ? -this.wrapRef.current.clientWidth
-          : this.wrapRef.current.clientWidth;
-        position = position.transform(offset, 0);
-      }
+      const position = Position.inDocument(this.wrapRef.current);
       const titleStyle = [styles.title];
       if (this.props.active) {
         titleStyle.push(styles.active);
@@ -64,11 +58,7 @@ export default class BrowserMenu extends React.Component {
               }
               style={{
                 minWidth: this.wrapRef.current.clientWidth,
-                ...(isSubmenu
-                  ? this.state.openToLeft
-                    ? { top: 0, right: '100%', left: 'auto' }
-                    : { top: 0, right: 'auto', left: 0 }
-                  : {}),
+                ...(isSubmenu ? { top: 0 } : {}),
               }}
             >
               {React.Children.map(this.props.children, child => {

--- a/src/components/BrowserMenu/BrowserMenu.react.js
+++ b/src/components/BrowserMenu/BrowserMenu.react.js
@@ -58,7 +58,13 @@ export default class BrowserMenu extends React.Component {
               }
               style={{
                 minWidth: this.wrapRef.current.clientWidth,
-                ...(isSubmenu ? { top: 0 } : {}),
+                ...(isSubmenu
+                  ? {
+                    top: 0,
+                    [this.state.openToLeft ? 'right' : 'left']:
+                        `${this.wrapRef.current.clientWidth - 3}px`,
+                  }
+                  : {}),
               }}
             >
               {React.Children.map(this.props.children, child => {

--- a/src/components/BrowserMenu/BrowserMenu.react.js
+++ b/src/components/BrowserMenu/BrowserMenu.react.js
@@ -36,7 +36,7 @@ export default class BrowserMenu extends React.Component {
         >
           <div className={styles.menu}>
             <div className={titleStyle.join(' ')} onClick={() => this.setState({ open: false })}>
-              <Icon name={this.props.icon} width={14} height={14} />
+              {this.props.icon && <Icon name={this.props.icon} width={14} height={14} />}
               <span>{this.props.title}</span>
             </div>
             <div className={styles.body} style={{ minWidth: this.wrapRef.current.clientWidth }}>
@@ -68,17 +68,29 @@ export default class BrowserMenu extends React.Component {
     if (this.props.disabled) {
       classes.push(styles.disabled);
     }
-    let onClick = null;
+    const isSubmenu = !!this.props.parentClose;
+    const entryEvents = {};
     if (!this.props.disabled) {
-      onClick = () => {
-        this.setState({ open: true });
-        this.props.setCurrent(null);
-      };
+      if (isSubmenu) {
+        entryEvents.onMouseEnter = () => {
+          this.setState({ open: true });
+          this.props.setCurrent?.(null);
+        };
+      } else {
+        entryEvents.onClick = () => {
+          this.setState({ open: true });
+          this.props.setCurrent(null);
+        };
+      }
     }
     return (
-      <div className={styles.wrap} ref={this.wrapRef}>
-        <div className={classes.join(' ')} onClick={onClick}>
-          <Icon name={this.props.icon} width={14} height={14} />
+      <div
+        className={styles.wrap}
+        ref={this.wrapRef}
+        onMouseLeave={isSubmenu ? () => this.setState({ open: false }) : undefined}
+      >
+        <div className={classes.join(' ')} {...entryEvents}>
+          {this.props.icon && <Icon name={this.props.icon} width={14} height={14} />}
           <span>{this.props.title}</span>
         </div>
         {menu}
@@ -88,7 +100,7 @@ export default class BrowserMenu extends React.Component {
 }
 
 BrowserMenu.propTypes = {
-  icon: PropTypes.string.isRequired.describe('The name of the icon to place in the menu.'),
+  icon: PropTypes.string.describe('The name of the icon to place in the menu.'),
   title: PropTypes.string.isRequired.describe('The title text of the menu.'),
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).describe(
     'The contents of the menu when open. It should be a set of MenuItem and Separator components.'

--- a/src/components/BrowserMenu/BrowserMenu.react.js
+++ b/src/components/BrowserMenu/BrowserMenu.react.js
@@ -45,10 +45,15 @@ export default class BrowserMenu extends React.Component {
             className={styles.menu}
             onMouseLeave={isSubmenu ? () => this.setState({ open: false }) : undefined}
           >
-            <div className={titleStyle.join(' ')} onClick={() => this.setState({ open: false })}>
-              {this.props.icon && <Icon name={this.props.icon} width={14} height={14} />}
-              <span>{this.props.title}</span>
-            </div>
+            {!isSubmenu && (
+              <div
+                className={titleStyle.join(' ')}
+                onClick={() => this.setState({ open: false })}
+              >
+                {this.props.icon && <Icon name={this.props.icon} width={14} height={14} />}
+                <span>{this.props.title}</span>
+              </div>
+            )}
             <div
               className={
                 isSubmenu

--- a/src/components/BrowserMenu/BrowserMenu.react.js
+++ b/src/components/BrowserMenu/BrowserMenu.react.js
@@ -68,21 +68,17 @@ export default class BrowserMenu extends React.Component {
                   : {}),
               }}
             >
-              {React.Children.map(this.props.children, child => {
-                if (child.type === BrowserMenu) {
+              {React.Children.map(this.props.children, (child) => {
+                if (React.isValidElement(child) && child.type === BrowserMenu) {
                   return React.cloneElement(child, {
                     ...child.props,
-                    parentClose: () => this.setState({ open: false }),
+                    parentClose: () => {
+                      this.setState({ open: false });
+                      this.props.parentClose?.();
+                    },
                   });
                 }
-                return React.cloneElement(child, {
-                  ...child.props,
-                  onClick: () => {
-                    child.props.onClick?.();
-                    this.setState({ open: false });
-                    this.props.parentClose?.();
-                  },
-                });
+                return child;
               })}
             </div>
           </div>
@@ -119,7 +115,7 @@ export default class BrowserMenu extends React.Component {
           {this.props.icon && <Icon name={this.props.icon} width={14} height={14} />}
           <span>{this.props.title}</span>
           {isSubmenu &&
-            React.Children.toArray(this.props.children).some(c => c.type === BrowserMenu) && (
+            React.Children.toArray(this.props.children).some(c => React.isValidElement(c) && c.type === BrowserMenu) && (
             <Icon
               name="right-outline"
               width={12}

--- a/src/components/BrowserMenu/BrowserMenu.react.js
+++ b/src/components/BrowserMenu/BrowserMenu.react.js
@@ -16,13 +16,12 @@ export default class BrowserMenu extends React.Component {
   constructor() {
     super();
 
-    this.state = { open: false, openToLeft: false };
+    this.state = { open: false };
     this.wrapRef = React.createRef();
   }
 
   render() {
     let menu = null;
-    const isSubmenu = !!this.props.parentClose;
     if (this.state.open) {
       const position = Position.inDocument(this.wrapRef.current);
       const titleStyle = [styles.title];
@@ -36,54 +35,20 @@ export default class BrowserMenu extends React.Component {
           onExternalClick={() => this.setState({ open: false })}
         >
           <div className={styles.menu}>
-            {!isSubmenu && (
-              <div
-                className={titleStyle.join(' ')}
-                onClick={() => this.setState({ open: false })}
-              >
-                {this.props.icon && <Icon name={this.props.icon} width={14} height={14} />}
-                <span>{this.props.title}</span>
-              </div>
-            )}
-            <div
-              className={
-                isSubmenu
-                  ? this.state.openToLeft
-                    ? styles.subMenuBodyLeft
-                    : styles.subMenuBody
-                  : styles.body
-              }
-              style={{
-                minWidth: this.wrapRef.current.clientWidth,
-                ...(isSubmenu
-                  ? {
-                    top: 0,
-                    left: this.state.openToLeft
-                      ? 0
-                      : `${this.wrapRef.current.clientWidth - 3}px`,
-                    transform: this.state.openToLeft
-                      ? 'translateX(calc(-100% + 3px))'
-                      : undefined,
-                  }
-                  : {}),
-              }}
-            >
-              {React.Children.map(this.props.children, child => {
-                if (child.type === BrowserMenu) {
-                  return React.cloneElement(child, {
-                    ...child.props,
-                    parentClose: () => this.setState({ open: false }),
-                  });
-                }
-                return React.cloneElement(child, {
+            <div className={titleStyle.join(' ')} onClick={() => this.setState({ open: false })}>
+              <Icon name={this.props.icon} width={14} height={14} />
+              <span>{this.props.title}</span>
+            </div>
+            <div className={styles.body} style={{ minWidth: this.wrapRef.current.clientWidth }}>
+              {React.Children.map(this.props.children, child =>
+                React.cloneElement(child, {
                   ...child.props,
                   onClick: () => {
                     child.props.onClick?.();
                     this.setState({ open: false });
-                    this.props.parentClose?.();
                   },
-                });
-              })}
+                })
+              )}
             </div>
           </div>
         </Popover>
@@ -96,37 +61,18 @@ export default class BrowserMenu extends React.Component {
     if (this.props.disabled) {
       classes.push(styles.disabled);
     }
-    const entryEvents = {};
+    let onClick = null;
     if (!this.props.disabled) {
-      if (isSubmenu) {
-        entryEvents.onMouseEnter = () => {
-          const rect = this.wrapRef.current.getBoundingClientRect();
-          const width = this.wrapRef.current.clientWidth;
-          const openToLeft = rect.right + width > window.innerWidth;
-          this.setState({ open: true, openToLeft });
-          this.props.setCurrent?.(null);
-        };
-      } else {
-        entryEvents.onClick = () => {
-          this.setState({ open: true, openToLeft: false });
-          this.props.setCurrent(null);
-        };
-      }
+      onClick = () => {
+        this.setState({ open: true });
+        this.props.setCurrent(null);
+      };
     }
     return (
       <div className={styles.wrap} ref={this.wrapRef}>
-        <div className={classes.join(' ')} {...entryEvents}>
-          {this.props.icon && <Icon name={this.props.icon} width={14} height={14} />}
+        <div className={classes.join(' ')} onClick={onClick}>
+          <Icon name={this.props.icon} width={14} height={14} />
           <span>{this.props.title}</span>
-          {isSubmenu &&
-            React.Children.toArray(this.props.children).some(c => c.type === BrowserMenu) && (
-            <Icon
-              name="right-outline"
-              width={12}
-              height={12}
-              className={styles.submenuArrow}
-            />
-          )}
         </div>
         {menu}
       </div>
@@ -135,12 +81,12 @@ export default class BrowserMenu extends React.Component {
 }
 
 BrowserMenu.propTypes = {
-  icon: PropTypes.string.describe('The name of the icon to place in the menu.'),
+  icon: PropTypes.string.isRequired.describe('The name of the icon to place in the menu.'),
   title: PropTypes.string.isRequired.describe('The title text of the menu.'),
-  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).describe(
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]).describe(
     'The contents of the menu when open. It should be a set of MenuItem and Separator components.'
-  ),
-  parentClose: PropTypes.func.describe(
-    'Closes the parent menu when a nested menu item is selected.'
   ),
 };

--- a/src/components/BrowserMenu/BrowserMenu.react.js
+++ b/src/components/BrowserMenu/BrowserMenu.react.js
@@ -16,7 +16,7 @@ export default class BrowserMenu extends React.Component {
   constructor() {
     super();
 
-    this.state = { open: false };
+    this.state = { open: false, openToLeft: false };
     this.wrapRef = React.createRef();
   }
 
@@ -26,7 +26,10 @@ export default class BrowserMenu extends React.Component {
     if (this.state.open) {
       let position = Position.inDocument(this.wrapRef.current);
       if (isSubmenu) {
-        position = position.transform(this.wrapRef.current.clientWidth, 0);
+        const offset = this.state.openToLeft
+          ? -this.wrapRef.current.clientWidth
+          : this.wrapRef.current.clientWidth;
+        position = position.transform(offset, 0);
       }
       const titleStyle = [styles.title];
       if (this.props.active) {
@@ -47,10 +50,20 @@ export default class BrowserMenu extends React.Component {
               <span>{this.props.title}</span>
             </div>
             <div
-              className={isSubmenu ? styles.subMenuBody : styles.body}
+              className={
+                isSubmenu
+                  ? this.state.openToLeft
+                    ? styles.subMenuBodyLeft
+                    : styles.subMenuBody
+                  : styles.body
+              }
               style={{
                 minWidth: this.wrapRef.current.clientWidth,
-                ...(isSubmenu ? { top: 0, right: 'auto', left: 0 } : {}),
+                ...(isSubmenu
+                  ? this.state.openToLeft
+                    ? { top: 0, right: '100%', left: 'auto' }
+                    : { top: 0, right: 'auto', left: 0 }
+                  : {}),
               }}
             >
               {React.Children.map(this.props.children, child => {
@@ -85,12 +98,15 @@ export default class BrowserMenu extends React.Component {
     if (!this.props.disabled) {
       if (isSubmenu) {
         entryEvents.onMouseEnter = () => {
-          this.setState({ open: true });
+          const rect = this.wrapRef.current.getBoundingClientRect();
+          const width = this.wrapRef.current.clientWidth;
+          const openToLeft = rect.right + width > window.innerWidth;
+          this.setState({ open: true, openToLeft });
           this.props.setCurrent?.(null);
         };
       } else {
         entryEvents.onClick = () => {
-          this.setState({ open: true });
+          this.setState({ open: true, openToLeft: false });
           this.props.setCurrent(null);
         };
       }

--- a/src/components/BrowserMenu/BrowserMenu.react.js
+++ b/src/components/BrowserMenu/BrowserMenu.react.js
@@ -61,8 +61,12 @@ export default class BrowserMenu extends React.Component {
                 ...(isSubmenu
                   ? {
                     top: 0,
-                    [this.state.openToLeft ? 'right' : 'left']:
-                        `${this.wrapRef.current.clientWidth - 3}px`,
+                    left: this.state.openToLeft
+                      ? 0
+                      : `${this.wrapRef.current.clientWidth - 3}px`,
+                    transform: this.state.openToLeft
+                      ? 'translateX(calc(-100% + 3px))'
+                      : undefined,
                   }
                   : {}),
               }}

--- a/src/components/BrowserMenu/BrowserMenu.react.js
+++ b/src/components/BrowserMenu/BrowserMenu.react.js
@@ -40,15 +40,22 @@ export default class BrowserMenu extends React.Component {
               <span>{this.props.title}</span>
             </div>
             <div className={styles.body} style={{ minWidth: this.wrapRef.current.clientWidth }}>
-              {React.Children.map(this.props.children, child =>
-                React.cloneElement(child, {
+              {React.Children.map(this.props.children, child => {
+                if (child.type === BrowserMenu) {
+                  return React.cloneElement(child, {
+                    ...child.props,
+                    parentClose: () => this.setState({ open: false }),
+                  });
+                }
+                return React.cloneElement(child, {
                   ...child.props,
                   onClick: () => {
                     this.setState({ open: false });
+                    this.props.parentClose?.();
                     child.props.onClick();
                   },
-                })
-              )}
+                });
+              })}
             </div>
           </div>
         </Popover>
@@ -83,10 +90,10 @@ export default class BrowserMenu extends React.Component {
 BrowserMenu.propTypes = {
   icon: PropTypes.string.isRequired.describe('The name of the icon to place in the menu.'),
   title: PropTypes.string.isRequired.describe('The title text of the menu.'),
-  children: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.node),
-    PropTypes.node,
-  ]).describe(
+  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).describe(
     'The contents of the menu when open. It should be a set of MenuItem and Separator components.'
+  ),
+  parentClose: PropTypes.func.describe(
+    'Closes the parent menu when a nested menu item is selected.'
   ),
 };

--- a/src/components/BrowserMenu/BrowserMenu.react.js
+++ b/src/components/BrowserMenu/BrowserMenu.react.js
@@ -22,8 +22,12 @@ export default class BrowserMenu extends React.Component {
 
   render() {
     let menu = null;
+    const isSubmenu = !!this.props.parentClose;
     if (this.state.open) {
-      const position = Position.inDocument(this.wrapRef.current);
+      let position = Position.inDocument(this.wrapRef.current);
+      if (isSubmenu) {
+        position = position.transform(this.wrapRef.current.clientWidth, 0);
+      }
       const titleStyle = [styles.title];
       if (this.props.active) {
         titleStyle.push(styles.active);
@@ -34,12 +38,21 @@ export default class BrowserMenu extends React.Component {
           position={position}
           onExternalClick={() => this.setState({ open: false })}
         >
-          <div className={styles.menu}>
+          <div
+            className={styles.menu}
+            onMouseLeave={isSubmenu ? () => this.setState({ open: false }) : undefined}
+          >
             <div className={titleStyle.join(' ')} onClick={() => this.setState({ open: false })}>
               {this.props.icon && <Icon name={this.props.icon} width={14} height={14} />}
               <span>{this.props.title}</span>
             </div>
-            <div className={styles.body} style={{ minWidth: this.wrapRef.current.clientWidth }}>
+            <div
+              className={isSubmenu ? styles.subMenuBody : styles.body}
+              style={{
+                minWidth: this.wrapRef.current.clientWidth,
+                ...(isSubmenu ? { top: 0, right: 'auto', left: 0 } : {}),
+              }}
+            >
               {React.Children.map(this.props.children, child => {
                 if (child.type === BrowserMenu) {
                   return React.cloneElement(child, {
@@ -68,7 +81,6 @@ export default class BrowserMenu extends React.Component {
     if (this.props.disabled) {
       classes.push(styles.disabled);
     }
-    const isSubmenu = !!this.props.parentClose;
     const entryEvents = {};
     if (!this.props.disabled) {
       if (isSubmenu) {
@@ -84,14 +96,19 @@ export default class BrowserMenu extends React.Component {
       }
     }
     return (
-      <div
-        className={styles.wrap}
-        ref={this.wrapRef}
-        onMouseLeave={isSubmenu ? () => this.setState({ open: false }) : undefined}
-      >
+      <div className={styles.wrap} ref={this.wrapRef}>
         <div className={classes.join(' ')} {...entryEvents}>
           {this.props.icon && <Icon name={this.props.icon} width={14} height={14} />}
           <span>{this.props.title}</span>
+          {isSubmenu &&
+            React.Children.toArray(this.props.children).some(c => c.type === BrowserMenu) && (
+            <Icon
+              name="right-outline"
+              width={12}
+              height={12}
+              className={styles.submenuArrow}
+            />
+          )}
         </div>
         {menu}
       </div>

--- a/src/components/BrowserMenu/BrowserMenu.react.js
+++ b/src/components/BrowserMenu/BrowserMenu.react.js
@@ -5,12 +5,12 @@
  * This source code is licensed under the license found in the LICENSE file in
  * the root directory of this source tree.
  */
-import Popover from 'components/Popover/Popover.react';
+import styles from 'components/BrowserMenu/BrowserMenu.scss';
 import Icon from 'components/Icon/Icon.react';
+import Popover from 'components/Popover/Popover.react';
 import Position from 'lib/Position';
 import PropTypes from 'lib/PropTypes';
 import React from 'react';
-import styles from 'components/BrowserMenu/BrowserMenu.scss';
 
 export default class BrowserMenu extends React.Component {
   constructor() {

--- a/src/components/BrowserMenu/BrowserMenu.react.js
+++ b/src/components/BrowserMenu/BrowserMenu.react.js
@@ -16,12 +16,13 @@ export default class BrowserMenu extends React.Component {
   constructor() {
     super();
 
-    this.state = { open: false };
+    this.state = { open: false, openToLeft: false };
     this.wrapRef = React.createRef();
   }
 
   render() {
     let menu = null;
+    const isSubmenu = !!this.props.parentClose;
     if (this.state.open) {
       const position = Position.inDocument(this.wrapRef.current);
       const titleStyle = [styles.title];
@@ -35,20 +36,54 @@ export default class BrowserMenu extends React.Component {
           onExternalClick={() => this.setState({ open: false })}
         >
           <div className={styles.menu}>
-            <div className={titleStyle.join(' ')} onClick={() => this.setState({ open: false })}>
-              <Icon name={this.props.icon} width={14} height={14} />
-              <span>{this.props.title}</span>
-            </div>
-            <div className={styles.body} style={{ minWidth: this.wrapRef.current.clientWidth }}>
-              {React.Children.map(this.props.children, child =>
-                React.cloneElement(child, {
+            {!isSubmenu && (
+              <div
+                className={titleStyle.join(' ')}
+                onClick={() => this.setState({ open: false })}
+              >
+                {this.props.icon && <Icon name={this.props.icon} width={14} height={14} />}
+                <span>{this.props.title}</span>
+              </div>
+            )}
+            <div
+              className={
+                isSubmenu
+                  ? this.state.openToLeft
+                    ? styles.subMenuBodyLeft
+                    : styles.subMenuBody
+                  : styles.body
+              }
+              style={{
+                minWidth: this.wrapRef.current.clientWidth,
+                ...(isSubmenu
+                  ? {
+                    top: 0,
+                    left: this.state.openToLeft
+                      ? 0
+                      : `${this.wrapRef.current.clientWidth - 3}px`,
+                    transform: this.state.openToLeft
+                      ? 'translateX(calc(-100% + 3px))'
+                      : undefined,
+                  }
+                  : {}),
+              }}
+            >
+              {React.Children.map(this.props.children, child => {
+                if (child.type === BrowserMenu) {
+                  return React.cloneElement(child, {
+                    ...child.props,
+                    parentClose: () => this.setState({ open: false }),
+                  });
+                }
+                return React.cloneElement(child, {
                   ...child.props,
                   onClick: () => {
                     child.props.onClick?.();
                     this.setState({ open: false });
+                    this.props.parentClose?.();
                   },
-                })
-              )}
+                });
+              })}
             </div>
           </div>
         </Popover>
@@ -61,18 +96,37 @@ export default class BrowserMenu extends React.Component {
     if (this.props.disabled) {
       classes.push(styles.disabled);
     }
-    let onClick = null;
+    const entryEvents = {};
     if (!this.props.disabled) {
-      onClick = () => {
-        this.setState({ open: true });
-        this.props.setCurrent(null);
-      };
+      if (isSubmenu) {
+        entryEvents.onMouseEnter = () => {
+          const rect = this.wrapRef.current.getBoundingClientRect();
+          const width = this.wrapRef.current.clientWidth;
+          const openToLeft = rect.right + width > window.innerWidth;
+          this.setState({ open: true, openToLeft });
+          this.props.setCurrent?.(null);
+        };
+      } else {
+        entryEvents.onClick = () => {
+          this.setState({ open: true, openToLeft: false });
+          this.props.setCurrent(null);
+        };
+      }
     }
     return (
       <div className={styles.wrap} ref={this.wrapRef}>
-        <div className={classes.join(' ')} onClick={onClick}>
-          <Icon name={this.props.icon} width={14} height={14} />
+        <div className={classes.join(' ')} {...entryEvents}>
+          {this.props.icon && <Icon name={this.props.icon} width={14} height={14} />}
           <span>{this.props.title}</span>
+          {isSubmenu &&
+            React.Children.toArray(this.props.children).some(c => c.type === BrowserMenu) && (
+            <Icon
+              name="right-outline"
+              width={12}
+              height={12}
+              className={styles.submenuArrow}
+            />
+          )}
         </div>
         {menu}
       </div>
@@ -81,12 +135,12 @@ export default class BrowserMenu extends React.Component {
 }
 
 BrowserMenu.propTypes = {
-  icon: PropTypes.string.isRequired.describe('The name of the icon to place in the menu.'),
+  icon: PropTypes.string.describe('The name of the icon to place in the menu.'),
   title: PropTypes.string.isRequired.describe('The title text of the menu.'),
-  children: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.node),
-    PropTypes.node,
-  ]).describe(
+  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).describe(
     'The contents of the menu when open. It should be a set of MenuItem and Separator components.'
+  ),
+  parentClose: PropTypes.func.describe(
+    'Closes the parent menu when a nested menu item is selected.'
   ),
 };

--- a/src/components/BrowserMenu/BrowserMenu.react.js
+++ b/src/components/BrowserMenu/BrowserMenu.react.js
@@ -81,9 +81,9 @@ export default class BrowserMenu extends React.Component {
                 return React.cloneElement(child, {
                   ...child.props,
                   onClick: () => {
+                    child.props.onClick?.();
                     this.setState({ open: false });
                     this.props.parentClose?.();
-                    child.props.onClick();
                   },
                 });
               })}

--- a/src/components/BrowserMenu/BrowserMenu.scss
+++ b/src/components/BrowserMenu/BrowserMenu.scss
@@ -89,6 +89,38 @@
   font-size: 14px;
 }
 
+
+.subMenuBody {
+  position: absolute;
+  top: 0;
+  border-radius: 0 5px 5px 5px;
+  background: #797592;
+  padding: 8px 0;
+  font-size: 14px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
+}
+
+.subMenuBodyLeft {
+  position: absolute;
+  top: 0;
+  border-radius: 5px 0 5px 5px;
+  background: #797592;
+  padding: 8px 0;
+  font-size: 14px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
+}
+
+.submenuArrow {
+  margin-left: 4px;
+  fill: #66637A;
+}
+
+.entry:hover .submenuArrow {
+  fill: white;
+}
+
 .item {
   padding: 4px 14px;
   white-space: nowrap;

--- a/src/components/BrowserMenu/BrowserMenu.scss
+++ b/src/components/BrowserMenu/BrowserMenu.scss
@@ -89,6 +89,25 @@
   font-size: 14px;
 }
 
+.subMenuBody {
+  position: absolute;
+  top: 0;
+  left: 100%;
+  border-radius: 0 5px 5px 5px;
+  background: #797592;
+  padding: 8px 0;
+  font-size: 14px;
+}
+
+.submenuArrow {
+  margin-left: 4px;
+  fill: #66637A;
+}
+
+.entry:hover .submenuArrow {
+  fill: white;
+}
+
 .item {
   padding: 4px 14px;
   white-space: nowrap;

--- a/src/components/BrowserMenu/BrowserMenu.scss
+++ b/src/components/BrowserMenu/BrowserMenu.scss
@@ -89,24 +89,29 @@
   font-size: 14px;
 }
 
+
 .subMenuBody {
   position: absolute;
   top: 0;
-  left: 100%;
+  left: calc(100% - 3px);
   border-radius: 0 5px 5px 5px;
   background: #797592;
   padding: 8px 0;
   font-size: 14px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
 }
 
 .subMenuBodyLeft {
   position: absolute;
   top: 0;
-  right: 100%;
+  right: calc(100% - 3px);
   border-radius: 5px 0 5px 5px;
   background: #797592;
   padding: 8px 0;
   font-size: 14px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
 }
 
 .submenuArrow {

--- a/src/components/BrowserMenu/BrowserMenu.scss
+++ b/src/components/BrowserMenu/BrowserMenu.scss
@@ -93,7 +93,6 @@
 .subMenuBody {
   position: absolute;
   top: 0;
-  left: calc(100% - 3px);
   border-radius: 0 5px 5px 5px;
   background: #797592;
   padding: 8px 0;
@@ -105,7 +104,6 @@
 .subMenuBodyLeft {
   position: absolute;
   top: 0;
-  right: calc(100% - 3px);
   border-radius: 5px 0 5px 5px;
   background: #797592;
   padding: 8px 0;

--- a/src/components/BrowserMenu/BrowserMenu.scss
+++ b/src/components/BrowserMenu/BrowserMenu.scss
@@ -99,6 +99,16 @@
   font-size: 14px;
 }
 
+.subMenuBodyLeft {
+  position: absolute;
+  top: 0;
+  right: 100%;
+  border-radius: 5px 0 5px 5px;
+  background: #797592;
+  padding: 8px 0;
+  font-size: 14px;
+}
+
 .submenuArrow {
   margin-left: 4px;
   fill: #66637A;

--- a/src/components/BrowserMenu/BrowserMenu.scss
+++ b/src/components/BrowserMenu/BrowserMenu.scss
@@ -89,38 +89,6 @@
   font-size: 14px;
 }
 
-
-.subMenuBody {
-  position: absolute;
-  top: 0;
-  border-radius: 0 5px 5px 5px;
-  background: #797592;
-  padding: 8px 0;
-  font-size: 14px;
-  border: 1px solid rgba(0, 0, 0, 0.1);
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
-}
-
-.subMenuBodyLeft {
-  position: absolute;
-  top: 0;
-  border-radius: 5px 0 5px 5px;
-  background: #797592;
-  padding: 8px 0;
-  font-size: 14px;
-  border: 1px solid rgba(0, 0, 0, 0.1);
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
-}
-
-.submenuArrow {
-  margin-left: 4px;
-  fill: #66637A;
-}
-
-.entry:hover .submenuArrow {
-  fill: white;
-}
-
 .item {
   padding: 4px 14px;
   white-space: nowrap;

--- a/src/components/BrowserMenu/MenuItem.react.js
+++ b/src/components/BrowserMenu/MenuItem.react.js
@@ -19,8 +19,24 @@ const MenuItem = ({ text, disabled, active, greenActive, onClick }) => {
   if (greenActive) {
     classes.push(styles.greenActive);
   }
+
+  const handleClick = (e) => {
+    if (!disabled && onClick) {
+      onClick(e);
+    }
+  };
+
   return (
-    <div className={classes.join(' ')} onClick={disabled ? undefined : onClick}>
+    <div
+      className={classes.join(' ')}
+      onClick={handleClick}
+      onMouseDown={handleClick} // This is needed - onClick alone doesn't work in this context
+      style={{
+        position: 'relative',
+        zIndex: 9999,
+        cursor: 'pointer'
+      }}
+    >
       {text}
     </div>
   );

--- a/src/dashboard/Data/Browser/BrowserToolbar.react.js
+++ b/src/dashboard/Data/Browser/BrowserToolbar.react.js
@@ -447,7 +447,7 @@ const BrowserToolbar = ({
       )}
       <div className={styles.toolbarSeparator} />
       <BrowserMenu setCurrent={setCurrent} title="Settings" icon="gear-solid">
-        <BrowserMenu title="Info Panel" icon="info-solid">
+        <BrowserMenu title="Info Panel">
           <MenuItem
             text={
               <span>

--- a/src/dashboard/Data/Browser/BrowserToolbar.react.js
+++ b/src/dashboard/Data/Browser/BrowserToolbar.react.js
@@ -447,23 +447,25 @@ const BrowserToolbar = ({
       )}
       <div className={styles.toolbarSeparator} />
       <BrowserMenu setCurrent={setCurrent} title="Settings" icon="gear-solid">
-        <MenuItem
-          text={
-            <span>
-              {scrollToTop && (
-                <Icon
-                  name="check"
-                  width={12}
-                  height={12}
-                  fill="#ffffffff"
-                  className="menuCheck"
-                />
-              )}
-              Scroll to top
-            </span>
-          }
-          onClick={toggleScrollToTop}
-        />
+        <BrowserMenu title="Info Panel" icon="info-solid">
+          <MenuItem
+            text={
+              <span>
+                {scrollToTop && (
+                  <Icon
+                    name="check"
+                    width={12}
+                    height={12}
+                    fill="#ffffffff"
+                    className="menuCheck"
+                  />
+                )}
+                Scroll to top
+              </span>
+            }
+            onClick={toggleScrollToTop}
+          />
+        </BrowserMenu>
       </BrowserMenu>
     </Toolbar>
   );

--- a/src/dashboard/Data/Browser/BrowserToolbar.react.js
+++ b/src/dashboard/Data/Browser/BrowserToolbar.react.js
@@ -7,18 +7,18 @@
  */
 import BrowserFilter from 'components/BrowserFilter/BrowserFilter.react';
 import BrowserMenu from 'components/BrowserMenu/BrowserMenu.react';
-import Icon from 'components/Icon/Icon.react';
 import MenuItem from 'components/BrowserMenu/MenuItem.react';
+import Separator from 'components/BrowserMenu/Separator.react';
+import ColumnsConfiguration from 'components/ColumnsConfiguration/ColumnsConfiguration.react';
+import Icon from 'components/Icon/Icon.react';
+import Toggle from 'components/Toggle/Toggle.react';
+import Toolbar from 'components/Toolbar/Toolbar.react';
+import styles from 'dashboard/Data/Browser/Browser.scss';
+import LoginDialog from 'dashboard/Data/Browser/LoginDialog.react';
+import SecureFieldsDialog from 'dashboard/Data/Browser/SecureFieldsDialog.react';
+import SecurityDialog from 'dashboard/Data/Browser/SecurityDialog.react';
 import prettyNumber from 'lib/prettyNumber';
 import React, { useRef } from 'react';
-import Separator from 'components/BrowserMenu/Separator.react';
-import styles from 'dashboard/Data/Browser/Browser.scss';
-import Toolbar from 'components/Toolbar/Toolbar.react';
-import SecurityDialog from 'dashboard/Data/Browser/SecurityDialog.react';
-import ColumnsConfiguration from 'components/ColumnsConfiguration/ColumnsConfiguration.react';
-import SecureFieldsDialog from 'dashboard/Data/Browser/SecureFieldsDialog.react';
-import LoginDialog from 'dashboard/Data/Browser/LoginDialog.react';
-import Toggle from 'components/Toggle/Toggle.react';
 
 const BrowserToolbar = ({
   className,
@@ -447,7 +447,7 @@ const BrowserToolbar = ({
       )}
       <div className={styles.toolbarSeparator} />
       <BrowserMenu setCurrent={setCurrent} title="Settings" icon="gear-solid">
-        <BrowserMenu title="Info Panel">
+        <BrowserMenu title="Info Panel" setCurrent={setCurrent}>
           <MenuItem
             text={
               <span>
@@ -463,7 +463,9 @@ const BrowserToolbar = ({
                 Scroll to top
               </span>
             }
-            onClick={toggleScrollToTop}
+            onClick={() => {
+              toggleScrollToTop();
+            }}
           />
         </BrowserMenu>
       </BrowserMenu>

--- a/src/dashboard/Data/Browser/BrowserToolbar.react.js
+++ b/src/dashboard/Data/Browser/BrowserToolbar.react.js
@@ -447,23 +447,25 @@ const BrowserToolbar = ({
       )}
       <div className={styles.toolbarSeparator} />
       <BrowserMenu setCurrent={setCurrent} title="Settings" icon="gear-solid">
-        <MenuItem
-          text={
-            <span>
-              {scrollToTop && (
-                <Icon
-                  name="check"
-                  width={12}
-                  height={12}
-                  fill="#ffffffff"
-                  className="menuCheck"
-                />
-              )}
-              Scroll to top
-            </span>
-          }
-          onClick={toggleScrollToTop}
-        />
+        <BrowserMenu title="Info Panel">
+          <MenuItem
+            text={
+              <span>
+                {scrollToTop && (
+                  <Icon
+                    name="check"
+                    width={12}
+                    height={12}
+                    fill="#ffffffff"
+                    className="menuCheck"
+                  />
+                )}
+                Scroll to top
+              </span>
+            }
+            onClick={toggleScrollToTop}
+          />
+        </BrowserMenu>
       </BrowserMenu>
     </Toolbar>
   );

--- a/src/dashboard/Data/Browser/BrowserToolbar.react.js
+++ b/src/dashboard/Data/Browser/BrowserToolbar.react.js
@@ -447,25 +447,23 @@ const BrowserToolbar = ({
       )}
       <div className={styles.toolbarSeparator} />
       <BrowserMenu setCurrent={setCurrent} title="Settings" icon="gear-solid">
-        <BrowserMenu title="Info Panel">
-          <MenuItem
-            text={
-              <span>
-                {scrollToTop && (
-                  <Icon
-                    name="check"
-                    width={12}
-                    height={12}
-                    fill="#ffffffff"
-                    className="menuCheck"
-                  />
-                )}
-                Scroll to top
-              </span>
-            }
-            onClick={toggleScrollToTop}
-          />
-        </BrowserMenu>
+        <MenuItem
+          text={
+            <span>
+              {scrollToTop && (
+                <Icon
+                  name="check"
+                  width={12}
+                  height={12}
+                  fill="#ffffffff"
+                  className="menuCheck"
+                />
+              )}
+              Scroll to top
+            </span>
+          }
+          onClick={toggleScrollToTop}
+        />
       </BrowserMenu>
     </Toolbar>
   );

--- a/src/dashboard/Data/Views/Views.react.js
+++ b/src/dashboard/Data/Views/Views.react.js
@@ -340,7 +340,7 @@ class Views extends TableView {
               text = 'Link';
             }
             content = (
-              <a href={url} target="_blank" rel="noreferrer">
+              <a href={url} target="_blank" rel="noopener noreferrer">
                 {text}
               </a>
             );


### PR DESCRIPTION
## Summary
- support nested BrowserMenus with parentClose handler
- nest the "Info Panel" menu under "Settings"

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d6f5597c8832d9adf2057f175a236