### PR TITLE
feat: Add config parameter name to quick add dialogs in Config page

### DIFF
--- a/src/dashboard/Data/Config/AddArrayEntryDialog.react.js
+++ b/src/dashboard/Data/Config/AddArrayEntryDialog.react.js
@@ -85,6 +85,7 @@ export default class AddArrayEntryDialog extends React.Component {
   }
 
   render() {
+    const param = this.props.param;
     const confirmDisabled =
       this.state.value === '' ||
       (this.state.showMismatchRow && !this.state.mismatchConfirmed);
@@ -93,7 +94,8 @@ export default class AddArrayEntryDialog extends React.Component {
       <Modal
         type={Modal.Types.INFO}
         icon="plus-solid"
-        title="Add entry"
+        title={'Add entry'}
+        subtitle={param}
         confirmText="Add Unique"
         cancelText="Cancel"
         onCancel={this.props.onCancel}

--- a/src/dashboard/Data/Config/Config.react.js
+++ b/src/dashboard/Data/Config/Config.react.js
@@ -124,6 +124,7 @@ class Config extends TableView {
             this.addArrayEntry(this.state.addEntryParam, value)
           }
           lastType={this.state.addEntryLastType}
+          param={this.state.addEntryParam}
         />
       );
     }
@@ -575,7 +576,7 @@ class Config extends TableView {
         );
       }
 
-      this.showNote('Entry added');
+      this.showNote(`Entry added to ${param}`);
     } catch (e) {
       this.showNote(`Failed to add entry: ${e.message}`, true);
     } finally {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dialog for adding array entries now includes a contextual subtitle showing the relevant parameter.
  * Success notifications are more informative, indicating which parameter the new entry was added to.
  * Parameter context is passed into the dialog to support these UI enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->