### PR TITLE
fix: Sync-scrolling multiple panels jumps to bottom of shortest panel when scrolling up

### DIFF
--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -168,6 +168,7 @@ export default class DataBrowser extends React.Component {
     this.aggregationPanelRef = React.createRef();
     this.panelColumnRefs = [];
     this.multiPanelWrapperRef = React.createRef();
+    this.panelScrollPositions = [];
     this.isSyncingPanelScroll = false;
   }
 
@@ -908,22 +909,90 @@ export default class DataBrowser extends React.Component {
     });
   }
 
+  applySyncedScroll(delta, sourceIndex, sourcePreviousScrollTop) {
+    if (
+      !this.state.syncPanelScroll ||
+      this.state.panelCount <= 1 ||
+      this.isSyncingPanelScroll ||
+      delta === 0
+    ) {
+      return;
+    }
+
+    const panels = this.panelColumnRefs;
+    if (panels.length === 0) {
+      return;
+    }
+
+    const maxScrollTops = panels.map(ref => {
+      const node = ref?.current;
+      return node ? Math.max(0, node.scrollHeight - node.clientHeight) : 0;
+    });
+    const minMaxScrollTop = maxScrollTops.length ? Math.min(...maxScrollTops) : 0;
+
+    const previousPositions = panels.map((ref, i) => {
+      if (i === sourceIndex && sourcePreviousScrollTop !== undefined) {
+        return sourcePreviousScrollTop;
+      }
+      const stored = this.panelScrollPositions[i];
+      if (stored !== undefined) {
+        return stored;
+      }
+      const node = ref?.current;
+      return node ? node.scrollTop : 0;
+    });
+
+    const hasPanelBeyondShortest = previousPositions.some(pos => pos > minMaxScrollTop);
+
+    this.isSyncingPanelScroll = true;
+
+    panels.forEach((ref, i) => {
+      const node = ref?.current;
+      if (!node) {
+        return;
+      }
+
+      const maxScroll = maxScrollTops[i];
+      const baseScrollTop = previousPositions[i] ?? 0;
+      let nextScrollTop = baseScrollTop + delta;
+
+      if (delta < 0) {
+        if (hasPanelBeyondShortest) {
+          if (baseScrollTop > minMaxScrollTop) {
+            nextScrollTop = Math.max(nextScrollTop, minMaxScrollTop);
+          } else {
+            // Keep shortest (or already-caught-up) panels pinned until others reach the same position.
+            nextScrollTop = minMaxScrollTop;
+          }
+        } else {
+          nextScrollTop = Math.max(nextScrollTop, 0);
+        }
+      } else {
+        nextScrollTop = Math.min(nextScrollTop, maxScroll);
+      }
+
+      nextScrollTop = Math.max(0, Math.min(nextScrollTop, maxScroll));
+      node.scrollTop = nextScrollTop;
+      this.panelScrollPositions[i] = nextScrollTop;
+    });
+
+    requestAnimationFrame(() => {
+      this.isSyncingPanelScroll = false;
+    });
+  }
+
   handlePanelScroll(event, index) {
+    const currentScrollTop = event.target.scrollTop;
+    const previousScrollTop =
+      this.panelScrollPositions[index] !== undefined ? this.panelScrollPositions[index] : currentScrollTop;
+    this.panelScrollPositions[index] = currentScrollTop;
+
     if (!this.state.syncPanelScroll || this.state.panelCount <= 1 || this.isSyncingPanelScroll) {
       return;
     }
 
-    this.isSyncingPanelScroll = true;
-    // Sync scroll position to all other panel columns
-    const scrollTop = event.target.scrollTop;
-    this.panelColumnRefs.forEach((ref, i) => {
-      if (i !== index && ref && ref.current) {
-        ref.current.scrollTop = scrollTop;
-      }
-    });
-    requestAnimationFrame(() => {
-      this.isSyncingPanelScroll = false;
-    });
+    const delta = currentScrollTop - previousScrollTop;
+    this.applySyncedScroll(delta, index, previousScrollTop);
   }
 
   handleWrapperWheel(event) {
@@ -934,17 +1003,9 @@ export default class DataBrowser extends React.Component {
     // Prevent default scrolling
     event.preventDefault();
 
-    this.isSyncingPanelScroll = true;
     // Apply scroll to all columns
     const delta = event.deltaY;
-    this.panelColumnRefs.forEach((ref) => {
-      if (ref && ref.current) {
-        ref.current.scrollTop += delta;
-      }
-    });
-    requestAnimationFrame(() => {
-      this.isSyncingPanelScroll = false;
-    });
+    this.applySyncedScroll(delta);
   }
 
   fetchDataForMultiPanel(objectId) {

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -168,7 +168,6 @@ export default class DataBrowser extends React.Component {
     this.aggregationPanelRef = React.createRef();
     this.panelColumnRefs = [];
     this.multiPanelWrapperRef = React.createRef();
-    this.isSyncingPanelScroll = false;
   }
 
   componentWillReceiveProps(props) {
@@ -909,20 +908,16 @@ export default class DataBrowser extends React.Component {
   }
 
   handlePanelScroll(event, index) {
-    if (!this.state.syncPanelScroll || this.state.panelCount <= 1 || this.isSyncingPanelScroll) {
+    if (!this.state.syncPanelScroll || this.state.panelCount <= 1) {
       return;
     }
 
-    this.isSyncingPanelScroll = true;
     // Sync scroll position to all other panel columns
     const scrollTop = event.target.scrollTop;
     this.panelColumnRefs.forEach((ref, i) => {
       if (i !== index && ref && ref.current) {
         ref.current.scrollTop = scrollTop;
       }
-    });
-    requestAnimationFrame(() => {
-      this.isSyncingPanelScroll = false;
     });
   }
 
@@ -934,16 +929,12 @@ export default class DataBrowser extends React.Component {
     // Prevent default scrolling
     event.preventDefault();
 
-    this.isSyncingPanelScroll = true;
     // Apply scroll to all columns
     const delta = event.deltaY;
     this.panelColumnRefs.forEach((ref) => {
       if (ref && ref.current) {
         ref.current.scrollTop += delta;
       }
-    });
-    requestAnimationFrame(() => {
-      this.isSyncingPanelScroll = false;
     });
   }
 

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -168,6 +168,7 @@ export default class DataBrowser extends React.Component {
     this.aggregationPanelRef = React.createRef();
     this.panelColumnRefs = [];
     this.multiPanelWrapperRef = React.createRef();
+    this.isSyncingPanelScroll = false;
   }
 
   componentWillReceiveProps(props) {
@@ -908,16 +909,20 @@ export default class DataBrowser extends React.Component {
   }
 
   handlePanelScroll(event, index) {
-    if (!this.state.syncPanelScroll || this.state.panelCount <= 1) {
+    if (!this.state.syncPanelScroll || this.state.panelCount <= 1 || this.isSyncingPanelScroll) {
       return;
     }
 
+    this.isSyncingPanelScroll = true;
     // Sync scroll position to all other panel columns
     const scrollTop = event.target.scrollTop;
     this.panelColumnRefs.forEach((ref, i) => {
       if (i !== index && ref && ref.current) {
         ref.current.scrollTop = scrollTop;
       }
+    });
+    requestAnimationFrame(() => {
+      this.isSyncingPanelScroll = false;
     });
   }
 
@@ -929,12 +934,16 @@ export default class DataBrowser extends React.Component {
     // Prevent default scrolling
     event.preventDefault();
 
+    this.isSyncingPanelScroll = true;
     // Apply scroll to all columns
     const delta = event.deltaY;
     this.panelColumnRefs.forEach((ref) => {
       if (ref && ref.current) {
         ref.current.scrollTop += delta;
       }
+    });
+    requestAnimationFrame(() => {
+      this.isSyncingPanelScroll = false;
     });
   }
 

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -168,7 +168,6 @@ export default class DataBrowser extends React.Component {
     this.aggregationPanelRef = React.createRef();
     this.panelColumnRefs = [];
     this.multiPanelWrapperRef = React.createRef();
-    this.panelScrollPositions = [];
     this.isSyncingPanelScroll = false;
   }
 
@@ -909,90 +908,22 @@ export default class DataBrowser extends React.Component {
     });
   }
 
-  applySyncedScroll(delta, sourceIndex, sourcePreviousScrollTop) {
-    if (
-      !this.state.syncPanelScroll ||
-      this.state.panelCount <= 1 ||
-      this.isSyncingPanelScroll ||
-      delta === 0
-    ) {
-      return;
-    }
-
-    const panels = this.panelColumnRefs;
-    if (panels.length === 0) {
-      return;
-    }
-
-    const maxScrollTops = panels.map(ref => {
-      const node = ref?.current;
-      return node ? Math.max(0, node.scrollHeight - node.clientHeight) : 0;
-    });
-    const minMaxScrollTop = maxScrollTops.length ? Math.min(...maxScrollTops) : 0;
-
-    const previousPositions = panels.map((ref, i) => {
-      if (i === sourceIndex && sourcePreviousScrollTop !== undefined) {
-        return sourcePreviousScrollTop;
-      }
-      const stored = this.panelScrollPositions[i];
-      if (stored !== undefined) {
-        return stored;
-      }
-      const node = ref?.current;
-      return node ? node.scrollTop : 0;
-    });
-
-    const hasPanelBeyondShortest = previousPositions.some(pos => pos > minMaxScrollTop);
-
-    this.isSyncingPanelScroll = true;
-
-    panels.forEach((ref, i) => {
-      const node = ref?.current;
-      if (!node) {
-        return;
-      }
-
-      const maxScroll = maxScrollTops[i];
-      const baseScrollTop = previousPositions[i] ?? 0;
-      let nextScrollTop = baseScrollTop + delta;
-
-      if (delta < 0) {
-        if (hasPanelBeyondShortest) {
-          if (baseScrollTop > minMaxScrollTop) {
-            nextScrollTop = Math.max(nextScrollTop, minMaxScrollTop);
-          } else {
-            // Keep shortest (or already-caught-up) panels pinned until others reach the same position.
-            nextScrollTop = minMaxScrollTop;
-          }
-        } else {
-          nextScrollTop = Math.max(nextScrollTop, 0);
-        }
-      } else {
-        nextScrollTop = Math.min(nextScrollTop, maxScroll);
-      }
-
-      nextScrollTop = Math.max(0, Math.min(nextScrollTop, maxScroll));
-      node.scrollTop = nextScrollTop;
-      this.panelScrollPositions[i] = nextScrollTop;
-    });
-
-    requestAnimationFrame(() => {
-      this.isSyncingPanelScroll = false;
-    });
-  }
-
   handlePanelScroll(event, index) {
-    const currentScrollTop = event.target.scrollTop;
-    const previousScrollTop =
-      this.panelScrollPositions[index] !== undefined ? this.panelScrollPositions[index] : currentScrollTop;
-    this.panelScrollPositions[index] = currentScrollTop;
-
     if (!this.state.syncPanelScroll || this.state.panelCount <= 1 || this.isSyncingPanelScroll) {
       return;
     }
 
-    const delta = currentScrollTop - previousScrollTop;
-    this.applySyncedScroll(delta, index, previousScrollTop);
+    this.isSyncingPanelScroll = true;
+    // Sync scroll position to all other panel columns
+    const scrollTop = event.target.scrollTop;
+    this.panelColumnRefs.forEach((ref, i) => {
+      if (i !== index && ref && ref.current) {
+        ref.current.scrollTop = scrollTop;
+      }
+    });
+    requestAnimationFrame(() => {
+      this.isSyncingPanelScroll = false;
+    });
   }
 
   handleWrapperWheel(event) {
@@ -1003,9 +934,17 @@ export default class DataBrowser extends React.Component {
     // Prevent default scrolling
     event.preventDefault();
 
+    this.isSyncingPanelScroll = true;
     // Apply scroll to all columns
     const delta = event.deltaY;
-    this.applySyncedScroll(delta);
+    this.panelColumnRefs.forEach((ref) => {
+      if (ref && ref.current) {
+        ref.current.scrollTop += delta;
+      }
+    });
+    requestAnimationFrame(() => {
+      this.isSyncingPanelScroll = false;
+    });
   }
 
   fetchDataForMultiPanel(objectId) {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Sync-scrolling multiple panels jumps to bottom of shortest panel when scrolling up.

### Approach

Fix scroll position algorithm.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined multi-panel scrolling synchronization in the data browser to better handle wheel-based interactions.
  * Improved active panel detection to prevent conflicting scroll updates when interacting with multiple panels.
  * Enhanced scroll handling for more consistent performance across panels.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->