### PR TITLE
fix: No individual data loading indicators when displaying multiple info panels

### DIFF
--- a/src/dashboard/Data/Browser/Databrowser.scss
+++ b/src/dashboard/Data/Browser/Databrowser.scss
@@ -36,6 +36,7 @@
     min-width: 0;
     overflow-y: auto;
     overflow-x: hidden;
+    position: relative;
 
     /* Custom narrow scrollbar for webkit browsers */
     &::-webkit-scrollbar {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description

There are no individual loading indicators when displaying multiple info panels. Instead there is only 1 main loading indicator that overlays the whole sidebar.

### Approach

Add individual loading indicators.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced loading state tracking for multi-panel data fetching in the data browser.

* **Style**
  * Updated column layout positioning in the data browser.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->