### PR TITLE
fix: View table data may be retained when switching between views

### DIFF
--- a/src/dashboard/Data/Views/Views.react.js
+++ b/src/dashboard/Data/Views/Views.react.js
@@ -81,6 +81,8 @@ class Views extends TableView {
     }
     if (this.props.params.name !== nextProps.params.name || this.context !== nextContext) {
       window.scrollTo({ top: 0 });
+      // Clear table state immediately when switching views to prevent data retention
+      this.setState({ data: [], order: [], columns: {}, tableWidth: 0 });
       this.loadData(nextProps.params.name);
     }
   }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description

View table data may be retained when switching between views. This means, when switching to a different view, the table data may contain entries from the previous view table data.

### Approach

Clear table data on switch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminates stale table content when switching views by immediately clearing previous data before loading new results.
  * Preserves and enforces scroll-to-top behavior on every view change for consistent navigation.
  * Reduces visual flicker and confusion by showing an empty state promptly while new data loads.
  * Improves perceived responsiveness and reliability when navigating between views.
  * Enhances overall stability of the dashboard’s table rendering during rapid view changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->