### PR TITLE
feat: Automatically resize info panel sidebar width when adding or removing panels

### DIFF
--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -1063,10 +1063,14 @@ export default class DataBrowser extends React.Component {
       }
 
       // Update state with all available data
+      const newWidth = (this.state.panelWidth / this.state.panelCount) * newPanelCount;
+      const limitedWidth = Math.min(newWidth, this.state.maxWidth);
+
       this.setState({
         panelCount: newPanelCount,
         displayedObjectIds: newDisplayedObjectIds,
-        multiPanelData: currentObjectData
+        multiPanelData: currentObjectData,
+        panelWidth: limitedWidth,
       });
 
       // Fetch missing data asynchronously
@@ -1086,9 +1090,13 @@ export default class DataBrowser extends React.Component {
       const newPanelCount = prevState.panelCount - 1;
       // Remove the last displayed object
       const newDisplayedObjectIds = prevState.displayedObjectIds.slice(0, -1);
+
+      const newWidth = (prevState.panelWidth / prevState.panelCount) * newPanelCount;
+
       return {
         panelCount: newPanelCount,
-        displayedObjectIds: newDisplayedObjectIds
+        displayedObjectIds: newDisplayedObjectIds,
+        panelWidth: newWidth,
       };
     });
   }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description

Adding or removing info panels keeps the side bar width the same and requires to manually resize the sidebar to accommodate more or less panels.

### Approach
<!-- Add a description of the approach in this PR. -->

Automatically resize info panel width when adding or removing panels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Data browser panels now automatically resize to fit the available space when panels are added or removed, providing a seamless multi-panel experience without requiring manual adjustments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->