### PR TITLE
fix: Info panel briefly shows cached media content from previously selected cell when using pre-fetch

### DIFF
--- a/src/components/AggregationPanel/AggregationPanel.js
+++ b/src/components/AggregationPanel/AggregationPanel.js
@@ -113,11 +113,11 @@ const AggregationPanel = ({
             case 'table':
               return <TableElement key={idx} columns={item.columns} rows={item.rows} style={item.style} />;
             case 'image':
-              return <ImageElement key={idx} url={item.url} style={item.style} />;
+              return <ImageElement key={`${idx}-${item.url}`} url={item.url} style={item.style} />;
             case 'video':
-              return <VideoElement key={idx} url={item.url} style={item.style} />;
+              return <VideoElement key={`${idx}-${item.url}`} url={item.url} style={item.style} />;
             case 'audio':
-              return <AudioElement key={idx} url={item.url} style={item.style} />;
+              return <AudioElement key={`${idx}-${item.url}`} url={item.url} style={item.style} />;
             case 'button':
               return <ButtonElement key={idx} item={item} showNote={showNote} style={item.style} />;
             case 'panel':


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description

The issue is that the ImageElement, VideoElement, and AudioElement components are simple functional components that don't handle URL changes properly. When the URL prop changes (because a different row is selected), the browser may still cache and display the previous media content. 

### Approach

The solution is to add a key prop based on the URL to force React to unmount and remount the component when the URL changes.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved stability and rendering consistency for collections of images, videos, and audio items in the aggregation panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->