### PR TITLE
fix: Legacy filters without `filterId` do not appear in sidebar

### DIFF
--- a/src/components/CategoryList/CategoryList.react.js
+++ b/src/components/CategoryList/CategoryList.react.js
@@ -168,9 +168,11 @@ export default class CategoryList extends React.Component {
               {this.state.openClasses.includes(id) &&
                 c.filters.map((filterData, index) => {
                   const { name, filter, id } = filterData;
-                  const url = `${this.props.linkPrefix}${c.name}?filters=${encodeURIComponent(
-                    filter
-                  )}&filterId=${id}`;
+                  // Only include filterId in URL if the filter has an ID (modern filters)
+                  // Legacy filters without ID should work with just the filter content
+                  const url = id
+                    ? `${this.props.linkPrefix}${c.name}?filters=${encodeURIComponent(filter)}&filterId=${id}`
+                    : `${this.props.linkPrefix}${c.name}?filters=${encodeURIComponent(filter)}`;
                   return (
                     <div key={index} className={styles.childLink}>
                       <Link


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filter link URLs in category filters to only include the filter ID when available, ensuring cleaner and more accurate links for both legacy and new filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->