### PR TITLE
fix: Legacy filters without `filterId` cannot be deleted in data browser

### DIFF
--- a/src/components/BrowserFilter/BrowserFilter.react.js
+++ b/src/components/BrowserFilter/BrowserFilter.react.js
@@ -381,26 +381,39 @@ export default class BrowserFilter extends React.Component {
       if (preferences.filters) {
         // Find the filter by name and content for legacy filters
         const currentFiltersString = JSON.stringify(this.props.filters.toJS());
+        console.log('Deleting legacy filter - current filters string:', currentFiltersString);
+        console.log('Looking for filter with name:', currentFilterInfo.name);
+        
         const updatedFilters = preferences.filters.filter(filter => {
           // For legacy filters (no id), match by name AND content
           if (!filter.id && filter.name === currentFilterInfo.name) {
+            console.log('Found matching legacy filter to delete:', filter);
             try {
               const savedFiltersString = JSON.stringify(JSON.parse(filter.filter));
-              return savedFiltersString !== currentFiltersString;
+              const shouldDelete = savedFiltersString === currentFiltersString;
+              console.log('Should delete filter?', shouldDelete);
+              return !shouldDelete; // Return false to remove this filter
             } catch {
               // If parsing fails, keep the filter
+              console.log('Parse error, keeping filter');
               return true;
             }
           }
           // Keep all other filters
           return true;
         });
+        
+        console.log('Original filters count:', preferences.filters.length);
+        console.log('Updated filters count:', updatedFilters.length);
+        console.log('Updated filters:', updatedFilters);
 
         ClassPreferences.updatePreferences(
           this.context.applicationId,
           this.props.className,
           { ...preferences, filters: updatedFilters }
         );
+        
+        console.log('Preferences updated successfully');
       }
     } else if (currentFilterInfo.id) {
       // Handle modern filters with ID

--- a/src/components/BrowserFilter/BrowserFilter.react.js
+++ b/src/components/BrowserFilter/BrowserFilter.react.js
@@ -74,27 +74,32 @@ export default class BrowserFilter extends React.Component {
       return false;
     }
 
-    // Fallback only when no filterId in URL: Check if current filter structure matches any saved filter
-    // This is for legacy compatibility
-    const preferences = ClassPreferences.getPreferences(
-      this.context.applicationId,
-      this.props.className
-    );
+    // Check for legacy filters (filters parameter without filterId)
+    const filtersParam = urlParams.get('filters');
+    if (filtersParam && this.props.filters.size > 0) {
+      const preferences = ClassPreferences.getPreferences(
+        this.context.applicationId,
+        this.props.className
+      );
 
-    if (!preferences.filters || this.props.filters.size === 0) {
-      return false;
+      if (preferences.filters) {
+        // Try to find a saved filter that matches the current filter content
+        const currentFiltersString = JSON.stringify(this.props.filters.toJS());
+        
+        const matchingFilter = preferences.filters.find(savedFilter => {
+          try {
+            const savedFiltersString = JSON.stringify(JSON.parse(savedFilter.filter));
+            return savedFiltersString === currentFiltersString;
+          } catch {
+            return false;
+          }
+        });
+
+        return !!matchingFilter;
+      }
     }
 
-    const currentFiltersString = JSON.stringify(this.props.filters.toJS());
-
-    return preferences.filters.some(savedFilter => {
-      try {
-        const savedFiltersString = JSON.stringify(JSON.parse(savedFilter.filter));
-        return savedFiltersString === currentFiltersString;
-      } catch {
-        return false;
-      }
-    });
+    return false;
   }  getCurrentFilterInfo() {
     // Extract filterId from URL if present
     const urlParams = new URLSearchParams(window.location.search);
@@ -132,11 +137,57 @@ export default class BrowserFilter extends React.Component {
       }
     }
 
+    // Check for legacy filters (filters parameter without filterId)
+    const filtersParam = urlParams.get('filters');
+    if (filtersParam && this.props.filters.size > 0) {
+      const preferences = ClassPreferences.getPreferences(
+        this.context.applicationId,
+        this.props.className
+      );
+
+      if (preferences.filters) {
+        // Try to find a saved filter that matches the current filter content
+        const currentFiltersString = JSON.stringify(this.props.filters.toJS());
+        
+        const matchingFilter = preferences.filters.find(savedFilter => {
+          try {
+            const savedFiltersString = JSON.stringify(JSON.parse(savedFilter.filter));
+            return savedFiltersString === currentFiltersString;
+          } catch {
+            return false;
+          }
+        });
+
+        if (matchingFilter) {
+          // Check if the filter has relative dates
+          let hasRelativeDates = false;
+          try {
+            const filterData = JSON.parse(matchingFilter.filter);
+            hasRelativeDates = filterData.some(filter =>
+              filter.compareTo && filter.compareTo.__type === 'RelativeDate'
+            );
+          } catch (error) {
+            console.warn('Failed to parse saved filter:', error);
+            hasRelativeDates = false;
+          }
+
+          return {
+            id: matchingFilter.id || null, // Legacy filters might not have an id
+            name: matchingFilter.name,
+            isApplied: true,
+            hasRelativeDates: hasRelativeDates,
+            isLegacy: !matchingFilter.id // Mark as legacy if no id
+          };
+        }
+      }
+    }
+
     return {
       id: null,
       name: '',
       isApplied: false,
-      hasRelativeDates: false
+      hasRelativeDates: false,
+      isLegacy: false
     };
   }
 
@@ -182,9 +233,22 @@ export default class BrowserFilter extends React.Component {
     );
 
     if (preferences.filters && name) {
-      return preferences.filters.some(filter =>
-        filter.name === name && filter.id !== this.getCurrentFilterInfo().id
-      );
+      const currentFilterInfo = this.getCurrentFilterInfo();
+      return preferences.filters.some(filter => {
+        // For filters with the same name, check if it's not the current filter
+        if (filter.name === name) {
+          // If current filter has an ID, exclude it by ID
+          if (currentFilterInfo.id && filter.id === currentFilterInfo.id) {
+            return false;
+          }
+          // If current filter is legacy (no ID), exclude it by name match
+          if (currentFilterInfo.isLegacy && !filter.id && filter.name === currentFilterInfo.name) {
+            return false;
+          }
+          return true;
+        }
+        return false;
+      });
     }
     return false;
   }
@@ -298,29 +362,66 @@ export default class BrowserFilter extends React.Component {
 
   deleteCurrentFilter() {
     const currentFilterInfo = this.getCurrentFilterInfo();
-    if (!currentFilterInfo.id) {
+    
+    // For legacy filters without ID, we need to delete by name and content match
+    if (!currentFilterInfo.id && currentFilterInfo.isLegacy && currentFilterInfo.name) {
+      const preferences = ClassPreferences.getPreferences(
+        this.context.applicationId,
+        this.props.className
+      );
+
+      if (preferences.filters) {
+        // Find the filter by name and content for legacy filters
+        const currentFiltersString = JSON.stringify(this.props.filters.toJS());
+        const updatedFilters = preferences.filters.filter(filter => {
+          // For legacy filters (no id), match by name AND content
+          if (!filter.id && filter.name === currentFilterInfo.name) {
+            try {
+              const savedFiltersString = JSON.stringify(JSON.parse(filter.filter));
+              return savedFiltersString !== currentFiltersString;
+            } catch {
+              // If parsing fails, keep the filter
+              return true;
+            }
+          }
+          // Keep all other filters
+          return true;
+        });
+
+        ClassPreferences.updatePreferences(
+          this.context.applicationId,
+          this.props.className,
+          { ...preferences, filters: updatedFilters }
+        );
+      }
+    } else if (currentFilterInfo.id) {
+      // Handle modern filters with ID
+      const preferences = ClassPreferences.getPreferences(
+        this.context.applicationId,
+        this.props.className
+      );
+
+      if (preferences.filters) {
+        const updatedFilters = preferences.filters.filter(filter => filter.id !== currentFilterInfo.id);
+        ClassPreferences.updatePreferences(
+          this.context.applicationId,
+          this.props.className,
+          { ...preferences, filters: updatedFilters }
+        );
+      }
+    } else {
+      // No filter to delete
       this.setState({ confirmDelete: false });
       return;
     }
 
-    // Delete the filter from ClassPreferences
-    const preferences = ClassPreferences.getPreferences(
-      this.context.applicationId,
-      this.props.className
-    );
-
-    if (preferences.filters) {
-      const updatedFilters = preferences.filters.filter(filter => filter.id !== currentFilterInfo.id);
-      ClassPreferences.updatePreferences(
-        this.context.applicationId,
-        this.props.className,
-        { ...preferences, filters: updatedFilters }
-      );
-    }
-
-    // Remove filterId from URL
+    // Remove filterId from URL if present
     const urlParams = new URLSearchParams(window.location.search);
     urlParams.delete('filterId');
+    // For legacy filters, also remove the filters parameter
+    if (currentFilterInfo.isLegacy) {
+      urlParams.delete('filters');
+    }
     const newUrl = `${window.location.pathname}${urlParams.toString() ? '?' + urlParams.toString() : ''}`;
     window.history.replaceState({}, '', newUrl);
 
@@ -331,7 +432,7 @@ export default class BrowserFilter extends React.Component {
 
     // Call onDeleteFilter prop if provided
     if (this.props.onDeleteFilter) {
-      this.props.onDeleteFilter(currentFilterInfo.id);
+      this.props.onDeleteFilter(currentFilterInfo.id || currentFilterInfo.name);
     }
   }
 
@@ -458,7 +559,13 @@ export default class BrowserFilter extends React.Component {
 
     // If we're in showMore mode, we're editing an existing filter
     const currentFilterInfo = this.getCurrentFilterInfo();
-    const filterId = this.state.showMore ? currentFilterInfo.id : null;
+    let filterId = this.state.showMore ? currentFilterInfo.id : null;
+    
+    // For legacy filters (no ID), pass a special identifier so the save handler can convert them
+    if (this.state.showMore && currentFilterInfo.isLegacy && !filterId) {
+      // Pass the filter name as a special legacy identifier
+      filterId = `legacy:${currentFilterInfo.name}`;
+    }
 
     const savedFilterId = this.props.onSaveFilter(formatted, this.state.name, this.state.relativeDates, filterId);
 

--- a/src/components/BrowserFilter/BrowserFilter.react.js
+++ b/src/components/BrowserFilter/BrowserFilter.react.js
@@ -105,8 +105,6 @@ export default class BrowserFilter extends React.Component {
     const urlParams = new URLSearchParams(window.location.search);
     const filterId = urlParams.get('filterId');
     const filtersParam = urlParams.get('filters');
-    
-    console.log('getCurrentFilterInfo - URL params:', { filterId, filtersParam, propsFiltersSize: this.props.filters.size });
 
     if (filterId) {
       const preferences = ClassPreferences.getPreferences(
@@ -150,15 +148,11 @@ export default class BrowserFilter extends React.Component {
       if (preferences.filters) {
         // Try to find a saved filter that matches the current filter content
         const currentFiltersString = JSON.stringify(this.props.filters.toJS());
-        console.log('Legacy filter matching - currentFiltersString:', currentFiltersString);
-        console.log('Legacy filter matching - saved filters:', preferences.filters);
         
         const matchingFilter = preferences.filters.find(savedFilter => {
           try {
             const savedFiltersString = JSON.stringify(JSON.parse(savedFilter.filter));
-            console.log('Comparing with saved filter:', savedFilter.name, 'savedFiltersString:', savedFiltersString);
             const matches = savedFiltersString === currentFiltersString;
-            console.log('Match result:', matches);
             return matches;
           } catch {
             return false;
@@ -369,71 +363,34 @@ export default class BrowserFilter extends React.Component {
 
   deleteCurrentFilter() {
     const currentFilterInfo = this.getCurrentFilterInfo();
-    console.log('Deleting filter - currentFilterInfo:', currentFilterInfo);
-    
-    // For legacy filters without ID, we need to delete by name and content match
-    if (!currentFilterInfo.id && currentFilterInfo.isLegacy && currentFilterInfo.name) {
-      const preferences = ClassPreferences.getPreferences(
-        this.context.applicationId,
-        this.props.className
-      );
 
-      if (preferences.filters) {
-        // Find the filter by name and content for legacy filters
-        const currentFiltersString = JSON.stringify(this.props.filters.toJS());
-        console.log('Deleting legacy filter - current filters string:', currentFiltersString);
-        console.log('Looking for filter with name:', currentFilterInfo.name);
-        
-        const updatedFilters = preferences.filters.filter(filter => {
-          // For legacy filters (no id), match by name AND content
-          if (!filter.id && filter.name === currentFilterInfo.name) {
-            console.log('Found matching legacy filter to delete:', filter);
-            try {
-              const savedFiltersString = JSON.stringify(JSON.parse(filter.filter));
-              const shouldDelete = savedFiltersString === currentFiltersString;
-              console.log('Should delete filter?', shouldDelete);
-              return !shouldDelete; // Return false to remove this filter
-            } catch {
-              // If parsing fails, keep the filter
-              console.log('Parse error, keeping filter');
-              return true;
+    // Use parent's onDeleteFilter method which handles everything including force update
+    if (this.props.onDeleteFilter) {
+      // For legacy filters, we need to pass the entire filter object for the parent to match
+      if (currentFilterInfo.isLegacy) {
+        const preferences = ClassPreferences.getPreferences(this.context.applicationId, this.props.className);
+        if (preferences.filters) {
+          const currentFiltersString = JSON.stringify(this.props.filters.toJS());
+          const matchingFilter = preferences.filters.find(filter => {
+            if (!filter.id && filter.name === currentFilterInfo.name) {
+              try {
+                const savedFiltersString = JSON.stringify(JSON.parse(filter.filter));
+                return savedFiltersString === currentFiltersString;
+              } catch {
+                return false;
+              }
             }
+            return false;
+          });
+          
+          if (matchingFilter) {
+            this.props.onDeleteFilter(matchingFilter);
           }
-          // Keep all other filters
-          return true;
-        });
-        
-        console.log('Original filters count:', preferences.filters.length);
-        console.log('Updated filters count:', updatedFilters.length);
-        console.log('Updated filters:', updatedFilters);
-
-        ClassPreferences.updatePreferences(
-          this.context.applicationId,
-          this.props.className,
-          { ...preferences, filters: updatedFilters }
-        );
-        
-        console.log('Preferences updated successfully');
+        }
+      } else if (currentFilterInfo.id) {
+        // For modern filters with ID, just pass the ID
+        this.props.onDeleteFilter(currentFilterInfo.id);
       }
-    } else if (currentFilterInfo.id) {
-      // Handle modern filters with ID
-      const preferences = ClassPreferences.getPreferences(
-        this.context.applicationId,
-        this.props.className
-      );
-
-      if (preferences.filters) {
-        const updatedFilters = preferences.filters.filter(filter => filter.id !== currentFilterInfo.id);
-        ClassPreferences.updatePreferences(
-          this.context.applicationId,
-          this.props.className,
-          { ...preferences, filters: updatedFilters }
-        );
-      }
-    } else {
-      // No filter to delete
-      this.setState({ confirmDelete: false });
-      return;
     }
 
     // Remove filterId from URL if present
@@ -450,11 +407,6 @@ export default class BrowserFilter extends React.Component {
     this.props.onChange(new ImmutableMap());
     this.setState({ confirmDelete: false });
     this.toggle();
-
-    // Call onDeleteFilter prop if provided
-    if (this.props.onDeleteFilter) {
-      this.props.onDeleteFilter(currentFilterInfo.id || currentFilterInfo.name);
-    }
   }
 
   copyCurrentFilter() {

--- a/src/components/BrowserFilter/BrowserFilter.react.js
+++ b/src/components/BrowserFilter/BrowserFilter.react.js
@@ -85,7 +85,7 @@ export default class BrowserFilter extends React.Component {
       if (preferences.filters) {
         // Try to find a saved filter that matches the current filter content
         const currentFiltersString = JSON.stringify(this.props.filters.toJS());
-        
+
         const matchingFilter = preferences.filters.find(savedFilter => {
           try {
             const savedFiltersString = JSON.stringify(JSON.parse(savedFilter.filter));
@@ -148,7 +148,7 @@ export default class BrowserFilter extends React.Component {
       if (preferences.filters) {
         // Try to find a saved filter that matches the current filter content
         const currentFiltersString = JSON.stringify(this.props.filters.toJS());
-        
+
         const matchingFilter = preferences.filters.find(savedFilter => {
           try {
             const savedFiltersString = JSON.stringify(JSON.parse(savedFilter.filter));
@@ -382,7 +382,7 @@ export default class BrowserFilter extends React.Component {
             }
             return false;
           });
-          
+
           if (matchingFilter) {
             this.props.onDeleteFilter(matchingFilter);
           }
@@ -533,7 +533,7 @@ export default class BrowserFilter extends React.Component {
     // If we're in showMore mode, we're editing an existing filter
     const currentFilterInfo = this.getCurrentFilterInfo();
     let filterId = this.state.showMore ? currentFilterInfo.id : null;
-    
+
     // For legacy filters (no ID), pass a special identifier so the save handler can convert them
     if (this.state.showMore && currentFilterInfo.isLegacy && !filterId) {
       // Pass the filter name as a special legacy identifier

--- a/src/components/BrowserFilter/BrowserFilter.react.js
+++ b/src/components/BrowserFilter/BrowserFilter.react.js
@@ -104,6 +104,9 @@ export default class BrowserFilter extends React.Component {
     // Extract filterId from URL if present
     const urlParams = new URLSearchParams(window.location.search);
     const filterId = urlParams.get('filterId');
+    const filtersParam = urlParams.get('filters');
+    
+    console.log('getCurrentFilterInfo - URL params:', { filterId, filtersParam, propsFiltersSize: this.props.filters.size });
 
     if (filterId) {
       const preferences = ClassPreferences.getPreferences(
@@ -138,7 +141,6 @@ export default class BrowserFilter extends React.Component {
     }
 
     // Check for legacy filters (filters parameter without filterId)
-    const filtersParam = urlParams.get('filters');
     if (filtersParam && this.props.filters.size > 0) {
       const preferences = ClassPreferences.getPreferences(
         this.context.applicationId,
@@ -148,11 +150,16 @@ export default class BrowserFilter extends React.Component {
       if (preferences.filters) {
         // Try to find a saved filter that matches the current filter content
         const currentFiltersString = JSON.stringify(this.props.filters.toJS());
+        console.log('Legacy filter matching - currentFiltersString:', currentFiltersString);
+        console.log('Legacy filter matching - saved filters:', preferences.filters);
         
         const matchingFilter = preferences.filters.find(savedFilter => {
           try {
             const savedFiltersString = JSON.stringify(JSON.parse(savedFilter.filter));
-            return savedFiltersString === currentFiltersString;
+            console.log('Comparing with saved filter:', savedFilter.name, 'savedFiltersString:', savedFiltersString);
+            const matches = savedFiltersString === currentFiltersString;
+            console.log('Match result:', matches);
+            return matches;
           } catch {
             return false;
           }
@@ -362,6 +369,7 @@ export default class BrowserFilter extends React.Component {
 
   deleteCurrentFilter() {
     const currentFilterInfo = this.getCurrentFilterInfo();
+    console.log('Deleting filter - currentFilterInfo:', currentFilterInfo);
     
     // For legacy filters without ID, we need to delete by name and content match
     if (!currentFilterInfo.id && currentFilterInfo.isLegacy && currentFilterInfo.name) {

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -1259,7 +1259,31 @@ class Browser extends DashboardView {
 
     let newFilterId = filterId;
 
-    if (filterId) {
+    if (filterId && filterId.startsWith('legacy:')) {
+      // Handle legacy filter update by converting to modern filter
+      const legacyFilterName = filterId.substring(7); // Remove 'legacy:' prefix
+      const existingLegacyFilterIndex = preferences.filters.findIndex(filter =>
+        !filter.id && filter.name === legacyFilterName
+      );
+
+      if (existingLegacyFilterIndex !== -1) {
+        // Convert legacy filter to modern filter by adding an ID
+        newFilterId = crypto.randomUUID();
+        preferences.filters[existingLegacyFilterIndex] = {
+          name,
+          id: newFilterId,
+          filter: _filters,
+        };
+      } else {
+        // Legacy filter not found, create new one
+        newFilterId = crypto.randomUUID();
+        preferences.filters.push({
+          name,
+          id: newFilterId,
+          filter: _filters,
+        });
+      }
+    } else if (filterId) {
       // Update existing filter
       const existingFilterIndex = preferences.filters.findIndex(filter => filter.id === filterId);
       if (existingFilterIndex !== -1) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive support for legacy filters, allowing detection, editing, and deletion of filters identified by a URL parameter.
  * Legacy filters are now clearly identified and can be converted to modern filters during the save process.

* **Bug Fixes**
  * Improved filter name conflict checks to handle legacy filters correctly.
  * Enhanced error handling and logging for relative date detection in filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->