### PR TITLE
fix: Session management issue that causes malformed redirect URLs

### DIFF
--- a/Parse-Dashboard/Authentication.js
+++ b/Parse-Dashboard/Authentication.js
@@ -77,6 +77,7 @@ function initialize(app, options) {
     (req,res,next) => {
       let redirect = 'apps';
       if (req.body.redirect) {
+        // Strip leading slash from redirect to prevent double slashes
         redirect = req.body.redirect.charAt(0) === '/' ? req.body.redirect.substring(1) : req.body.redirect
       }
       return passport.authenticate('local', {

--- a/Parse-Dashboard/Authentication.js
+++ b/Parse-Dashboard/Authentication.js
@@ -76,13 +76,22 @@ function initialize(app, options) {
     csrf(),
     (req,res,next) => {
       let redirect = 'apps';
+      let originalRedirect = null;
       if (req.body.redirect) {
-        // Strip leading slash from redirect to prevent double slashes
-        redirect = req.body.redirect.charAt(0) === '/' ? req.body.redirect.substring(1) : req.body.redirect
+        originalRedirect = req.body.redirect;
+        // Validate redirect to prevent open redirect vulnerability
+        if (originalRedirect.includes('://') || originalRedirect.startsWith('//')) {
+          // Reject absolute URLs and protocol-relative URLs
+          redirect = 'apps';
+          originalRedirect = null;
+        } else {
+          // Strip leading slash from redirect to prevent double slashes
+          redirect = originalRedirect.charAt(0) === '/' ? originalRedirect.substring(1) : originalRedirect;
+        }
       }
       return passport.authenticate('local', {
         successRedirect: `${self.mountPath}${redirect}`,
-        failureRedirect: `${self.mountPath}login${req.body.redirect ? `?redirect=${req.body.redirect}` : ''}`,
+        failureRedirect: `${self.mountPath}login${originalRedirect ? `?redirect=${originalRedirect}` : ''}`,
         failureFlash : true
       })(req, res, next)
     },

--- a/Parse-Dashboard/app.js
+++ b/Parse-Dashboard/app.js
@@ -1062,8 +1062,12 @@ You have direct access to the Parse database through function calls, so you can 
     }
 
     app.get('/login', csrf(), function(req, res) {
-      const redirectURL = req.url.includes('?redirect=') && req.url.split('?redirect=')[1].length > 1 && req.url.split('?redirect=')[1];
+      let redirectURL = req.url.includes('?redirect=') && req.url.split('?redirect=')[1].length > 1 && req.url.split('?redirect=')[1];
       if (!users || (req.user && req.user.isAuthenticated)) {
+        // Strip leading slash from redirect to prevent double slashes or malformed URLs
+        if (redirectURL && redirectURL.charAt(0) === '/') {
+          redirectURL = redirectURL.substring(1);
+        }
         return res.redirect(`${mountPath}${redirectURL || 'apps'}`);
       }
 

--- a/Parse-Dashboard/app.js
+++ b/Parse-Dashboard/app.js
@@ -1062,11 +1062,25 @@ You have direct access to the Parse database through function calls, so you can 
     }
 
     app.get('/login', csrf(), function(req, res) {
-      let redirectURL = req.url.includes('?redirect=') && req.url.split('?redirect=')[1].length > 1 && req.url.split('?redirect=')[1];
+      let redirectURL = null;
+      try {
+        const url = new URL(req.url, 'http://localhost');
+        redirectURL = url.searchParams.get('redirect');
+      } catch (error) {
+        console.warn('Invalid URL in login redirect:', error.message);
+      }
       if (!users || (req.user && req.user.isAuthenticated)) {
-        // Strip leading slash from redirect to prevent double slashes or malformed URLs
-        if (redirectURL && redirectURL.charAt(0) === '/') {
-          redirectURL = redirectURL.substring(1);
+        // Validate and sanitize redirect URL to prevent open redirect vulnerability
+        if (redirectURL) {
+          // Reject absolute URLs and protocol-relative URLs
+          if (redirectURL.includes('://') || redirectURL.startsWith('//')) {
+            redirectURL = null;
+          } else {
+            // Strip leading slash to prevent double slashes
+            if (redirectURL.charAt(0) === '/') {
+              redirectURL = redirectURL.substring(1);
+            }
+          }
         }
         return res.redirect(`${mountPath}${redirectURL || 'apps'}`);
       }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description

Invalid redirect URL in this scenario:

1. Open two browser tabs with dashboard.
2. In tab A click the logout button.
3. In tab B click a link to a Parse Pointer which opens in a new tab. Since the user is now logged out, the new tab C that is opened shows the login page.
4. In tab A, log into dashboard again.
5. Reload tab C which shows the login page. Since the user already logged in tab A, the dashboard should directly show the dashboard page, instead it opens an invalid URL.

The problem is that the session check recognizes you're already authenticated and tries to redirect, but the redirect URL is malformed.

### Approach

Fix redirect handlers to properly strip leading slashes before concatenation. This ensures that regardless of whether the user submits the login form or reloads a login page while already authenticated, the redirect URLs are always properly formatted without double slashes or malformed relative paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Enhanced redirect URL validation to prevent open redirect vulnerabilities, rejecting absolute and protocol-relative URLs while ensuring only safe internal redirects are processed.

* **Bug Fixes**
  * Improved URL parsing with enhanced error handling for invalid or malformed redirect parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->