### PR TITLE
fix: Switching between browser tabs can cause illegible text color for config parameter value field

### DIFF
--- a/src/components/TextInput/TextInput.scss
+++ b/src/components/TextInput/TextInput.scss
@@ -12,6 +12,7 @@
   border: 0;
   outline: 0;
   background: $inputBackgroundColor;
+  color: #000;
   font-size: 16px;
   width: 100%;
   min-width: calc(var(--modal-min-width) * (1 - var(--modal-label-ratio)));
@@ -19,6 +20,10 @@
   padding: 6px;
   vertical-align: top;
   resize: both;
+
+  &:disabled {
+    color: $mainTextColor;
+  }
 
   &:focus {
     @include placeholder {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description

The TextInput component doesn't have an explicit color property defined, which means it relies on CSS inheritance. When navigating between tabs, sometimes the browser's paint/style recalculation can cause issues with CSS inheritance, especially if there's any dynamic styling or state changes. 

### Approach

Added an explicit color property to `.text_input` class to ensure the text input color is always defined.
