### PR TITLE
fix: Filter text field in data browser partly looses focus when selecting in drop-down element by hitting enter key to apply filter

### DIFF
--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -426,12 +426,12 @@ export default class DataBrowser extends React.Component {
       return;
     }
 
-    // Check if the event target is an input or textarea
+    // Check if the event target is an input, textarea, or select element
     const target = e.target;
-    const isInputElement = target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA');
+    const isInputElement = target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.tagName === 'SELECT');
 
-    // Ignore all keyboard events when focus is on input/textarea elements
-    // This allows normal text editing behavior in filter inputs
+    // Ignore all keyboard events when focus is on input/textarea/select elements
+    // This allows normal text editing behavior in filter inputs and dropdown navigation
     if (isInputElement) {
       return;
     }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description

Same as https://github.com/parse-community/parse-dashboard/pull/2992, but it's missing `<SELECT>` HTML elements.

### Approach

Add `<SELECT>` HTML elements.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents unintended keyboard shortcuts when focusing or navigating dropdowns.
  * Ensures keyboard interactions in SELECT fields are treated like inputs/textareas, avoiding conflicts.
  * Improves consistency of keyboard navigation across form controls in the Data Browser.
  * Enhances overall UX by reducing accidental actions during dropdown selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->