### PR TITLE
fix: Dashboard config objects stored on server with public read / write access

### DIFF
--- a/src/lib/ServerConfigStorage.js
+++ b/src/lib/ServerConfigStorage.js
@@ -59,6 +59,9 @@ export default class ServerConfigStorage {
     this._clearAllValueFields(configObject);
     configObject.set(valueType, value);
 
+    // Set empty ACL so object is only accessible with master key
+    configObject.setACL(new Parse.ACL());
+
     // Use master key for operations
     return configObject.save(null, { useMasterKey: true });
   }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description

The dashboard config objects are stored on server with public read / write access.

### Approach

Store with read / write by master key only.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Tightened access controls on server configuration data to prevent unintended exposure. Configuration entries now default to restricted access, reducing risk from misconfiguration or unauthorized reads. No changes to how configuration is retrieved or deleted, and no user-facing behavior changes are expected. This hardening improves overall security and integrity of server settings while maintaining existing functionality and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->