### PR TITLE
fix: Filter text field in data browser partly looses focus when hitting enter key to apply filter

### DIFF
--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -425,6 +425,17 @@ export default class DataBrowser extends React.Component {
     if (this.props.disableKeyControls) {
       return;
     }
+
+    // Check if the event target is an input or textarea
+    const target = e.target;
+    const isInputElement = target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA');
+
+    // Ignore all keyboard events when focus is on input/textarea elements
+    // This allows normal text editing behavior in filter inputs
+    if (isInputElement) {
+      return;
+    }
+
     if (e.keyCode === 67 && (e.ctrlKey || e.metaKey)) {
       // Check for text selection FIRST
       const selection = window.getSelection();


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description

Filter text field in data browser partly looses focus when hitting enter key to apply filter. The curser stays in the text field, but some keystrokes are applied to the selected data browser cell instead of the text field text.

### Approach

Keep focus in text field and apply all key inputs to text field.

