### PR TITLE
feat: Add button to view table to open all pointers of a column in new browser tabs

### DIFF
--- a/src/dashboard/Data/Views/Views.react.js
+++ b/src/dashboard/Data/Views/Views.react.js
@@ -897,8 +897,8 @@ class Views extends TableView {
         if (newWindow) {
           successCount++;
         }
-      } catch {
-        // Error handled by final notification logic
+      } catch (error) {
+        console.error('Failed to open tab for pointer:', pointer, error);
       }
     });
 

--- a/src/dashboard/Data/Views/Views.react.js
+++ b/src/dashboard/Data/Views/Views.react.js
@@ -569,6 +569,8 @@ class Views extends TableView {
                   e.stopPropagation();
                   e.preventDefault();
                   this.handleOpenAllPointers(name);
+                  // Remove focus after action to follow UX best practices
+                  e.currentTarget.blur();
                 }}
                 aria-label={`Open all pointers in ${name} column in new tabs`}
                 title="Open all pointers in new tabs"

--- a/src/dashboard/Data/Views/Views.react.js
+++ b/src/dashboard/Data/Views/Views.react.js
@@ -277,6 +277,9 @@ class Views extends TableView {
             }
             if (!columns[key]) {
               columns[key] = { type, width: Math.min(computeWidth(key), 200) };
+            } else if (type === 'Pointer' && columns[key].type !== 'Pointer') {
+              // If we find a pointer value, upgrade the column type to Pointer
+              columns[key].type = 'Pointer';
             }
             const width = computeWidth(val);
             if (width > columns[key].width && columns[key].width < 200) {

--- a/src/dashboard/Data/Views/Views.react.js
+++ b/src/dashboard/Data/Views/Views.react.js
@@ -570,8 +570,9 @@ class Views extends TableView {
               >
                 <Icon
                   name="right-outline"
-                  width={12}
-                  height={12}
+                  width={20}
+                  height={20}
+                  fill="white"
                 />
               </span>
             )}

--- a/src/dashboard/Data/Views/Views.react.js
+++ b/src/dashboard/Data/Views/Views.react.js
@@ -550,12 +550,36 @@ class Views extends TableView {
   }
 
   renderHeaders() {
-    return this.state.order.map(({ name, width }, i) => (
-      <div key={name} className={styles.headerWrap} style={{ width }}>
-        {name}
-        <DragHandle className={styles.handle} onDrag={delta => this.handleResize(i, delta)} />
-      </div>
-    ));
+    return this.state.order.map(({ name, width }, i) => {
+      const columnType = this.state.columns[name]?.type;
+      const isPointerColumn = columnType === 'Pointer';
+      
+      return (
+        <div key={name} className={styles.headerWrap} style={{ width }}>
+          <span className={styles.headerText}>
+            {name}
+            {isPointerColumn && (
+              <span
+                className={styles.pointerIcon}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  e.preventDefault();
+                  this.handleOpenAllPointers(name);
+                }}
+                title="Open all pointers in new tabs"
+              >
+                <Icon
+                  name="right-outline"
+                  width={12}
+                  height={12}
+                />
+              </span>
+            )}
+          </span>
+          <DragHandle className={styles.handle} onDrag={delta => this.handleResize(i, delta)} />
+        </div>
+      );
+    });
   }
 
   renderEmpty() {
@@ -829,6 +853,59 @@ class Views extends TableView {
 
   handleValueClick(value) {
     this.setState({ viewValue: value });
+  }
+
+  handleOpenAllPointers(columnName) {
+    const data = this.tableData();
+    const pointers = data
+      .map(row => row[columnName])
+      .filter(value => value && value.__type === 'Pointer' && value.className && value.objectId);
+
+    // Open each unique pointer in a new tab
+    const uniquePointers = new Map();
+    pointers.forEach(pointer => {
+      const key = `${pointer.className}-${pointer.objectId}`;
+      if (!uniquePointers.has(key)) {
+        uniquePointers.set(key, pointer);
+      }
+    });
+
+    if (uniquePointers.size === 0) {
+      this.showNote('No pointers found in this column', true);
+      return;
+    }
+
+    const pointersArray = Array.from(uniquePointers.values());
+
+    // Open all tabs immediately to maintain user activation context
+    let successCount = 0;
+
+    pointersArray.forEach((pointer) => {
+      try {
+        const filters = JSON.stringify([{ field: 'objectId', constraint: 'eq', compareTo: pointer.objectId }]);
+        const url = generatePath(
+          this.context,
+          `browser/${pointer.className}?filters=${encodeURIComponent(filters)}`,
+          true
+        );
+        const newWindow = window.open(url, '_blank');
+
+        if (newWindow) {
+          successCount++;
+        }
+      } catch {
+        // Error handled by final notification logic
+      }
+    });
+
+    // Show result notification
+    if (successCount === pointersArray.length) {
+      this.showNote(`Opened ${successCount} pointer${successCount > 1 ? 's' : ''} in new tab${successCount > 1 ? 's' : ''}`, false);
+    } else if (successCount > 0) {
+      this.showNote(`Opened ${successCount} of ${pointersArray.length} tabs. ${pointersArray.length - successCount} blocked by popup blocker.`, true);
+    } else {
+      this.showNote('Unable to open tabs. Please allow popups for this site and try again.', true);
+    }
   }
 
   showNote(message, isError) {

--- a/src/dashboard/Data/Views/Views.react.js
+++ b/src/dashboard/Data/Views/Views.react.js
@@ -556,7 +556,7 @@ class Views extends TableView {
     return this.state.order.map(({ name, width }, i) => {
       const columnType = this.state.columns[name]?.type;
       const isPointerColumn = columnType === 'Pointer';
-      
+
       return (
         <div key={name} className={styles.headerWrap} style={{ width }}>
           <span className={styles.headerText}>

--- a/src/dashboard/Data/Views/Views.react.js
+++ b/src/dashboard/Data/Views/Views.react.js
@@ -560,15 +560,17 @@ class Views extends TableView {
       return (
         <div key={name} className={styles.headerWrap} style={{ width }}>
           <span className={styles.headerText}>
-            {name}
+            <span className={styles.headerLabel}>{name}</span>
             {isPointerColumn && (
-              <span
+              <button
+                type="button"
                 className={styles.pointerIcon}
                 onClick={(e) => {
                   e.stopPropagation();
                   e.preventDefault();
                   this.handleOpenAllPointers(name);
                 }}
+                aria-label={`Open all pointers in ${name} column in new tabs`}
                 title="Open all pointers in new tabs"
               >
                 <Icon
@@ -577,7 +579,7 @@ class Views extends TableView {
                   height={20}
                   fill="white"
                 />
-              </span>
+              </button>
             )}
           </span>
           <DragHandle className={styles.handle} onDrag={delta => this.handleResize(i, delta)} />
@@ -851,7 +853,8 @@ class Views extends TableView {
         `browser/${className}?filters=${encodeURIComponent(filters)}`,
         true
       ),
-      '_blank'
+      '_blank',
+      'noopener,noreferrer'
     );
   }
 
@@ -868,7 +871,8 @@ class Views extends TableView {
     // Open each unique pointer in a new tab
     const uniquePointers = new Map();
     pointers.forEach(pointer => {
-      const key = `${pointer.className}-${pointer.objectId}`;
+      // Use a more collision-proof key format with explicit separators
+      const key = `className:${pointer.className}|objectId:${pointer.objectId}`;
       if (!uniquePointers.has(key)) {
         uniquePointers.set(key, pointer);
       }
@@ -881,8 +885,16 @@ class Views extends TableView {
 
     const pointersArray = Array.from(uniquePointers.values());
 
+    // Confirm for large numbers of tabs to prevent overwhelming the user
+    if (pointersArray.length > 10) {
+      const confirmMessage = `This will open ${pointersArray.length} new tabs. This might overwhelm your browser. Continue?`;
+      if (!confirm(confirmMessage)) {
+        return;
+      }
+    }
+
     // Open all tabs immediately to maintain user activation context
-    let successCount = 0;
+    let errorCount = 0;
 
     pointersArray.forEach((pointer) => {
       try {
@@ -892,21 +904,20 @@ class Views extends TableView {
           `browser/${pointer.className}?filters=${encodeURIComponent(filters)}`,
           true
         );
-        const newWindow = window.open(url, '_blank');
-
-        if (newWindow) {
-          successCount++;
-        }
+        window.open(url, '_blank', 'noopener,noreferrer');
+        // Note: window.open with security attributes may return null even when successful,
+        // so we assume success unless an exception is thrown
       } catch (error) {
         console.error('Failed to open tab for pointer:', pointer, error);
+        errorCount++;
       }
     });
 
     // Show result notification
-    if (successCount === pointersArray.length) {
-      this.showNote(`Opened ${successCount} pointer${successCount > 1 ? 's' : ''} in new tab${successCount > 1 ? 's' : ''}`, false);
-    } else if (successCount > 0) {
-      this.showNote(`Opened ${successCount} of ${pointersArray.length} tabs. ${pointersArray.length - successCount} blocked by popup blocker.`, true);
+    if (errorCount === 0) {
+      this.showNote(`Opened ${pointersArray.length} pointer${pointersArray.length > 1 ? 's' : ''} in new tab${pointersArray.length > 1 ? 's' : ''}`, false);
+    } else if (errorCount < pointersArray.length) {
+      this.showNote(`Opened ${pointersArray.length - errorCount} of ${pointersArray.length} tabs. ${errorCount} failed to open.`, true);
     } else {
       this.showNote('Unable to open tabs. Please allow popups for this site and try again.', true);
     }

--- a/src/dashboard/Data/Views/Views.scss
+++ b/src/dashboard/Data/Views/Views.scss
@@ -23,9 +23,26 @@
   align-items: center;
   justify-content: space-between;
   width: 100%;
+  min-width: 0; // Enable text truncation in flex containers
+}
+
+.headerLabel {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  min-width: 0; // Enable text truncation
 }
 
 .pointerIcon {
+  // Reset button styles
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  background: rgba(255, 255, 255, 0.2);
+  
+  // Custom styles
   cursor: pointer;
   opacity: 0.7;
   transition: opacity 0.2s ease;
@@ -36,7 +53,6 @@
   justify-content: center;
   height: 20px;
   width: 20px;
-  background: rgba(255, 255, 255, 0.2);
   border-radius: 50%;
   margin-left: 5px;
   flex-shrink: 0;
@@ -48,6 +64,13 @@
   &:hover {
     opacity: 1;
     background: rgba(255, 255, 255, 0.3);
+  }
+  
+  &:focus {
+    opacity: 1;
+    background: rgba(255, 255, 255, 0.4);
+    outline: 2px solid rgba(255, 255, 255, 0.8);
+    outline-offset: 1px;
   }
 }
 

--- a/src/dashboard/Data/Views/Views.scss
+++ b/src/dashboard/Data/Views/Views.scss
@@ -18,6 +18,27 @@
   text-overflow: ellipsis;
 }
 
+.headerText {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.pointerIcon {
+  cursor: pointer;
+  opacity: 0.7;
+  transition: opacity 0.2s ease;
+  z-index: 10;
+  pointer-events: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  
+  &:hover {
+    opacity: 1;
+  }
+}
+
 .handle {
   position: absolute;
   top: 0;

--- a/src/dashboard/Data/Views/Views.scss
+++ b/src/dashboard/Data/Views/Views.scss
@@ -21,7 +21,8 @@
 .headerText {
   display: flex;
   align-items: center;
-  gap: 6px;
+  justify-content: space-between;
+  width: 100%;
 }
 
 .pointerIcon {
@@ -33,9 +34,20 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  height: 20px;
+  width: 20px;
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 50%;
+  margin-left: 5px;
+  flex-shrink: 0;
+  
+  & svg {
+    transform: rotate(316deg);
+  }
   
   &:hover {
     opacity: 1;
+    background: rgba(255, 255, 255, 0.3);
   }
 }
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description

If a user wants to open each pointer in a view table column in a new browser tab, the user needs to click on each pointer individually.

### Approach

Add icon to batch-open pointers in a view table column in new browser tabs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Pointer-type columns are now auto-detected and promoted when pointer values appear.
  - Headers display a pointer icon for pointer-type columns; clicking it opens each unique referenced record in new tabs and shows success/partial/failure/no-results feedback.

- Style
  - Updated header layout, truncation behavior, and an interactive pointer icon with hover/focus affordances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->