### PR TITLE
feat: Add info panel setting to auto-load first row on opening new browser tab

### DIFF
--- a/src/dashboard/Data/Browser/BrowserToolbar.react.js
+++ b/src/dashboard/Data/Browser/BrowserToolbar.react.js
@@ -85,8 +85,8 @@ const BrowserToolbar = ({
   appName,
   scrollToTop,
   toggleScrollToTop,
-  autoSelectFirstRow,
-  toggleAutoSelectFirstRow,
+  autoLoadFirstRow,
+  toggleAutoLoadFirstRow,
 }) => {
   const selectionLength = Object.keys(selection).length;
   const isPendingEditCloneRows = editCloneRows && editCloneRows.length > 0;
@@ -393,7 +393,7 @@ const BrowserToolbar = ({
           <MenuItem
             text={
               <span>
-                {autoSelectFirstRow && (
+                {autoLoadFirstRow && (
                   <Icon
                     name="check"
                     width={12}
@@ -402,11 +402,11 @@ const BrowserToolbar = ({
                     className="menuCheck"
                   />
                 )}
-                Auto-select first row
+                Auto-load first row
               </span>
             }
             onClick={() => {
-              toggleAutoSelectFirstRow();
+              toggleAutoLoadFirstRow();
             }}
           />
         </BrowserMenu>

--- a/src/dashboard/Data/Browser/BrowserToolbar.react.js
+++ b/src/dashboard/Data/Browser/BrowserToolbar.react.js
@@ -85,6 +85,8 @@ const BrowserToolbar = ({
   appName,
   scrollToTop,
   toggleScrollToTop,
+  autoSelectFirstRow,
+  toggleAutoSelectFirstRow,
 }) => {
   const selectionLength = Object.keys(selection).length;
   const isPendingEditCloneRows = editCloneRows && editCloneRows.length > 0;
@@ -386,6 +388,25 @@ const BrowserToolbar = ({
             }
             onClick={() => {
               toggleScrollToTop();
+            }}
+          />
+          <MenuItem
+            text={
+              <span>
+                {autoSelectFirstRow && (
+                  <Icon
+                    name="check"
+                    width={12}
+                    height={12}
+                    fill="#ffffffff"
+                    className="menuCheck"
+                  />
+                )}
+                Auto-select first row
+              </span>
+            }
+            onClick={() => {
+              toggleAutoSelectFirstRow();
             }}
           />
         </BrowserMenu>

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -87,8 +87,8 @@ export default class DataBrowser extends React.Component {
       window.localStorage?.getItem(AGGREGATION_PANEL_VISIBLE) === 'true';
     const storedScrollToTop =
       window.localStorage?.getItem(BROWSER_SCROLL_TO_TOP) !== 'false';
-    const storedAutoSelectFirstRow =
-      window.localStorage?.getItem(BROWSER_AUTO_SELECT_FIRST_ROW) === 'true';
+    const storedAutoLoadFirstRow =
+      window.localStorage?.getItem(AGGREGATION_PANEL_AUTO_LOAD_FIRST_ROW) === 'true';
     const hasAggregation =
       props.classwiseCloudFunctions?.[
         `${props.app.applicationId}${props.appName}`
@@ -114,7 +114,7 @@ export default class DataBrowser extends React.Component {
       frozenColumnIndex: -1,
       showRowNumber: storedRowNumber,
       scrollToTop: storedScrollToTop,
-      autoSelectFirstRow: storedAutoSelectFirstRow,
+      autoLoadFirstRow: storedAutoLoadFirstRow,
       prefetchCache: {},
       selectionHistory: [],
     };
@@ -139,7 +139,7 @@ export default class DataBrowser extends React.Component {
     this.unfreezeColumns = this.unfreezeColumns.bind(this);
     this.setShowRowNumber = this.setShowRowNumber.bind(this);
     this.toggleScrollToTop = this.toggleScrollToTop.bind(this);
-    this.toggleAutoSelectFirstRow = this.toggleAutoSelectFirstRow.bind(this);
+    this.toggleAutoLoadFirstRow = this.toggleAutoLoadFirstRow.bind(this);
     this.handleCellClick = this.handleCellClick.bind(this);
     this.saveOrderTimeout = null;
     this.aggregationPanelRef = React.createRef();
@@ -227,9 +227,9 @@ export default class DataBrowser extends React.Component {
       }
     }
 
-    // Auto-select first row if enabled and conditions are met
+    // Auto-load first row if enabled and conditions are met
     if (
-      this.state.autoSelectFirstRow &&
+      this.state.autoLoadFirstRow &&
       this.state.isPanelVisible &&
       this.props.data &&
       this.props.data.length > 0 &&
@@ -316,10 +316,10 @@ export default class DataBrowser extends React.Component {
       }
     }
 
-    // Auto-select first row when opening panel if enabled and no row is selected
+    // Auto-load first row when opening panel if enabled and no row is selected
     if (
       newVisibility &&
-      this.state.autoSelectFirstRow &&
+      this.state.autoLoadFirstRow &&
       !this.state.selectedObjectId &&
       this.props.data &&
       this.props.data.length > 0
@@ -741,11 +741,11 @@ export default class DataBrowser extends React.Component {
     });
   }
 
-  toggleAutoSelectFirstRow() {
+  toggleAutoLoadFirstRow() {
     this.setState(prevState => {
-      const newAutoSelectFirstRow = !prevState.autoSelectFirstRow;
-      window.localStorage?.setItem(BROWSER_AUTO_SELECT_FIRST_ROW, newAutoSelectFirstRow);
-      return { autoSelectFirstRow: newAutoSelectFirstRow };
+      const newAutoLoadFirstRow = !prevState.autoLoadFirstRow;
+      window.localStorage?.setItem(AGGREGATION_PANEL_AUTO_LOAD_FIRST_ROW, newAutoLoadFirstRow);
+      return { autoLoadFirstRow: newAutoLoadFirstRow };
     });
   }
 
@@ -1049,8 +1049,8 @@ export default class DataBrowser extends React.Component {
           appName={this.props.appName}
           scrollToTop={this.state.scrollToTop}
           toggleScrollToTop={this.toggleScrollToTop}
-          autoSelectFirstRow={this.state.autoSelectFirstRow}
-          toggleAutoSelectFirstRow={this.toggleAutoSelectFirstRow}
+          autoLoadFirstRow={this.state.autoLoadFirstRow}
+          toggleAutoLoadFirstRow={this.toggleAutoLoadFirstRow}
           {...other}
         />
 

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -22,6 +22,7 @@ import AggregationPanel from '../../../components/AggregationPanel/AggregationPa
 const BROWSER_SHOW_ROW_NUMBER = 'browserShowRowNumber';
 const AGGREGATION_PANEL_VISIBLE = 'aggregationPanelVisible';
 const BROWSER_SCROLL_TO_TOP = 'browserScrollToTop';
+const AGGREGATION_PANEL_AUTO_LOAD_FIRST_ROW = 'aggregationPanelAutoLoadFirstRow';
 
 function formatValueForCopy(value, type) {
   if (value === undefined) {
@@ -86,6 +87,8 @@ export default class DataBrowser extends React.Component {
       window.localStorage?.getItem(AGGREGATION_PANEL_VISIBLE) === 'true';
     const storedScrollToTop =
       window.localStorage?.getItem(BROWSER_SCROLL_TO_TOP) !== 'false';
+    const storedAutoSelectFirstRow =
+      window.localStorage?.getItem(BROWSER_AUTO_SELECT_FIRST_ROW) === 'true';
     const hasAggregation =
       props.classwiseCloudFunctions?.[
         `${props.app.applicationId}${props.appName}`
@@ -111,6 +114,7 @@ export default class DataBrowser extends React.Component {
       frozenColumnIndex: -1,
       showRowNumber: storedRowNumber,
       scrollToTop: storedScrollToTop,
+      autoSelectFirstRow: storedAutoSelectFirstRow,
       prefetchCache: {},
       selectionHistory: [],
     };
@@ -135,6 +139,7 @@ export default class DataBrowser extends React.Component {
     this.unfreezeColumns = this.unfreezeColumns.bind(this);
     this.setShowRowNumber = this.setShowRowNumber.bind(this);
     this.toggleScrollToTop = this.toggleScrollToTop.bind(this);
+    this.toggleAutoSelectFirstRow = this.toggleAutoSelectFirstRow.bind(this);
     this.handleCellClick = this.handleCellClick.bind(this);
     this.saveOrderTimeout = null;
     this.aggregationPanelRef = React.createRef();
@@ -222,6 +227,29 @@ export default class DataBrowser extends React.Component {
       }
     }
 
+    // Auto-select first row if enabled and conditions are met
+    if (
+      this.state.autoSelectFirstRow &&
+      this.state.isPanelVisible &&
+      this.props.data &&
+      this.props.data.length > 0 &&
+      !this.state.selectedObjectId &&
+      ((!prevProps.data || prevProps.data.length === 0) ||
+       prevProps.className !== this.props.className ||
+       prevState.isPanelVisible !== this.state.isPanelVisible)
+    ) {
+      const firstRowObjectId = this.props.data[0].id;
+      this.setShowAggregatedData(true);
+      this.setSelectedObjectId(firstRowObjectId);
+      // Also set the current cell to the first cell of the first row
+      this.setCurrent({ row: 0, col: 0 });
+      this.handleCallCloudFunction(
+        firstRowObjectId,
+        this.props.className,
+        this.props.app.applicationId
+      );
+    }
+
     if (
       (this.props.AggregationPanelData !== prevProps.AggregationPanelData ||
         this.state.selectedObjectId !== prevState.selectedObjectId) &&
@@ -286,6 +314,25 @@ export default class DataBrowser extends React.Component {
       if (this.props.errorAggregatedData != {}) {
         this.props.setErrorAggregatedData({});
       }
+    }
+
+    // Auto-select first row when opening panel if enabled and no row is selected
+    if (
+      newVisibility &&
+      this.state.autoSelectFirstRow &&
+      !this.state.selectedObjectId &&
+      this.props.data &&
+      this.props.data.length > 0
+    ) {
+      const firstRowObjectId = this.props.data[0].id;
+      this.setShowAggregatedData(true);
+      this.setSelectedObjectId(firstRowObjectId);
+      this.setCurrent({ row: 0, col: 0 });
+      this.handleCallCloudFunction(
+        firstRowObjectId,
+        this.props.className,
+        this.props.app.applicationId
+      );
     }
 
     if (!newVisibility && this.state.selectedObjectId) {
@@ -694,6 +741,14 @@ export default class DataBrowser extends React.Component {
     });
   }
 
+  toggleAutoSelectFirstRow() {
+    this.setState(prevState => {
+      const newAutoSelectFirstRow = !prevState.autoSelectFirstRow;
+      window.localStorage?.setItem(BROWSER_AUTO_SELECT_FIRST_ROW, newAutoSelectFirstRow);
+      return { autoSelectFirstRow: newAutoSelectFirstRow };
+    });
+  }
+
   getPrefetchSettings() {
     const config =
       this.props.classwiseCloudFunctions?.[
@@ -994,6 +1049,8 @@ export default class DataBrowser extends React.Component {
           appName={this.props.appName}
           scrollToTop={this.state.scrollToTop}
           toggleScrollToTop={this.toggleScrollToTop}
+          autoSelectFirstRow={this.state.autoSelectFirstRow}
+          toggleAutoSelectFirstRow={this.toggleAutoSelectFirstRow}
           {...other}
         />
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added an “Auto-load first row” setting in the Browser toolbar (Settings → Info Panel) with a check indicator when enabled.
  * When enabled, opening the Aggregation panel auto-selects the first row, shows aggregated data, and focuses the first cell if no row is selected.
  * Preference persists between sessions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->