### PR TITLE
feat: Add Parse Server version compatibility detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,12 @@ After starting the dashboard, you can visit http://localhost:4040 in your browse
 ## Compatibility
 
 ### Parse Server
-Parse Dashboard is compatible with the following Parse Server versions.
+Parse Dashboard is compatible with the following versions of Parse Server.
 
-| Parse Dashboard Version | Parse Server Version | Compatible |
-|-------------------------|----------------------|------------|
-| >=1.0                   | >= 2.1.4             | ✅ Yes      |
+| Parse Dashboard | Parse Server     |
+|-----------------|------------------|
+| >= 1.0.0        | >= 2.1.4 < 7.0.0 |
+| >= 8.0.0        | >= 7.0.0         |
 
 ### Node.js
 Parse Dashboard is continuously tested with the most recent releases of Node.js to ensure compatibility. We follow the [Node.js Long Term Support plan](https://github.com/nodejs/Release) and only test against versions that are officially supported and have not reached their end-of-life date.

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ Parse Dashboard is compatible with the following versions of Parse Server.
 | >= 1.0.0        | >= 2.1.4 < 7.0.0 |
 | >= 8.0.0        | >= 7.0.0         |
 
+Parse Dashboard automatically checks the Parse Server version when connecting and displays a warning if the server version does not meet the minimum required version. The required Parse Server version is defined in the `supportedParseServerVersion` field in `package.json`.
+
 ### Node.js
 Parse Dashboard is continuously tested with the most recent releases of Node.js to ensure compatibility. We follow the [Node.js Long Term Support plan](https://github.com/nodejs/Release) and only test against versions that are officially supported and have not reached their end-of-life date.
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "Push Status Page",
     "Relation Editor"
   ],
+  "supportedParseServerVersion": ">=7.0.0",
   "keywords": [
     "parse",
     "dashboard"

--- a/src/dashboard/Apps/AppsIndex.react.js
+++ b/src/dashboard/Apps/AppsIndex.react.js
@@ -82,25 +82,32 @@ const AppCard = ({ app, icon }) => {
 
   return (
     <li onClick={canBrowse} style={{ background: app.primaryBackgroundColor }}>
-      <a className={styles.icon}>
-        {icon ? (
-          <img src={'appicons/' + icon} width={56} height={56} />
-        ) : (
-          <Icon width={56} height={56} name="blank-app-outline" fill="#1E384D" />
-        )}
-      </a>
-      <div className={styles.details}>
-        <a className={styles.appname}>{app.name}</a>
-        {versionMessage}
+      <div className={styles.appCardContent}>
+        <a className={styles.icon}>
+          {icon ? (
+            <img src={'appicons/' + icon} width={56} height={56} />
+          ) : (
+            <Icon width={56} height={56} name="blank-app-outline" fill="#1E384D" />
+          )}
+        </a>
+        <div className={styles.details}>
+          <a className={styles.appname}>{app.name}</a>
+          {versionMessage}
+        </div>
+        <CountsSection className={styles.glance} title="At a glance">
+          <AppBadge production={app.production} />
+          <Metric number={dash(app.users, prettyNumber(app.users))} label="total users" />
+          <Metric
+            number={dash(app.installations, prettyNumber(app.installations))}
+            label="total installations"
+          />
+        </CountsSection>
       </div>
-      <CountsSection className={styles.glance} title="At a glance">
-        <AppBadge production={app.production} />
-        <Metric number={dash(app.users, prettyNumber(app.users))} label="total users" />
-        <Metric
-          number={dash(app.installations, prettyNumber(app.installations))}
-          label="total installations"
-        />
-      </CountsSection>
+      {!app.serverInfo.error && app.serverInfo.versionWarning && (
+        <div className={styles.versionWarning}>
+          ⚠️ {app.serverInfo.versionWarning}
+        </div>
+      )}
     </li>
   );
 };

--- a/src/dashboard/Apps/AppsIndex.scss
+++ b/src/dashboard/Apps/AppsIndex.scss
@@ -103,18 +103,22 @@
   margin: 0 auto;
 
   li {
-    display: flex;
     cursor: pointer;
     background: #193040;
     border-radius: 5px;
     margin: 14px 0;
-    padding: 0 9px;
-    height: 74px;
+    min-height: 74px;
 
     &:hover{
       background: #172C3B;
     }
   }
+}
+
+.appCardContent {
+  display: flex;
+  padding: 0 9px;
+  min-height: 74px;
 }
 
 .icon {
@@ -188,6 +192,17 @@
 
 .serverVersion {
   @include ellipsis();
+}
+
+.versionWarning {
+  background: rgba(255, 152, 0, 0.15);
+  border-top: 1px solid rgba(255, 152, 0, 0.3);
+  color: #ff9800;
+  font-size: 11px;
+  padding: 8px 12px;
+  line-height: 1.4;
+  word-wrap: break-word;
+  border-radius: 0 0 5px 5px;
 }
 
 .edit {

--- a/src/dashboard/Dashboard.js
+++ b/src/dashboard/Dashboard.js
@@ -55,6 +55,8 @@ import { Helmet } from 'react-helmet';
 import Playground from './Data/Playground/Playground.react';
 import DashboardSettings from './Settings/DashboardSettings/DashboardSettings.react';
 import Security from './Settings/Security/Security.react';
+import semver from 'semver';
+import packageInfo from '../../package.json';
 
 const ShowSchemaOverview = false; //In progress features. Change false to true to work on this feature.
 
@@ -138,6 +140,19 @@ export default class Dashboard extends React.Component {
               .then(
                 serverInfo => {
                   app.serverInfo = serverInfo;
+
+                  // Check Parse Server version compatibility
+                  const supportedVersion = packageInfo.supportedParseServerVersion;
+                  const serverVersion = serverInfo.parseServerVersion;
+
+                  if (serverVersion && serverVersion !== 'unknown' && supportedVersion) {
+                    const cleanedVersion = semver.valid(semver.coerce(serverVersion));
+                    if (cleanedVersion && !semver.satisfies(cleanedVersion, supportedVersion)) {
+                      app.serverInfo.versionWarning =
+                        `Parse Server ${serverVersion} is not officially supported by this version of Parse Dashboard. You may encounter issues or reduced functionality. Supported Parse Server versions are ${supportedVersion}. Either upgrade Parse Server, or downgrade Parse Dashboard to a compatible version.`;
+                    }
+                  }
+
                   return app;
                 },
                 error => {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Upgrade of Parse JS SDK in https://github.com/parse-community/parse-dashboard/pull/3003 increases required minimum version to Parse Server 7. The PR wasn't merged as breaking change, as planned in https://github.com/parse-community/parse-dashboard/pull/2749.

This adds a feature to specify the compatible Parse Server versions in package.json. If a server is unsupported, a warning message is shown:

<img width="767" height="143" alt="image" src="https://github.com/user-attachments/assets/a840b7cf-f3e3-4469-8df3-0e62672171dd" />


### Approach

Add server compat table.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Revised Parse Dashboard/Parse Server compatibility wording and restructured the compatibility table; added note about automatic server-version checks and minimum required version.
* **New Features**
  * Dashboard now detects Parse Server version on connect and shows an in-app compatibility warning when requirements aren’t met.
* **Style**
  * Updated app list layout and styling to surface metrics and version-warning notices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->