### PR TITLE
fix: Info panel data not reloading when clicking refresh button in data browser

### DIFF
--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -1040,7 +1040,7 @@ class Browser extends DashboardView {
   async refresh() {
     if (Object.keys(this.state.selection).length > 0) {
       if (!window.confirm(SELECTED_ROWS_MESSAGE)) {
-        return;
+        return false;
       }
     }
     const relation = this.state.relation;
@@ -1062,6 +1062,7 @@ class Browser extends DashboardView {
       });
       await this.fetchData(this.props.params.className, prevFilters);
     }
+    return true;
   }
 
   async fetchParseData(source, filters) {

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -411,7 +411,6 @@ class Browser extends DashboardView {
         this.currentInfoPanelQuery = null;
       }
     });
-    return promise;
   }
 
   setAggregationPanelData(data) {
@@ -1038,17 +1037,12 @@ class Browser extends DashboardView {
     return schemaSimplifiedData;
   }
 
-  async refresh(onRefreshStart) {
+  async refresh() {
     if (Object.keys(this.state.selection).length > 0) {
       if (!window.confirm(SELECTED_ROWS_MESSAGE)) {
         return false;
       }
     }
-
-    if (onRefreshStart && typeof onRefreshStart === 'function') {
-      onRefreshStart();
-    }
-
     const relation = this.state.relation;
     const prevFilters = this.state.filters || new List();
     const initialState = {
@@ -1058,21 +1052,17 @@ class Browser extends DashboardView {
       selection: {},
       editCloneRows: null,
     };
-    try {
-      if (relation) {
-        this.setState(initialState);
-        await this.setRelation(relation, prevFilters);
-      } else {
-        this.setState({
-          ...initialState,
-          relation: null,
-        });
-        await this.fetchData(this.props.params.className, prevFilters);
-      }
-      return true;
-    } catch {
-      return false;
+    if (relation) {
+      this.setState(initialState);
+      this.setRelation(relation, prevFilters);
+    } else {
+      this.setState({
+        ...initialState,
+        relation: null,
+      });
+      this.fetchData(this.props.params.className, prevFilters);
     }
+    return true;
   }
 
   async fetchParseData(source, filters) {
@@ -1519,7 +1509,7 @@ class Browser extends DashboardView {
         this.props.navigate(url);
       }
     );
-    return this.fetchRelation(relation, filters);
+    this.fetchRelation(relation, filters);
   }
 
   handlePointerClick({ className, id, field = 'objectId' }) {

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -411,6 +411,7 @@ class Browser extends DashboardView {
         this.currentInfoPanelQuery = null;
       }
     });
+    return promise;
   }
 
   setAggregationPanelData(data) {
@@ -1037,12 +1038,17 @@ class Browser extends DashboardView {
     return schemaSimplifiedData;
   }
 
-  async refresh() {
+  async refresh(onRefreshStart) {
     if (Object.keys(this.state.selection).length > 0) {
       if (!window.confirm(SELECTED_ROWS_MESSAGE)) {
         return false;
       }
     }
+
+    if (onRefreshStart && typeof onRefreshStart === 'function') {
+      onRefreshStart();
+    }
+
     const relation = this.state.relation;
     const prevFilters = this.state.filters || new List();
     const initialState = {
@@ -1052,17 +1058,21 @@ class Browser extends DashboardView {
       selection: {},
       editCloneRows: null,
     };
-    if (relation) {
-      this.setState(initialState);
-      this.setRelation(relation, prevFilters);
-    } else {
-      this.setState({
-        ...initialState,
-        relation: null,
-      });
-      this.fetchData(this.props.params.className, prevFilters);
+    try {
+      if (relation) {
+        this.setState(initialState);
+        await this.setRelation(relation, prevFilters);
+      } else {
+        this.setState({
+          ...initialState,
+          relation: null,
+        });
+        await this.fetchData(this.props.params.className, prevFilters);
+      }
+      return true;
+    } catch {
+      return false;
     }
-    return true;
   }
 
   async fetchParseData(source, filters) {
@@ -1509,7 +1519,7 @@ class Browser extends DashboardView {
         this.props.navigate(url);
       }
     );
-    this.fetchRelation(relation, filters);
+    return this.fetchRelation(relation, filters);
   }
 
   handlePointerClick({ className, id, field = 'objectId' }) {

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -1060,7 +1060,7 @@ class Browser extends DashboardView {
         ...initialState,
         relation: null,
       });
-      await this.fetchData(this.props.params.className, prevFilters);
+      this.fetchData(this.props.params.className, prevFilters);
     }
     return true;
   }

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -106,6 +106,7 @@ export default class DataBrowser extends React.Component {
     this.state = {
       order: order,
       current: null,
+      lastSelectedCol: 0,
       editing: false,
       copyableValue: undefined,
       selectedObjectId: undefined,
@@ -197,6 +198,7 @@ export default class DataBrowser extends React.Component {
       this.setState({
         order: order,
         current: null,
+        lastSelectedCol: 0,
         editing: false,
         simplifiedSchema: this.getSimplifiedSchema(props.schema, props.className),
         allClassesSchema: this.getAllClassesSchema(props.schema, props.classes),
@@ -270,6 +272,12 @@ export default class DataBrowser extends React.Component {
       }
     }
 
+    if (this.state.current && this.state.current !== prevState.current) {
+      if (this.state.current.col !== this.state.lastSelectedCol) {
+        this.setState({ lastSelectedCol: this.state.current.col });
+      }
+    }
+
     // Auto-load first row if enabled and conditions are met
     if (
       this.state.autoLoadFirstRow &&
@@ -285,7 +293,15 @@ export default class DataBrowser extends React.Component {
       this.setShowAggregatedData(true);
       this.setSelectedObjectId(firstRowObjectId);
       // Also set the current cell to the first cell of the first row
-      this.setCurrent({ row: 0, col: 0 });
+      let col =
+        this.state.lastSelectedCol !== undefined &&
+        prevProps.className === this.props.className
+          ? this.state.lastSelectedCol
+          : 0;
+      if (col >= this.state.order.length) {
+        col = 0;
+      }
+      this.setCurrent({ row: 0, col });
       this.handleCallCloudFunction(
         firstRowObjectId,
         this.props.className,
@@ -437,7 +453,12 @@ export default class DataBrowser extends React.Component {
       const firstRowObjectId = this.props.data[0].id;
       this.setShowAggregatedData(true);
       this.setSelectedObjectId(firstRowObjectId);
-      this.setCurrent({ row: 0, col: 0 });
+      let col =
+        this.state.lastSelectedCol !== undefined ? this.state.lastSelectedCol : 0;
+      if (col >= this.state.order.length) {
+        col = 0;
+      }
+      this.setCurrent({ row: 0, col });
       this.handleCallCloudFunction(
         firstRowObjectId,
         this.props.className,

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -374,91 +374,41 @@ export default class DataBrowser extends React.Component {
     }, 1000);
   }
 
-  async refreshPanels() {
-    if (!this.state.isPanelVisible) {
-      return;
-    }
-
-    const { selectedObjectId, panelCount, displayedObjectIds, prefetchCache } = this.state;
-
-    // Prepare a new cache object by removing entries we want to refresh
-    const newPrefetchCache = { ...prefetchCache };
-
-    if (selectedObjectId) {
-      delete newPrefetchCache[selectedObjectId];
-    }
-
-    if (panelCount > 1 && displayedObjectIds.length > 0) {
-      displayedObjectIds.forEach(objectId => {
-        if (objectId !== selectedObjectId) {
-          delete newPrefetchCache[objectId];
-        }
-      });
-    }
-
-    // Batch state update
-    await new Promise(resolve => {
-      this.setState({ prefetchCache: newPrefetchCache }, resolve);
-    });
-
-    // Now perform fetches
-    const promises = [];
-
-    if (selectedObjectId) {
-      promises.push(this.handleCallCloudFunction(
-        selectedObjectId,
-        this.props.className,
-        this.props.app.applicationId
-      ));
-    }
-
-    if (panelCount > 1 && displayedObjectIds.length > 0) {
-      displayedObjectIds.forEach(objectId => {
-        if (objectId !== selectedObjectId) {
-          promises.push(this.fetchDataForMultiPanel(objectId));
-        }
-      });
-    }
-
-    await Promise.all(promises);
-  }
-
-  setPanelsLoading() {
-    if (!this.state.isPanelVisible) {
-      return;
-    }
-    // Set loading for the main selected panel
-    this.props.setLoadingInfoPanel(true);
-
-    // Set loading for all displayed panels
-    if (this.state.displayedObjectIds.length > 0) {
-      this.setState({
-        loadingObjectIds: new Set(this.state.displayedObjectIds)
-      });
-    }
-  }
-
   async handleRefresh() {
-    try {
-      const onRefreshStart = () => {
-        this.setPanelsLoading();
-      };
+    const shouldReload = await this.props.onRefresh();
 
-      const success = await this.props.onRefresh(onRefreshStart);
-
-      if (success) {
-        await this.refreshPanels();
-      } else {
-        // If refresh failed, reset loading state
-        this.props.setLoadingInfoPanel(false);
-        this.setState({ loadingObjectIds: new Set() });
+    // If panel is visible and we have selected objects, refresh their data
+    if (shouldReload && this.state.isPanelVisible) {
+      // Refresh current selected object
+      if (this.state.selectedObjectId) {
+        // Clear from cache to force reload
+        this.setState(prev => {
+          const n = { ...prev.prefetchCache };
+          delete n[this.state.selectedObjectId];
+          return { prefetchCache: n };
+        }, () => {
+          this.handleCallCloudFunction(
+            this.state.selectedObjectId,
+            this.props.className,
+            this.props.app.applicationId
+          );
+        });
       }
-    } catch (error) {
-      console.error('Error refreshing data:', error);
-      this.props.setLoadingInfoPanel(false);
-      this.setState({ loadingObjectIds: new Set() });
-      if (this.props.showNote) {
-        this.props.showNote('Failed to refresh data', true);
+
+      // Refresh other displayed objects if in multi-panel mode
+      if (this.state.panelCount > 1 && this.state.displayedObjectIds.length > 0) {
+        this.state.displayedObjectIds.forEach(objectId => {
+          if (objectId !== this.state.selectedObjectId) {
+            // Clear from cache
+            this.setState(prev => {
+              const n = { ...prev.prefetchCache };
+              delete n[objectId];
+              return { prefetchCache: n };
+            }, () => {
+              this.fetchDataForMultiPanel(objectId);
+            });
+          }
+        });
       }
     }
   }
@@ -1083,7 +1033,6 @@ export default class DataBrowser extends React.Component {
           [objectId]: cached.data
         }
       }));
-      return Promise.resolve();
     } else {
       // Fetch fresh data
       const cloudCodeFunction =
@@ -1092,7 +1041,7 @@ export default class DataBrowser extends React.Component {
         ]?.[className]?.[0]?.cloudCodeFunction;
 
       if (!cloudCodeFunction) {
-        return Promise.resolve();
+        return;
       }
 
       const params = {
@@ -1106,7 +1055,7 @@ export default class DataBrowser extends React.Component {
         loadingObjectIds: new Set(prev.loadingObjectIds).add(objectId)
       }));
 
-      return Parse.Cloud.run(cloudCodeFunction, params, options).then(result => {
+      Parse.Cloud.run(cloudCodeFunction, params, options).then(result => {
         // Store in both prefetchCache and multiPanelData
         this.setState(prev => {
           const newLoading = new Set(prev.loadingObjectIds);
@@ -1398,7 +1347,6 @@ export default class DataBrowser extends React.Component {
           [objectId]: cached.data
         }
       }));
-      return Promise.resolve();
     } else {
       if (cached) {
         this.setState(prev => {
@@ -1407,7 +1355,7 @@ export default class DataBrowser extends React.Component {
           return { prefetchCache: n };
         });
       }
-      return this.props.callCloudFunction(objectId, className, appId);
+      this.props.callCloudFunction(objectId, className, appId);
     }
   }
 

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -106,7 +106,6 @@ export default class DataBrowser extends React.Component {
     this.state = {
       order: order,
       current: null,
-      lastSelectedCol: 0,
       editing: false,
       copyableValue: undefined,
       selectedObjectId: undefined,
@@ -198,7 +197,6 @@ export default class DataBrowser extends React.Component {
       this.setState({
         order: order,
         current: null,
-        lastSelectedCol: 0,
         editing: false,
         simplifiedSchema: this.getSimplifiedSchema(props.schema, props.className),
         allClassesSchema: this.getAllClassesSchema(props.schema, props.classes),
@@ -272,12 +270,6 @@ export default class DataBrowser extends React.Component {
       }
     }
 
-    if (this.state.current && this.state.current !== prevState.current) {
-      if (this.state.current.col !== this.state.lastSelectedCol) {
-        this.setState({ lastSelectedCol: this.state.current.col });
-      }
-    }
-
     // Auto-load first row if enabled and conditions are met
     if (
       this.state.autoLoadFirstRow &&
@@ -293,15 +285,7 @@ export default class DataBrowser extends React.Component {
       this.setShowAggregatedData(true);
       this.setSelectedObjectId(firstRowObjectId);
       // Also set the current cell to the first cell of the first row
-      let col =
-        this.state.lastSelectedCol !== undefined &&
-        prevProps.className === this.props.className
-          ? this.state.lastSelectedCol
-          : 0;
-      if (col >= this.state.order.length) {
-        col = 0;
-      }
-      this.setCurrent({ row: 0, col });
+      this.setCurrent({ row: 0, col: 0 });
       this.handleCallCloudFunction(
         firstRowObjectId,
         this.props.className,
@@ -453,12 +437,7 @@ export default class DataBrowser extends React.Component {
       const firstRowObjectId = this.props.data[0].id;
       this.setShowAggregatedData(true);
       this.setSelectedObjectId(firstRowObjectId);
-      let col =
-        this.state.lastSelectedCol !== undefined ? this.state.lastSelectedCol : 0;
-      if (col >= this.state.order.length) {
-        col = 0;
-      }
-      this.setCurrent({ row: 0, col });
+      this.setCurrent({ row: 0, col: 0 });
       this.handleCallCloudFunction(
         firstRowObjectId,
         this.props.className,

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -143,6 +143,7 @@ export default class DataBrowser extends React.Component {
     this.handleKey = this.handleKey.bind(this);
     this.handleHeaderDragDrop = this.handleHeaderDragDrop.bind(this);
     this.handleResize = this.handleResize.bind(this);
+    this.handleRefresh = this.handleRefresh.bind(this);
     this.togglePanelVisibility = this.togglePanelVisibility.bind(this);
     this.setCurrent = this.setCurrent.bind(this);
     this.setEditing = this.setEditing.bind(this);
@@ -371,6 +372,45 @@ export default class DataBrowser extends React.Component {
       ColumnPreferences.updatePreferences(order, appId, className);
       shouldReload && this.props.onRefresh();
     }, 1000);
+  }
+
+  handleRefresh() {
+    this.props.onRefresh();
+
+    // If panel is visible and we have selected objects, refresh their data
+    if (this.state.isPanelVisible) {
+      // Refresh current selected object
+      if (this.state.selectedObjectId) {
+        // Clear from cache to force reload
+        this.setState(prev => {
+          const n = { ...prev.prefetchCache };
+          delete n[this.state.selectedObjectId];
+          return { prefetchCache: n };
+        }, () => {
+          this.handleCallCloudFunction(
+            this.state.selectedObjectId,
+            this.props.className,
+            this.props.app.applicationId
+          );
+        });
+      }
+
+      // Refresh other displayed objects if in multi-panel mode
+      if (this.state.panelCount > 1 && this.state.displayedObjectIds.length > 0) {
+        this.state.displayedObjectIds.forEach(objectId => {
+          if (objectId !== this.state.selectedObjectId) {
+            // Clear from cache
+            this.setState(prev => {
+              const n = { ...prev.prefetchCache };
+              delete n[objectId];
+              return { prefetchCache: n };
+            }, () => {
+              this.fetchDataForMultiPanel(objectId);
+            });
+          }
+        });
+      }
+    }
   }
 
   togglePanelVisibility() {
@@ -1597,6 +1637,7 @@ export default class DataBrowser extends React.Component {
           showPanelCheckbox={this.state.showPanelCheckbox}
           toggleShowPanelCheckbox={this.toggleShowPanelCheckbox}
           {...other}
+          onRefresh={this.handleRefresh}
         />
 
         {this.state.contextMenuX && (

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -374,41 +374,91 @@ export default class DataBrowser extends React.Component {
     }, 1000);
   }
 
+  async refreshPanels() {
+    if (!this.state.isPanelVisible) {
+      return;
+    }
+
+    const { selectedObjectId, panelCount, displayedObjectIds, prefetchCache } = this.state;
+
+    // Prepare a new cache object by removing entries we want to refresh
+    const newPrefetchCache = { ...prefetchCache };
+
+    if (selectedObjectId) {
+      delete newPrefetchCache[selectedObjectId];
+    }
+
+    if (panelCount > 1 && displayedObjectIds.length > 0) {
+      displayedObjectIds.forEach(objectId => {
+        if (objectId !== selectedObjectId) {
+          delete newPrefetchCache[objectId];
+        }
+      });
+    }
+
+    // Batch state update
+    await new Promise(resolve => {
+      this.setState({ prefetchCache: newPrefetchCache }, resolve);
+    });
+
+    // Now perform fetches
+    const promises = [];
+
+    if (selectedObjectId) {
+      promises.push(this.handleCallCloudFunction(
+        selectedObjectId,
+        this.props.className,
+        this.props.app.applicationId
+      ));
+    }
+
+    if (panelCount > 1 && displayedObjectIds.length > 0) {
+      displayedObjectIds.forEach(objectId => {
+        if (objectId !== selectedObjectId) {
+          promises.push(this.fetchDataForMultiPanel(objectId));
+        }
+      });
+    }
+
+    await Promise.all(promises);
+  }
+
+  setPanelsLoading() {
+    if (!this.state.isPanelVisible) {
+      return;
+    }
+    // Set loading for the main selected panel
+    this.props.setLoadingInfoPanel(true);
+
+    // Set loading for all displayed panels
+    if (this.state.displayedObjectIds.length > 0) {
+      this.setState({
+        loadingObjectIds: new Set(this.state.displayedObjectIds)
+      });
+    }
+  }
+
   async handleRefresh() {
-    const shouldReload = await this.props.onRefresh();
+    try {
+      const onRefreshStart = () => {
+        this.setPanelsLoading();
+      };
 
-    // If panel is visible and we have selected objects, refresh their data
-    if (shouldReload && this.state.isPanelVisible) {
-      // Refresh current selected object
-      if (this.state.selectedObjectId) {
-        // Clear from cache to force reload
-        this.setState(prev => {
-          const n = { ...prev.prefetchCache };
-          delete n[this.state.selectedObjectId];
-          return { prefetchCache: n };
-        }, () => {
-          this.handleCallCloudFunction(
-            this.state.selectedObjectId,
-            this.props.className,
-            this.props.app.applicationId
-          );
-        });
+      const success = await this.props.onRefresh(onRefreshStart);
+
+      if (success) {
+        await this.refreshPanels();
+      } else {
+        // If refresh failed, reset loading state
+        this.props.setLoadingInfoPanel(false);
+        this.setState({ loadingObjectIds: new Set() });
       }
-
-      // Refresh other displayed objects if in multi-panel mode
-      if (this.state.panelCount > 1 && this.state.displayedObjectIds.length > 0) {
-        this.state.displayedObjectIds.forEach(objectId => {
-          if (objectId !== this.state.selectedObjectId) {
-            // Clear from cache
-            this.setState(prev => {
-              const n = { ...prev.prefetchCache };
-              delete n[objectId];
-              return { prefetchCache: n };
-            }, () => {
-              this.fetchDataForMultiPanel(objectId);
-            });
-          }
-        });
+    } catch (error) {
+      console.error('Error refreshing data:', error);
+      this.props.setLoadingInfoPanel(false);
+      this.setState({ loadingObjectIds: new Set() });
+      if (this.props.showNote) {
+        this.props.showNote('Failed to refresh data', true);
       }
     }
   }
@@ -1033,6 +1083,7 @@ export default class DataBrowser extends React.Component {
           [objectId]: cached.data
         }
       }));
+      return Promise.resolve();
     } else {
       // Fetch fresh data
       const cloudCodeFunction =
@@ -1041,7 +1092,7 @@ export default class DataBrowser extends React.Component {
         ]?.[className]?.[0]?.cloudCodeFunction;
 
       if (!cloudCodeFunction) {
-        return;
+        return Promise.resolve();
       }
 
       const params = {
@@ -1055,7 +1106,7 @@ export default class DataBrowser extends React.Component {
         loadingObjectIds: new Set(prev.loadingObjectIds).add(objectId)
       }));
 
-      Parse.Cloud.run(cloudCodeFunction, params, options).then(result => {
+      return Parse.Cloud.run(cloudCodeFunction, params, options).then(result => {
         // Store in both prefetchCache and multiPanelData
         this.setState(prev => {
           const newLoading = new Set(prev.loadingObjectIds);
@@ -1347,6 +1398,7 @@ export default class DataBrowser extends React.Component {
           [objectId]: cached.data
         }
       }));
+      return Promise.resolve();
     } else {
       if (cached) {
         this.setState(prev => {
@@ -1355,7 +1407,7 @@ export default class DataBrowser extends React.Component {
           return { prefetchCache: n };
         });
       }
-      this.props.callCloudFunction(objectId, className, appId);
+      return this.props.callCloudFunction(objectId, className, appId);
     }
   }
 

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -374,11 +374,11 @@ export default class DataBrowser extends React.Component {
     }, 1000);
   }
 
-  handleRefresh() {
-    this.props.onRefresh();
+  async handleRefresh() {
+    const shouldReload = await this.props.onRefresh();
 
     // If panel is visible and we have selected objects, refresh their data
-    if (this.state.isPanelVisible) {
+    if (shouldReload && this.state.isPanelVisible) {
       // Refresh current selected object
       if (this.state.selectedObjectId) {
         // Clear from cache to force reload


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description

Info panel data not reloading when clicking refresh button in data browser.

### Approach

Reload info panel data on data browser reload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-panel refresh propagates to visible panels and toolbar/table components, selectively reloading visible objects and clearing stale prefetch caches.

* **Improvements**
  * Refresh now returns a boolean completion status so callers can react to cancel/success.
  * Refresh flow ensures panels reset loading state on cancel and triggers targeted data reloads for active panels.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->