### PR TITLE
fix: Currently displayed view reloads when editing and saving a different view

### DIFF
--- a/src/dashboard/Data/Views/Views.react.js
+++ b/src/dashboard/Data/Views/Views.react.js
@@ -87,7 +87,7 @@ class Views extends TableView {
     }
   }
 
-  async loadViews(app) {
+  async loadViews(app, skipDataReload = false) {
     // Initialize ViewPreferencesManager if not already done or if app changed
     if (!this.viewPreferencesManager || this.viewPreferencesManager.app !== app) {
       this.viewPreferencesManager = new ViewPreferencesManager(app);
@@ -132,7 +132,7 @@ class Views extends TableView {
             }
           }
         });
-        if (this._isMounted) {
+        if (this._isMounted && !skipDataReload) {
           this.loadData(this.props.params.name);
         }
       });
@@ -141,7 +141,7 @@ class Views extends TableView {
       // Fallback to local storage
       const views = ViewPreferences.getViews(app.applicationId);
       this.setState({ views, counts: {} }, () => {
-        if (this._isMounted) {
+        if (this._isMounted && !skipDataReload) {
           this.loadData(this.props.params.name);
         }
       });
@@ -757,6 +757,7 @@ class Views extends TableView {
           view={this.state.editView}
           onCancel={() => this.setState({ editView: null, editIndex: null })}
           onConfirm={view => {
+            const isEditingCurrentView = view.name === this.props.params.name;
             this.setState(
               state => {
                 const newViews = [...state.views];
@@ -772,7 +773,10 @@ class Views extends TableView {
                     this.showNote('Failed to save view changes', true);
                   }
                 }
-                this.loadViews(this.context);
+                // Only reload data if we're editing the currently displayed view
+                // Otherwise just reload the view list without reloading data
+                const skipDataReload = !isEditingCurrentView;
+                this.loadViews(this.context, skipDataReload);
               }
             );
           }}

--- a/src/dashboard/Data/Views/Views.react.js
+++ b/src/dashboard/Data/Views/Views.react.js
@@ -757,7 +757,9 @@ class Views extends TableView {
           view={this.state.editView}
           onCancel={() => this.setState({ editView: null, editIndex: null })}
           onConfirm={view => {
-            const isEditingCurrentView = view.name === this.props.params.name;
+            // Use the original view name (before editing) to check if it's the currently displayed view
+            const originalViewName = this.state.editView?.name;
+            const isEditingCurrentView = originalViewName === this.props.params.name;
             this.setState(
               state => {
                 const newViews = [...state.views];


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

When editing a View that is different from the currently displaying view and then saving, the currently displaying view's table data was being reloaded unnecessarily.

### Approach

The `onConfirm` callback in the `EditViewDialog` was always calling `loadViews()` without any condition, which internally called `loadData(this.props.params.name)` to reload the currently displayed view's data. Added a `skipDataReload` parameter to the `loadViews()` method. Modified the edit view confirm handler to check if the edited view is the currently displayed view. Only reload data when editing the currently displayed view; otherwise, skip the data reload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Editing a non-active view no longer triggers an unnecessary data reload, preventing UI flicker and preserving your current context.
  * Data reloads now respect edit context and local-cache fallbacks, reducing unexpected refreshes during save or error recovery.
  * Initial view loading avoids redundant reloads, improving stability when navigating and editing views.

* **Refactor**
  * Improved view-loading control to selectively skip data reloads, resulting in smoother interactions when managing views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->