### PR TITLE
feat: Add `matches regex` filter to data browser replacing limited `string contains string` filter

### DIFF
--- a/src/components/BrowserFilter/BrowserFilter.react.js
+++ b/src/components/BrowserFilter/BrowserFilter.react.js
@@ -491,9 +491,21 @@ export default class BrowserFilter extends React.Component {
         const date = new Date(compareTo.iso);
         return filter.set('compareTo', date);
       } else if (typeof compareTo === 'string' && !isNaN(Date.parse(compareTo))) {
-        // Convert date string to JavaScript Date
-        const date = new Date(compareTo);
-        return filter.set('compareTo', date);
+        // Only convert date strings to JavaScript Date if the field type is actually Date
+        const className = filter.get('class') || this.props.className;
+        const fieldName = filter.get('field');
+        const schema = this.props.schema;
+
+        if (schema && className && fieldName) {
+          const classSchema = schema[className];
+          const fieldType = classSchema?.[fieldName]?.type;
+
+          // Only convert to Date if the field type is actually Date
+          if (fieldType === 'Date') {
+            const date = new Date(compareTo);
+            return filter.set('compareTo', date);
+          }
+        }
       }
       // Leave JavaScript Date objects and other types unchanged
       return filter;

--- a/src/components/BrowserFilter/FilterRow.react.js
+++ b/src/components/BrowserFilter/FilterRow.react.js
@@ -228,7 +228,6 @@ function compareValue(
             <input
               type="text"
               value={value}
-              placeholder="regex pattern"
               onChange={e => onChangeCompareTo(e.target.value)}
               onKeyDown={onKeyDown}
               ref={setFocus}

--- a/src/components/BrowserFilter/FilterRow.react.js
+++ b/src/components/BrowserFilter/FilterRow.react.js
@@ -75,12 +75,14 @@ const RegexOptionsButton = ({ modifiers, onChangeModifiers }) => {
       <div
         ref={dropdownRef}
         style={{
-          background: '#343445',
+          background: '#1e1e2e',
+          border: '1px solid #66637A',
           borderRadius: '5px',
           padding: '8px',
           minWidth: '150px',
           color: 'white',
-          fontSize: '14px'
+          fontSize: '14px',
+          boxShadow: '0 4px 6px rgba(0, 0, 0, 0.3)'
         }}
       >
         <div style={{ marginBottom: '4px', fontWeight: 'bold', paddingBottom: '4px', borderBottom: '1px solid rgba(255,255,255,0.2)' }}>

--- a/src/components/BrowserFilter/FilterRow.react.js
+++ b/src/components/BrowserFilter/FilterRow.react.js
@@ -224,7 +224,7 @@ function compareValue(
     case 'String':
       if (currentConstraint === 'matches') {
         return (
-          <div style={{ display: 'flex', alignItems: 'center', gap: '4px', flex: 1 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
             <input
               type="text"
               value={value}
@@ -232,7 +232,7 @@ function compareValue(
               onChange={e => onChangeCompareTo(e.target.value)}
               onKeyDown={onKeyDown}
               ref={setFocus}
-              style={{ flex: 1 }}
+              style={{ width: '106px' }}
             />
             <RegexOptionsButton modifiers={modifiers} onChangeModifiers={onChangeModifiers} />
           </div>
@@ -414,24 +414,14 @@ const FilterRow = ({
         buildSuggestions={buildFieldSuggestions}
         buildLabel={() => ''}
       />
-      {compareInfo.type ? (
+      <div style={{ flex: 1 }}>
         <ChromeDropdown
-          width="175"
           color={active ? 'blue' : 'purple'}
           value={Constraints[currentConstraint].name}
           options={constraints.map(c => Constraints[c].name)}
           onChange={c => onChangeConstraint(constraintLookup[c], compareTo)}
         />
-      ) : (
-        <div style={{ flex: 1 }}>
-          <ChromeDropdown
-            color={active ? 'blue' : 'purple'}
-            value={Constraints[currentConstraint].name}
-            options={constraints.map(c => Constraints[c].name)}
-            onChange={c => onChangeConstraint(constraintLookup[c], compareTo)}
-          />
-        </div>
-      )}
+      </div>
       {compareValue(
         compareInfo,
         compareTo,

--- a/src/components/BrowserFilter/FilterRow.react.js
+++ b/src/components/BrowserFilter/FilterRow.react.js
@@ -251,6 +251,7 @@ function compareValue(
     case 'Boolean':
       return (
         <ChromeDropdown
+          width="140"
           color={active ? 'blue' : 'purple'}
           value={value ? 'True' : 'False'}
           options={['True', 'False']}

--- a/src/components/BrowserFilter/FilterRow.react.js
+++ b/src/components/BrowserFilter/FilterRow.react.js
@@ -29,7 +29,9 @@ function compareValue(
   active,
   parentContentId,
   setFocus,
-  currentConstraint
+  currentConstraint,
+  modifiers,
+  onChangeModifiers
 ) {
   if (currentConstraint === 'containedIn') {
     return (
@@ -60,6 +62,29 @@ function compareValue(
       return null;
     case 'Object':
     case 'String':
+      if (currentConstraint === 'matches') {
+        return (
+          <>
+            <input
+              type="text"
+              value={value}
+              placeholder="regex pattern"
+              onChange={e => onChangeCompareTo(e.target.value)}
+              onKeyDown={onKeyDown}
+              ref={setFocus}
+              style={{ width: '140px' }}
+            />
+            <input
+              type="text"
+              value={modifiers || ''}
+              placeholder="i"
+              onChange={e => onChangeModifiers(e.target.value)}
+              onKeyDown={onKeyDown}
+              style={{ width: '60px', marginLeft: '4px' }}
+            />
+          </>
+        );
+      }
       return (
         <input
           type="text"
@@ -131,10 +156,12 @@ const FilterRow = ({
   currentField,
   currentConstraint,
   compareTo,
+  modifiers,
   onChangeClass,
   onChangeField,
   onChangeConstraint,
   onChangeCompareTo,
+  onChangeModifiers,
   onKeyDown,
   onDeleteRow,
   active,
@@ -249,7 +276,9 @@ const FilterRow = ({
         active,
         parentContentId,
         setFocus,
-        currentConstraint
+        currentConstraint,
+        modifiers,
+        onChangeModifiers
       )}
       <button type="button" className={styles.remove} onClick={onDeleteRow}>
         <Icon name="minus-solid" width={14} height={14} fill="rgba(0,0,0,0.4)" />
@@ -267,4 +296,6 @@ FilterRow.propTypes = {
   currentConstraint: PropTypes.string.isRequired,
   compareTo: PropTypes.any,
   compareInfo: PropTypes.object,
+  modifiers: PropTypes.string,
+  onChangeModifiers: PropTypes.func,
 };

--- a/src/components/BrowserFilter/FilterRow.react.js
+++ b/src/components/BrowserFilter/FilterRow.react.js
@@ -155,26 +155,13 @@ const RegexOptionsButton = ({ modifiers, onChangeModifiers }) => {
       <button
         ref={buttonRef}
         type="button"
+        className={styles.remove}
         onClick={() => {
           setShowOptions(!showOptions);
         }}
-        style={{
-          background: '#343445',
-          border: 'none',
-          borderRadius: '5px',
-          width: '30px',
-          height: '30px',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          cursor: 'pointer',
-          color: 'white',
-          fontSize: '18px',
-          fontWeight: 'bold'
-        }}
         title="Regex options"
       >
-        ⚙
+        <Icon name="gear-solid" width={14} height={14} fill="rgba(0,0,0,0.4)" />
       </button>
       {optionsDropdown}
     </>

--- a/src/components/BrowserFilter/FilterRow.react.js
+++ b/src/components/BrowserFilter/FilterRow.react.js
@@ -11,8 +11,10 @@ import { Constraints } from 'lib/Filters';
 import DateTimeEntry from 'components/DateTimeEntry/DateTimeEntry.react';
 import Icon from 'components/Icon/Icon.react';
 import Parse from 'parse';
+import Popover from 'components/Popover/Popover.react';
+import Position from 'lib/Position';
 import PropTypes from 'lib/PropTypes';
-import React, { useCallback } from 'react';
+import React, { useCallback, useState, useRef } from 'react';
 import styles from 'components/BrowserFilter/BrowserFilter.scss';
 import validateNumeric from 'lib/validateNumeric';
 
@@ -20,6 +22,164 @@ const constraintLookup = {};
 for (const c in Constraints) {
   constraintLookup[Constraints[c].name] = c;
 }
+
+const RegexOptionsButton = ({ modifiers, onChangeModifiers }) => {
+  const [showOptions, setShowOptions] = useState(false);
+  const buttonRef = useRef(null);
+  const dropdownRef = useRef(null);
+
+  // Parse modifiers string into individual flags
+  const modifiersArray = modifiers ? modifiers.split('') : [];
+  const hasI = modifiersArray.includes('i');
+  const hasU = modifiersArray.includes('u');
+  const hasM = modifiersArray.includes('m');
+  const hasX = modifiersArray.includes('x');
+  const hasS = modifiersArray.includes('s');
+
+  const toggleModifier = (modifier) => {
+    let newModifiers = [...modifiersArray];
+    if (newModifiers.includes(modifier)) {
+      newModifiers = newModifiers.filter(m => m !== modifier);
+    } else {
+      newModifiers.push(modifier);
+    }
+    onChangeModifiers(newModifiers.join(''));
+  };
+
+  React.useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target) &&
+        buttonRef.current &&
+        !buttonRef.current.contains(event.target)
+      ) {
+        setShowOptions(false);
+      }
+    };
+
+    if (showOptions) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => {
+        document.removeEventListener('mousedown', handleClickOutside);
+      };
+    }
+  }, [showOptions]);
+
+  const optionsDropdown = showOptions ? (
+    <Popover
+      fixed={true}
+      position={Position.inDocument(buttonRef.current)}
+      data-popover-type="inner"
+    >
+      <div
+        ref={dropdownRef}
+        style={{
+          background: '#343445',
+          borderRadius: '5px',
+          padding: '8px',
+          minWidth: '150px',
+          color: 'white',
+          fontSize: '14px'
+        }}
+      >
+        <div style={{ marginBottom: '4px', fontWeight: 'bold', paddingBottom: '4px', borderBottom: '1px solid rgba(255,255,255,0.2)' }}>
+          Regex Options
+        </div>
+        <label
+          style={{ display: 'flex', alignItems: 'center', padding: '4px 0', cursor: 'pointer' }}
+          onClick={() => toggleModifier('i')}
+        >
+          <input
+            type="checkbox"
+            checked={hasI}
+            readOnly
+            style={{ marginRight: '8px', cursor: 'pointer' }}
+          />
+          <span>Case insensitive (i)</span>
+        </label>
+        <label
+          style={{ display: 'flex', alignItems: 'center', padding: '4px 0', cursor: 'pointer' }}
+          onClick={() => toggleModifier('u')}
+        >
+          <input
+            type="checkbox"
+            checked={hasU}
+            readOnly
+            style={{ marginRight: '8px', cursor: 'pointer' }}
+          />
+          <span>Unicode (u)</span>
+        </label>
+        <label
+          style={{ display: 'flex', alignItems: 'center', padding: '4px 0', cursor: 'pointer' }}
+          onClick={() => toggleModifier('m')}
+        >
+          <input
+            type="checkbox"
+            checked={hasM}
+            readOnly
+            style={{ marginRight: '8px', cursor: 'pointer' }}
+          />
+          <span>Multiline (m)</span>
+        </label>
+        <label
+          style={{ display: 'flex', alignItems: 'center', padding: '4px 0', cursor: 'pointer' }}
+          onClick={() => toggleModifier('x')}
+        >
+          <input
+            type="checkbox"
+            checked={hasX}
+            readOnly
+            style={{ marginRight: '8px', cursor: 'pointer' }}
+          />
+          <span>Extended (x)</span>
+        </label>
+        <label
+          style={{ display: 'flex', alignItems: 'center', padding: '4px 0', cursor: 'pointer' }}
+          onClick={() => toggleModifier('s')}
+        >
+          <input
+            type="checkbox"
+            checked={hasS}
+            readOnly
+            style={{ marginRight: '8px', cursor: 'pointer' }}
+          />
+          <span>Dotall (s)</span>
+        </label>
+      </div>
+    </Popover>
+  ) : null;
+
+  return (
+    <>
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={() => {
+          setShowOptions(!showOptions);
+        }}
+        style={{
+          background: '#343445',
+          border: 'none',
+          borderRadius: '5px',
+          width: '30px',
+          height: '30px',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          cursor: 'pointer',
+          color: 'white',
+          fontSize: '18px',
+          fontWeight: 'bold'
+        }}
+        title="Regex options"
+      >
+        ⚙
+      </button>
+      {optionsDropdown}
+    </>
+  );
+};
 
 function compareValue(
   info,
@@ -64,7 +224,7 @@ function compareValue(
     case 'String':
       if (currentConstraint === 'matches') {
         return (
-          <>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '4px', flex: 1 }}>
             <input
               type="text"
               value={value}
@@ -72,17 +232,10 @@ function compareValue(
               onChange={e => onChangeCompareTo(e.target.value)}
               onKeyDown={onKeyDown}
               ref={setFocus}
-              style={{ width: '140px' }}
+              style={{ flex: 1 }}
             />
-            <input
-              type="text"
-              value={modifiers || ''}
-              placeholder="i"
-              onChange={e => onChangeModifiers(e.target.value)}
-              onKeyDown={onKeyDown}
-              style={{ width: '60px', marginLeft: '4px' }}
-            />
-          </>
+            <RegexOptionsButton modifiers={modifiers} onChangeModifiers={onChangeModifiers} />
+          </div>
         );
       }
       return (
@@ -261,13 +414,24 @@ const FilterRow = ({
         buildSuggestions={buildFieldSuggestions}
         buildLabel={() => ''}
       />
-      <ChromeDropdown
-        width={compareInfo.type ? '175' : '325'}
-        color={active ? 'blue' : 'purple'}
-        value={Constraints[currentConstraint].name}
-        options={constraints.map(c => Constraints[c].name)}
-        onChange={c => onChangeConstraint(constraintLookup[c], compareTo)}
-      />
+      {compareInfo.type ? (
+        <ChromeDropdown
+          width="175"
+          color={active ? 'blue' : 'purple'}
+          value={Constraints[currentConstraint].name}
+          options={constraints.map(c => Constraints[c].name)}
+          onChange={c => onChangeConstraint(constraintLookup[c], compareTo)}
+        />
+      ) : (
+        <div style={{ flex: 1 }}>
+          <ChromeDropdown
+            color={active ? 'blue' : 'purple'}
+            value={Constraints[currentConstraint].name}
+            options={constraints.map(c => Constraints[c].name)}
+            onChange={c => onChangeConstraint(constraintLookup[c], compareTo)}
+          />
+        </div>
+      )}
       {compareValue(
         compareInfo,
         compareTo,

--- a/src/components/ChromeDropdown/ChromeDropdown.react.js
+++ b/src/components/ChromeDropdown/ChromeDropdown.react.js
@@ -53,7 +53,8 @@ export default class ChromeDropdown extends React.Component {
   }
 
   render() {
-    let widthStyle = { width: parseFloat(this.props.width || 140) };
+    const width = this.props.width ? parseFloat(this.props.width) : '100%';
+    let widthStyle = { width };
     const styles = this.styles;
     const color = this.props.color || 'purple';
 

--- a/src/components/Filter/Filter.react.js
+++ b/src/components/Filter/Filter.react.js
@@ -57,12 +57,26 @@ function changeConstraint(schema, currentClassName, filters, index, newConstrain
   if (Object.prototype.hasOwnProperty.call(Filters.Constraints[newConstraint], 'field')) {
     compareType = Filters.Constraints[newConstraint].field;
   }
+
+  // Determine compareTo value
+  let compareTo;
+  if (newConstraint === 'containedIn') {
+    compareTo = [];
+  } else if (newConstraint === 'matches') {
+    // For matches constraint, always use empty string, don't reuse previous value
+    compareTo = '';
+  } else if (compareType && prevCompareTo && typeof prevCompareTo === typeof Filters.DefaultComparisons[compareType]) {
+    // Only reuse prevCompareTo if types match
+    compareTo = prevCompareTo;
+  } else {
+    compareTo = Filters.DefaultComparisons[compareType];
+  }
+
   const newFilter = new Map({
     class: currentClassName,
     field: field,
     constraint: newConstraint,
-    compareTo:
-      compareType && prevCompareTo ? prevCompareTo : newConstraint === 'containedIn' ? [] : Filters.DefaultComparisons[compareType],
+    compareTo,
     modifiers: newConstraint === 'matches' ? 'i' : undefined,
   });
   return filters.set(index, newFilter);

--- a/src/components/Filter/Filter.react.js
+++ b/src/components/Filter/Filter.react.js
@@ -63,6 +63,7 @@ function changeConstraint(schema, currentClassName, filters, index, newConstrain
     constraint: newConstraint,
     compareTo:
       compareType && prevCompareTo ? prevCompareTo : newConstraint === 'containedIn' ? [] : Filters.DefaultComparisons[compareType],
+    modifiers: newConstraint === 'matches' ? 'i' : undefined,
   });
   return filters.set(index, newFilter);
 }
@@ -70,6 +71,10 @@ function changeConstraint(schema, currentClassName, filters, index, newConstrain
 function changeCompareTo(schema, filters, index, type, newCompare) {
   const newValue = newCompare;
   return filters.set(index, filters.get(index).set('compareTo', newValue));
+}
+
+function changeModifiers(filters, index, newModifiers) {
+  return filters.set(index, filters.get(index).set('modifiers', newModifiers));
 }
 
 function deleteRow(filters, index) {
@@ -124,6 +129,7 @@ const Filter = ({
         const field = filter.get('field');
         const constraint = filter.get('constraint');
         const compareTo = filter.get('compareTo');
+        const modifiers = filter.get('modifiers');
         let fields = [];
         if (available[currentClassName]) {
           fields = Object.keys(available[currentClassName]).concat([]);
@@ -182,6 +188,7 @@ const Filter = ({
           currentField: field,
           currentConstraint: constraint,
           compareTo,
+          modifiers,
           key: field + '-' + constraint + '-' + i,
           onChangeClass: newClassName => {
             onChange(changeClass(schema, filters, i, newClassName));
@@ -196,6 +203,9 @@ const Filter = ({
           },
           onChangeCompareTo: newCompare => {
             onChange(changeCompareTo(schema, filters, i, compareType, newCompare));
+          },
+          onChangeModifiers: newModifiers => {
+            onChange(changeModifiers(filters, i, newModifiers));
           },
           onKeyDown: ({ key }) => {
             if (key === 'Enter') {

--- a/src/components/Filter/Filter.react.js
+++ b/src/components/Filter/Filter.react.js
@@ -97,6 +97,7 @@ const Filter = ({
   if (compare !== hasCompareTo) {
     setCompare(hasCompareTo);
   }
+
   const currentApp = React.useContext(CurrentApp);
   blacklist = blacklist || [];
   const available = Filters.findRelatedClasses(className, allClasses, blacklist, filters);
@@ -119,7 +120,7 @@ const Filter = ({
       >
         <div style={{ width: '140px' }}>Class</div>
         <div style={{ width: '140px' }}>Field</div>
-        <div style={{ width: '175px' }}>Condition</div>
+        <div style={compare ? { width: '175px' } : { flex: 1 }}>Condition</div>
         {compare && <div>Value</div>}
         <div></div>
       </div>

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -1114,40 +1114,60 @@ class Browser extends DashboardView {
 
   async fetchData(source, filters = new List()) {
     this.loadingFilters = JSON.stringify(filters.toJSON());
-    const data = await this.fetchParseData(source, filters);
-    if (this.loadingFilters !== JSON.stringify(filters.toJSON())) {
-      return;
-    }
-
-    const filteredCounts = { ...this.state.filteredCounts };
-    if (filters.size > 0) {
-      if (this.state.isUnique) {
-        filteredCounts[source] = data.length;
-      } else {
-        filteredCounts[source] = await this.fetchParseDataCount(source, filters);
+    try {
+      const data = await this.fetchParseData(source, filters);
+      if (this.loadingFilters !== JSON.stringify(filters.toJSON())) {
+        return;
       }
-    } else {
-      delete filteredCounts[source];
+
+      const filteredCounts = { ...this.state.filteredCounts };
+      if (filters.size > 0) {
+        if (this.state.isUnique) {
+          filteredCounts[source] = data.length;
+        } else {
+          filteredCounts[source] = await this.fetchParseDataCount(source, filters);
+        }
+      } else {
+        delete filteredCounts[source];
+      }
+      this.setState({
+        data: data,
+        filters,
+        lastMax: this.state.limit,
+        filteredCounts: filteredCounts,
+      });
+    } catch (error) {
+      const msg = typeof error === 'string' ? error : error.message;
+      this.setState({
+        data: [],
+        filters,
+        lastMax: this.state.limit,
+      });
+      this.showNote(msg, true);
     }
-    this.setState({
-      data: data,
-      filters,
-      lastMax: this.state.limit,
-      filteredCounts: filteredCounts,
-    });
   }
 
   async fetchRelation(relation, filters = new List()) {
-    const data = await this.fetchParseData(relation, filters);
-    const relationCount = await this.fetchRelationCount(relation);
-    this.setState({
-      relation,
-      relationCount,
-      selection: {},
-      data,
-      filters,
-      lastMax: this.state.limit,
-    });
+    try {
+      const data = await this.fetchParseData(relation, filters);
+      const relationCount = await this.fetchRelationCount(relation);
+      this.setState({
+        relation,
+        relationCount,
+        selection: {},
+        data,
+        filters,
+        lastMax: this.state.limit,
+      });
+    } catch (error) {
+      const msg = typeof error === 'string' ? error : error.message;
+      this.setState({
+        data: [],
+        filters,
+        lastMax: this.state.limit,
+      });
+      this.showNote(msg, true);
+    }
   }
 
   async fetchRelationCount(relation) {
@@ -1209,6 +1229,9 @@ class Browser extends DashboardView {
           data: state.data.concat(nextPage),
         }));
       }
+    }).catch(error => {
+      const msg = typeof error === 'string' ? error : error.message;
+      this.showNote(msg, true);
     });
     this.setState({ lastMax: this.state.lastMax + this.state.limit });
   }

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -537,15 +537,24 @@ class Browser extends DashboardView {
           // Convert date strings to Parse Date objects for proper Parse query functionality
           const processedFilter = { ...filter, class: filter.class || props.params.className };
 
-          // Check if compareTo is a date string and convert it to a Parse Date object
-          if (processedFilter.compareTo &&
-              typeof processedFilter.compareTo === 'string' &&
-              !isNaN(Date.parse(processedFilter.compareTo))) {
-            // Convert string date to Parse Date format for proper query functionality
-            processedFilter.compareTo = {
-              __type: 'Date',
-              iso: new Date(processedFilter.compareTo).toISOString()
-            };
+          // Check the schema to see if this field is a Date type
+          const classes = props.schema?.data?.get('classes');
+          const className = processedFilter.class || props.params.className;
+          const fieldName = processedFilter.field;
+
+          if (classes && className && fieldName) {
+            const classSchema = classes.get(className);
+            const fieldType = classSchema?.get(fieldName)?.type;
+
+            // If field type is Date and compareTo is not already a Date object, convert it
+            if (fieldType === 'Date' &&
+                processedFilter.compareTo &&
+                typeof processedFilter.compareTo !== 'object') {
+              processedFilter.compareTo = {
+                __type: 'Date',
+                iso: new Date(processedFilter.compareTo).toISOString()
+              };
+            }
           }
 
           filters = filters.push(Map(processedFilter));

--- a/src/dashboard/Data/Browser/ObjectPickerDialog.react.js
+++ b/src/dashboard/Data/Browser/ObjectPickerDialog.react.js
@@ -73,25 +73,40 @@ export default class ObjectPickerDialog extends React.Component {
   }
 
   async selectRelationRows(relation, filters) {
-    const relationData = await this.fetchParseData(relation, filters);
-    this.setState({ initialRelationData: relationData });
-    relationData.forEach(({ id }) => this.selectRow(id, true));
+    try {
+      const relationData = await this.fetchParseData(relation, filters);
+      this.setState({ initialRelationData: relationData });
+      relationData.forEach(({ id }) => this.selectRow(id, true));
+    } catch (error) {
+      const msg = typeof error === 'string' ? error : error.message;
+      this.props.showNote(msg, true);
+    }
   }
 
   async fetchData(source, filters = new List()) {
-    const data = await this.fetchParseData(source, filters);
-    const filteredCounts = { ...this.state.filteredCounts };
-    if (filters.size > 0) {
-      filteredCounts[source] = await this.fetchParseDataCount(source, filters);
-    } else {
-      delete filteredCounts[source];
+    try {
+      const data = await this.fetchParseData(source, filters);
+      const filteredCounts = { ...this.state.filteredCounts };
+      if (filters.size > 0) {
+        filteredCounts[source] = await this.fetchParseDataCount(source, filters);
+      } else {
+        delete filteredCounts[source];
+      }
+      this.setState({
+        data: data,
+        filters,
+        lastMax: this.props.limit,
+        filteredCounts: filteredCounts,
+      });
+    } catch (error) {
+      const msg = typeof error === 'string' ? error : error.message;
+      this.setState({
+        data: [],
+        filters,
+        lastMax: this.props.limit,
+      });
+      this.props.showNote(msg, true);
     }
-    this.setState({
-      data: data,
-      filters,
-      lastMax: this.props.limit,
-      filteredCounts: filteredCounts,
-    });
   }
 
   async fetchParseData(source, filters) {
@@ -175,6 +190,9 @@ export default class ObjectPickerDialog extends React.Component {
           data: state.data.concat(nextPage),
         }));
       }
+    }).catch(error => {
+      const msg = typeof error === 'string' ? error : error.message;
+      this.props.showNote(msg, true);
     });
     this.setState({ lastMax: this.state.lastMax + this.props.limit });
   }

--- a/src/lib/Filters.js
+++ b/src/lib/Filters.js
@@ -59,7 +59,7 @@ export const Constraints = {
     comparable: true,
   },
   stringContainsString: {
-    name: 'string contains string',
+    name: 'contains string',
     field: 'String',
     composable: true,
     comparable: true,

--- a/src/lib/Filters.js
+++ b/src/lib/Filters.js
@@ -64,6 +64,12 @@ export const Constraints = {
     composable: true,
     comparable: true,
   },
+  matches: {
+    name: 'matches regex',
+    field: 'String',
+    composable: true,
+    comparable: true,
+  },
   before: {
     name: 'is before',
     field: 'Date',
@@ -185,7 +191,7 @@ export const FieldConstraints = {
   Pointer: ['exists', 'dne', 'eq', 'neq', 'starts', 'containedIn', 'unique'],
   Boolean: ['exists', 'dne', 'eq', 'neq', 'containedIn', 'unique'],
   Number: ['exists', 'dne', 'eq', 'neq', 'lt', 'lte', 'gt', 'gte', 'containedIn', 'unique'],
-  String: ['exists', 'dne', 'eq', 'neq', 'starts', 'ends', 'stringContainsString', 'containedIn', 'unique'],
+  String: ['exists', 'dne', 'eq', 'neq', 'starts', 'ends', 'stringContainsString', 'matches', 'containedIn', 'unique'],
   Date: [
     'exists',
     'dne',

--- a/src/lib/Filters.js
+++ b/src/lib/Filters.js
@@ -58,12 +58,6 @@ export const Constraints = {
     name: 'ends with',
     comparable: true,
   },
-  stringContainsString: {
-    name: 'contains string',
-    field: 'String',
-    composable: true,
-    comparable: true,
-  },
   matches: {
     name: 'matches regex',
     field: 'String',
@@ -191,7 +185,7 @@ export const FieldConstraints = {
   Pointer: ['exists', 'dne', 'eq', 'neq', 'starts', 'containedIn', 'unique'],
   Boolean: ['exists', 'dne', 'eq', 'neq', 'containedIn', 'unique'],
   Number: ['exists', 'dne', 'eq', 'neq', 'lt', 'lte', 'gt', 'gte', 'containedIn', 'unique'],
-  String: ['exists', 'dne', 'eq', 'neq', 'starts', 'ends', 'stringContainsString', 'matches', 'containedIn', 'unique'],
+  String: ['exists', 'dne', 'eq', 'neq', 'starts', 'ends', 'matches', 'containedIn', 'unique'],
   Date: [
     'exists',
     'dne',

--- a/src/lib/queryFromFilters.js
+++ b/src/lib/queryFromFilters.js
@@ -172,7 +172,7 @@ function addConstraint(query, filter) {
       query.matches(filter.get('field'), filter.get('compareTo'), 'i');
       break;
     case 'matches':
-      query.matches(filter.get('field'), filter.get('compareTo'));
+      query.matches(filter.get('field'), filter.get('compareTo'), filter.get('modifiers'));
       break;
     case 'keyExists':
       query.exists(filter.get('field') + '.' + filter.get('compareTo'));

--- a/src/lib/queryFromFilters.js
+++ b/src/lib/queryFromFilters.js
@@ -168,11 +168,8 @@ function addConstraint(query, filter) {
     case 'containedIn':
       query.containedIn(filter.get('field'), filter.get('compareTo'));
       break;
-    case 'stringContainsString':
-      query.matches(filter.get('field'), filter.get('compareTo'), 'i');
-      break;
     case 'matches':
-      query.matches(filter.get('field'), filter.get('compareTo'), filter.get('modifiers'));
+      query.matches(filter.get('field'), String(filter.get('compareTo')), filter.get('modifiers'));
       break;
     case 'keyExists':
       query.exists(filter.get('field') + '.' + filter.get('compareTo'));

--- a/src/lib/queryFromFilters.js
+++ b/src/lib/queryFromFilters.js
@@ -171,6 +171,9 @@ function addConstraint(query, filter) {
     case 'stringContainsString':
       query.matches(filter.get('field'), filter.get('compareTo'), 'i');
       break;
+    case 'matches':
+      query.matches(filter.get('field'), filter.get('compareTo'));
+      break;
     case 'keyExists':
       query.exists(filter.get('field') + '.' + filter.get('compareTo'));
       break;


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description

The existing "string contains string" filter is really a regex filter with fixed regex modifier `i` (case insensitive). The filter name is difficult to understand and the fixed modifier prohibits the versatility of regex patterns.

### Approach

- Removed the existing "string contains string" filter.
- Added the "matches regex" filter with a options dialog to set modifiers.
- Fixed an issue where an entered number value would be incorrectly interpreted as a date value.

Note that the `u` (unicode) modifier is only supported from Parse Server [8.3.0-alpha.2](https://github.com/parse-community/parse-server/releases/tag/8.3.0-alpha.2).