### PR TITLE
fix: ESC key does not cancel editing in data browser cell

### DIFF
--- a/src/components/DateTimeEditor/DateTimeEditor.react.js
+++ b/src/components/DateTimeEditor/DateTimeEditor.react.js
@@ -33,12 +33,14 @@ export default class DateTimeEditor extends React.Component {
 
   componentDidMount() {
     document.body.addEventListener('click', this.checkExternalClick);
-    this.inputRef.current.addEventListener('keypress', this.handleKey);
+    document.body.addEventListener('touchend', this.checkExternalClick);
+    this.inputRef.current.addEventListener('keydown', this.handleKey);
   }
 
   componentWillUnmount() {
     document.body.removeEventListener('click', this.checkExternalClick);
-    this.inputRef.current.removeEventListener('keypress', this.handleKey);
+    document.body.removeEventListener('touchend', this.checkExternalClick);
+    this.inputRef.current.removeEventListener('keydown', this.handleKey);
   }
 
   checkExternalClick(e) {
@@ -51,6 +53,16 @@ export default class DateTimeEditor extends React.Component {
     if (e.keyCode === 13) {
       this.commitDate();
       this.props.onCommit(this.state.value);
+      e.preventDefault();
+    } else if (e.keyCode === 27) {
+      // ESC key - cancel editing
+      if (this.props.onCancel) {
+        this.props.onCancel();
+      } else {
+        this.props.onCommit(this.props.value);
+      }
+      e.preventDefault();
+      e.stopPropagation();
     }
   }
 

--- a/src/components/GeoPointEditor/GeoPointEditor.react.js
+++ b/src/components/GeoPointEditor/GeoPointEditor.react.js
@@ -32,8 +32,8 @@ export default class GeoPointEditor extends React.Component {
       this.latitudeRef.current.focus();
     }
     this.latitudeRef.current.setSelectionRange(0, String(this.state.latitude).length);
-    this.latitudeRef.current.addEventListener('keypress', this.handleKeyLatitude);
-    this.longitudeRef.current.addEventListener('keypress', this.handleKeyLongitude);
+    this.latitudeRef.current.addEventListener('keydown', this.handleKeyLatitude);
+    this.longitudeRef.current.addEventListener('keydown', this.handleKeyLongitude);
   }
 
   componentWillReceiveProps(props) {
@@ -48,8 +48,8 @@ export default class GeoPointEditor extends React.Component {
   }
 
   componentWillUnmount() {
-    this.latitudeRef.current.removeEventListener('keypress', this.handleKeyLatitude);
-    this.longitudeRef.current.removeEventListener('keypress', this.handleKeyLongitude);
+    this.latitudeRef.current.removeEventListener('keydown', this.handleKeyLatitude);
+    this.longitudeRef.current.removeEventListener('keydown', this.handleKeyLongitude);
   }
 
   checkExternalClick() {
@@ -73,12 +73,32 @@ export default class GeoPointEditor extends React.Component {
     if (e.keyCode === 13 || e.keyCode === 44) {
       this.longitudeRef.current.focus();
       this.longitudeRef.current.setSelectionRange(0, String(this.state.longitude).length);
+      e.preventDefault();
+    } else if (e.keyCode === 27) {
+      // ESC key - cancel editing
+      if (this.props.onCancel) {
+        this.props.onCancel();
+      } else {
+        this.props.onCommit(this.props.value);
+      }
+      e.preventDefault();
+      e.stopPropagation();
     }
   }
 
   handleKeyLongitude(e) {
     if (e.keyCode === 13) {
       this.commitValue();
+      e.preventDefault();
+    } else if (e.keyCode === 27) {
+      // ESC key - cancel editing
+      if (this.props.onCancel) {
+        this.props.onCancel();
+      } else {
+        this.props.onCommit(this.props.value);
+      }
+      e.preventDefault();
+      e.stopPropagation();
     }
   }
 

--- a/src/components/NumberEditor/NumberEditor.react.js
+++ b/src/components/NumberEditor/NumberEditor.react.js
@@ -25,12 +25,14 @@ export default class NumberEditor extends React.Component {
   componentDidMount() {
     this.inputRef.current.setSelectionRange(0, String(this.state.value).length);
     document.body.addEventListener('click', this.checkExternalClick);
-    document.body.addEventListener('keypress', this.handleKey);
+    document.body.addEventListener('touchend', this.checkExternalClick);
+    document.body.addEventListener('keydown', this.handleKey);
   }
 
   componentWillUnmount() {
     document.body.removeEventListener('click', this.checkExternalClick);
-    document.body.removeEventListener('keypress', this.handleKey);
+    document.body.removeEventListener('touchend', this.checkExternalClick);
+    document.body.removeEventListener('keydown', this.handleKey);
   }
 
   checkExternalClick(e) {
@@ -42,6 +44,17 @@ export default class NumberEditor extends React.Component {
   handleKey(e) {
     if (e.keyCode === 13) {
       this.commitValue();
+      e.preventDefault();
+    } else if (e.keyCode === 27) {
+      // ESC key - cancel editing
+      if (this.props.onCancel) {
+        this.props.onCancel();
+      } else {
+        // If no onCancel callback, commit the original value
+        this.props.onCommit(this.props.value);
+      }
+      e.preventDefault();
+      e.stopPropagation();
     }
   }
 

--- a/src/components/StringEditor/StringEditor.react.js
+++ b/src/components/StringEditor/StringEditor.react.js
@@ -24,12 +24,14 @@ export default class StringEditor extends React.Component {
   componentDidMount() {
     this.inputRef.current.setSelectionRange(0, this.state.value.length);
     document.body.addEventListener('click', this.checkExternalClick);
-    document.body.addEventListener('keypress', this.handleKey);
+    document.body.addEventListener('touchend', this.checkExternalClick);
+    document.body.addEventListener('keydown', this.handleKey);
   }
 
   componentWillUnmount() {
     document.body.removeEventListener('click', this.checkExternalClick);
-    document.body.removeEventListener('keypress', this.handleKey);
+    document.body.removeEventListener('touchend', this.checkExternalClick);
+    document.body.removeEventListener('keydown', this.handleKey);
   }
 
   checkExternalClick(e) {
@@ -44,7 +46,18 @@ export default class StringEditor extends React.Component {
       // Otherwise, we submit
       if (!this.props.multiline || !e.shiftKey) {
         this.props.onCommit(this.state.value);
+        e.preventDefault();
       }
+    } else if (e.keyCode === 27) {
+      // ESC key - cancel editing
+      if (this.props.onCancel) {
+        this.props.onCancel();
+      } else {
+        // If no onCancel callback, just commit the original value
+        this.props.onCommit(this.props.value);
+      }
+      e.preventDefault();
+      e.stopPropagation();
     }
   }
 

--- a/src/dashboard/Data/Browser/Editor.react.js
+++ b/src/dashboard/Data/Browser/Editor.react.js
@@ -26,6 +26,7 @@ const Editor = ({ top, left, type, targetClass, value, readonly, width, onCommit
         multiline={!readonly}
         width={width}
         onCommit={onCommit}
+        onCancel={onCancel}
         resizable={true}
       />
     );
@@ -45,6 +46,7 @@ const Editor = ({ top, left, type, targetClass, value, readonly, width, onCommit
         multiline={true}
         width={width}
         onCommit={encodeCommit}
+        onCancel={onCancel}
       />
     );
   } else if (type === 'Polygon') {
@@ -83,6 +85,7 @@ const Editor = ({ top, left, type, targetClass, value, readonly, width, onCommit
         multiline={true}
         width={width}
         onCommit={encodeCommit}
+        onCancel={onCancel}
       />
     );
   } else if (type === 'Date') {
@@ -93,17 +96,18 @@ const Editor = ({ top, left, type, targetClass, value, readonly, width, onCommit
           readonly={true}
           width={width}
           onCommit={() => onCommit(value)}
+          onCancel={onCancel}
         />
       );
     } else {
-      content = <DateTimeEditor value={value || new Date()} width={width} onCommit={onCommit} />;
+      content = <DateTimeEditor value={value || new Date()} width={width} onCommit={onCommit} onCancel={onCancel} />;
     }
   } else if (type === 'Boolean') {
     content = <BooleanEditor value={value} width={width} onCommit={onCommit} />;
   } else if (type === 'Number') {
-    content = <NumberEditor value={value} width={width} onCommit={onCommit} />;
+    content = <NumberEditor value={value} width={width} onCommit={onCommit} onCancel={onCancel} />;
   } else if (type === 'GeoPoint') {
-    content = <GeoPointEditor value={value} width={width} onCommit={onCommit} />;
+    content = <GeoPointEditor value={value} width={width} onCommit={onCommit} onCancel={onCancel} />;
   } else if (type === 'File') {
     content = <FileEditor value={value} width={width} onCommit={onCommit} onCancel={onCancel} />;
   } else if (type === 'ACL') {
@@ -121,7 +125,7 @@ const Editor = ({ top, left, type, targetClass, value, readonly, width, onCommit
         );
       }
     };
-    content = <StringEditor value={value ? value.id : ''} width={width} onCommit={encodeCommit} />;
+    content = <StringEditor value={value ? value.id : ''} width={width} onCommit={encodeCommit} onCancel={onCancel} />;
   }
 
   return <div style={{ position: 'absolute', top: top, left: left }}>{content}</div>;


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description

When hitting the Esc key while editing a cell in the DataBrowser table, the editing does not abort.

### Approach

According to [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/Element/keypress_event), the keypress event is deprecated:

> Deprecated: This feature is no longer recommended. The keydown and beforeinput events should be used instead.

So this change also modernizes the code to follow current web standards.

The root cause chain was:

- StringEditor listened to keypress events
- User presses Escape key
- Browser doesn't fire keypress event for Escape
- handleKey never gets called
- Escape key handling code never executes
- Editing doesn't abort

By changing to keydown:

- StringEditor now listens to keydown events
- User presses Escape key
- Browser fires keydown event for Escape ✅
- handleKey gets called ✅
- Escape key handling code executes ✅
- Editing aborts as expected ✅



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Press Esc to cancel edits in text, number, date/time, and geo point fields without saving.

* **Improvements**
  * More consistent keyboard behavior using key-down; Enter-to-commit is smoother and predictable.
  * Better mobile usability: external taps are recognized for cancel/commit.
  * Cancel action is now supported across all editors, including complex field types.

* **Bug Fixes**
  * Prevents unintended browser actions when pressing Enter or Esc.
  * More reliable focus behavior between latitude and longitude inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->