### PR TITLE
fix: Missing alert when changing data browser table data while rows are selected

### DIFF
--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -2528,6 +2528,8 @@ class Browser extends DashboardView {
                 this.setState({ limit });
                 this.updateOrdering(this.state.ordering);
               }}
+              hasSelectedRows={Object.keys(this.state.selection).length > 0}
+              selectedRowsMessage={SELECTED_ROWS_MESSAGE}
             />
           </>
         );

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -1246,6 +1246,13 @@ class Browser extends DashboardView {
   }
 
   updateFilters(filters) {
+    // Check if there are selected rows
+    if (Object.keys(this.state.selection).length > 0) {
+      if (!window.confirm(SELECTED_ROWS_MESSAGE)) {
+        return;
+      }
+    }
+
     const relation = this.state.relation;
     if (relation) {
       this.setRelation(relation, filters);

--- a/src/dashboard/Data/Browser/BrowserFooter.react.js
+++ b/src/dashboard/Data/Browser/BrowserFooter.react.js
@@ -19,6 +19,10 @@ class BrowserFooter extends React.Component {
   }
 
   handleLimitChange = event => {
+    // Check if there are selected rows
+    if (this.props.hasSelectedRows && !window.confirm(this.props.selectedRowsMessage)) {
+      return;
+    }
     const newLimit = parseInt(event.target.value, 10);
     this.props.setLimit(newLimit);
     this.props.setSkip(0);
@@ -27,6 +31,10 @@ class BrowserFooter extends React.Component {
 
   handlePageChange = newSkip => {
     if (newSkip >= 0 && newSkip < this.props.count) {
+      // Check if there are selected rows
+      if (this.props.hasSelectedRows && !window.confirm(this.props.selectedRowsMessage)) {
+        return;
+      }
       this.props.setSkip(newSkip);
       this.setState({ pageInput: (Math.floor(newSkip / this.props.limit) + 1).toString() });
     }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description

When rows are selected while trying to changing the data browser table data, the alert is not displayed in the following cases:
- Applying / modifying filter
- Clicking the page arrows in the navigation bar
- Entering a page number in the navigation bar
- Selecting an item in the "obj per page" drop-down

### Approach
<!-- Add a description of the approach in this PR. -->

Show alert in above cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a confirmation prompt when changing filters, page, or page size while rows are selected to prevent accidental loss of selections.
  * If the prompt is canceled, the current view and selections remain unchanged.
  * The footer now reflects when rows are selected and respects the selection state during pagination and limit changes, improving clarity and control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->