### PR TITLE
Fix: allow saving new objects after deleting field values (#1751)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Details:
 
 > ### “If you are curious to see what's next!”
 
+### Bug Fixes
+
+- Fixed issue where deleting a field value in a new row would prevent saving the object (#1751). The delete key now sets the field value to null instead of using the Delete operation.
+
 These releases contain the latest development changes, but you should be prepared for anything, including sudden breaking changes or code refactoring. Use this branch to contribute to the project and open pull requests.
 
 Details:

--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -515,6 +515,18 @@ export default class BrowserCell extends Component {
     }
   }
 
+  handleSensitiveFieldDelete = (e, field, obj, renderCellContent) => {
+    const deleteKeys = ['Delete', 'Backspace'];
+
+    if (!obj) return;
+
+    if (deleteKeys.includes(e.key)) {
+      e.preventDefault();
+      obj.set(field, null);
+      renderCellContent();
+    }
+  }
+
   pickFilter(constraint, addToExistingFilter) {
     const definition = Filters.Constraints[constraint];
     const { filters, type, value, field, className } = this.props;
@@ -643,6 +655,12 @@ export default class BrowserCell extends Component {
         ref={this.cellRef}
         className={classes.join(' ')}
         style={style}
+        tabIndex={0} // Make the cell focusable so it can receive keyboard events like Delete
+        onKeyDown={e => {
+          const { field, obj } = this.props;
+          // Handle intercept delete keys for sensitive fields
+          this.handleSensitiveFieldDelete(e, field, obj, this.renderCellContent.bind(this));      
+        }}
         onClick={e => {
           if (e.metaKey === true && type === 'Pointer') {
             onPointerCmdClick(value);

--- a/src/components/BrowserRow/BrowserRow.react.js
+++ b/src/components/BrowserRow/BrowserRow.react.js
@@ -172,6 +172,7 @@ export default class BrowserRow extends Component {
               onFilterChange={onFilterChange}
               setRelation={setRelation}
               objectId={obj.id}
+              obj={obj}
               value={attr}
               hidden={hidden}
               isRequired={isRequired}

--- a/src/lib/tests/BrowserCell.test.js
+++ b/src/lib/tests/BrowserCell.test.js
@@ -49,4 +49,55 @@ describe('BrowserCell', () => {
       expect(component.props.className).toContain('required');
     });
   });
+  describe('Delete key interception', () => {
+    let obj;
+    let renderCellContent;
+
+    beforeEach(() => {
+      obj = {
+        set: jest.fn(),
+      };
+      renderCellContent = jest.fn();
+    });
+
+    it('should reset field value when Delete key is pressed', () => {
+      const element = (<BrowserCell field="username" obj={obj} />);
+      const testRenderer = renderer.create(element);
+      const instance = testRenderer.getInstance();
+      
+      const e = { key: 'Delete', preventDefault: jest.fn() };
+      instance.handleSensitiveFieldDelete(e, 'username', obj, renderCellContent);
+
+      expect(e.preventDefault).toHaveBeenCalled();
+      expect(obj.set).toHaveBeenCalledWith('username', null);
+      expect(renderCellContent).toHaveBeenCalled();
+    });
+
+    it('should reset field value when Backspace key is pressed', () => {
+      const element = (<BrowserCell field="password" obj={obj} />);
+      const testRenderer = renderer.create(element);
+      const instance = testRenderer.getInstance();  
+
+      const e = { key: 'Backspace', preventDefault: jest.fn() };
+      instance.handleSensitiveFieldDelete?.(e, 'password', obj, renderCellContent);
+
+      expect(e.preventDefault).toHaveBeenCalled();
+      expect(obj.set).toHaveBeenCalledWith('password', null);
+      expect(renderCellContent).toHaveBeenCalled();
+    });
+
+    it('should do nothing for other keys', () => {
+      const element = (<BrowserCell field="authData" obj={obj} />);
+      const testRenderer = renderer.create(element);
+      const instance = testRenderer.getInstance();
+
+      const e = { key: 'Enter', preventDefault: jest.fn() };
+      instance.handleSensitiveFieldDelete?.(e, 'password', obj, renderCellContent);
+      instance.handleSensitiveFieldDelete?.(e, 'authData', obj, renderCellContent);
+
+      expect(e.preventDefault).not.toHaveBeenCalled();
+      expect(obj.set).not.toHaveBeenCalled();
+      expect(renderCellContent).not.toHaveBeenCalled();
+    });
+  })
 });


### PR DESCRIPTION
**Issue**

Fix: Prevent query error when deleting field value in new _User object (#1751)

**Problema**

Atualmente, ao criar um novo objeto `_User` no **Parse Dashboard**, se o usuário adicionar um valor em um campo e depois o apagar usando `Delete` ou `Backspace`, o Dashboard tenta salvar o objeto com uma operação `__op: "Delete"`.

Esse comportamento gera erro no servidor:
``` 
  You cannot use [object Object] as a query parameter
```

Ou seja, não é possível salvar um novo objeto depois de apagar valores de campos opcionais.

**Abordagem e Decisões de Design**

* Interceptei os eventos de `Delete` e `Backspace` na célula do Data Browser.

* Em vez de atribuir uma operação `Delete`, passo o valor `null` para o campo, garantindo que o objeto seja salvo corretamente sem operações inválidas.

* Criei a função utilitária `handleSensitiveFieldDelete`, que:

  1. Bloqueia o comportamento padrão da tecla (`preventDefault`).

  2. Define o campo como `null`.

  3. Re-renderiza o conteúdo da célula.

Exemplo do método:

```javascript
handleSensitiveFieldDelete = (e, field, obj, renderCellContent) => {
  const deleteKeys = ['Delete', 'Backspace'];

  if (!obj) return;

  if (deleteKeys.includes(e.key)) {
    e.preventDefault();
    obj.set(field, null);
    renderCellContent();
  }
}
```

**Evidências**

* ✅ Antes: tentar salvar um novo _User após apagar o valor de um campo resultava em erro.

[delete_row_error.webm](https://github.com/user-attachments/assets/207b2f82-3010-4b55-b476-071e61b5e1e4)

* ✅ Depois: agora o objeto é salvo corretamente, mesmo após apagar valores de campos opcionais.

[delete_row_ok.webm](https://github.com/user-attachments/assets/d9169b17-b9fe-4ed2-ae6e-91c32b8dfc50)


**Testes Automatizados**

Adicionei testes unitários para garantir a correção e prevenir regressões:

* Pressionar Delete redefine o campo para null.

* Pressionar Backspace redefine o campo para null.

* Outras teclas não têm efeito.

Exemplo:

```javascript
it('should reset field value when Delete key is pressed', () => {
  instance.handleSensitiveFieldDelete(e, 'username', obj, renderCellContent);
  expect(obj.set).toHaveBeenCalledWith('username', null);
});
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Pressing Delete/Backspace in sensitive fields now clears the value (sets it to null) instead of triggering a delete action, preventing save failures in new rows.
  - Cells are now keyboard-focusable, enabling reliable inline clearing via keyboard without disrupting existing interactions.

- Documentation
  - Updated CHANGELOG (Alpha Releases) to note the fix for clearing sensitive fields and reduced risk of save failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->