### PR TITLE
feat: Remember info panel width and count across browser sessions

### DIFF
--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -26,6 +26,7 @@ const AGGREGATION_PANEL_AUTO_LOAD_FIRST_ROW = 'aggregationPanelAutoLoadFirstRow'
 const AGGREGATION_PANEL_SYNC_SCROLL = 'aggregationPanelSyncScroll';
 const AGGREGATION_PANEL_BATCH_NAVIGATE = 'aggregationPanelBatchNavigate';
 const AGGREGATION_PANEL_SHOW_CHECKBOX = 'aggregationPanelShowCheckbox';
+const AGGREGATION_PANEL_WIDTH = 'aggregationPanelWidth';
 
 function formatValueForCopy(value, type) {
   if (value === undefined) {
@@ -98,6 +99,8 @@ export default class DataBrowser extends React.Component {
       window.localStorage?.getItem(AGGREGATION_PANEL_BATCH_NAVIGATE) !== 'false';
     const storedShowPanelCheckbox =
       window.localStorage?.getItem(AGGREGATION_PANEL_SHOW_CHECKBOX) !== 'false';
+    const storedPanelWidth = window.localStorage?.getItem(AGGREGATION_PANEL_WIDTH);
+    const parsedPanelWidth = storedPanelWidth ? parseInt(storedPanelWidth, 10) : 300;
     const hasAggregation =
       props.classwiseCloudFunctions?.[
         `${props.app.applicationId}${props.appName}`
@@ -117,7 +120,7 @@ export default class DataBrowser extends React.Component {
       firstSelectedCell: null,
       selectedData: [],
       prevClassName: props.className,
-      panelWidth: 300,
+      panelWidth: parsedPanelWidth,
       isResizing: false,
       maxWidth: window.innerWidth - 300,
       showAggregatedData: true,
@@ -358,6 +361,7 @@ export default class DataBrowser extends React.Component {
       isResizing: false,
       panelWidth: size.width,
     });
+    window.localStorage?.setItem(AGGREGATION_PANEL_WIDTH, size.width);
   }
 
   handleResizeDiv(event, { size }) {

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -27,6 +27,7 @@ const AGGREGATION_PANEL_SYNC_SCROLL = 'aggregationPanelSyncScroll';
 const AGGREGATION_PANEL_BATCH_NAVIGATE = 'aggregationPanelBatchNavigate';
 const AGGREGATION_PANEL_SHOW_CHECKBOX = 'aggregationPanelShowCheckbox';
 const AGGREGATION_PANEL_WIDTH = 'aggregationPanelWidth';
+const AGGREGATION_PANEL_COUNT = 'aggregationPanelCount';
 
 function formatValueForCopy(value, type) {
   if (value === undefined) {
@@ -101,6 +102,8 @@ export default class DataBrowser extends React.Component {
       window.localStorage?.getItem(AGGREGATION_PANEL_SHOW_CHECKBOX) !== 'false';
     const storedPanelWidth = window.localStorage?.getItem(AGGREGATION_PANEL_WIDTH);
     const parsedPanelWidth = storedPanelWidth ? parseInt(storedPanelWidth, 10) : 300;
+    const storedPanelCount = window.localStorage?.getItem(AGGREGATION_PANEL_COUNT);
+    const parsedPanelCount = storedPanelCount ? parseInt(storedPanelCount, 10) : 1;
     const hasAggregation =
       props.classwiseCloudFunctions?.[
         `${props.app.applicationId}${props.appName}`
@@ -134,7 +137,7 @@ export default class DataBrowser extends React.Component {
       prefetchCache: {},
       selectionHistory: [],
       displayedObjectIds: [], // Array of object IDs currently displayed in the panel
-      panelCount: 1, // Number of panels to display
+      panelCount: parsedPanelCount, // Number of panels to display
       multiPanelData: {}, // Object mapping objectId to panel data
       _objectsToFetch: [], // Temporary field for async fetch handling
       loadingObjectIds: new Set(),
@@ -1152,6 +1155,8 @@ export default class DataBrowser extends React.Component {
         multiPanelData: currentObjectData,
         panelWidth: limitedWidth,
       });
+      window.localStorage?.setItem(AGGREGATION_PANEL_COUNT, newPanelCount);
+      window.localStorage?.setItem(AGGREGATION_PANEL_WIDTH, limitedWidth);
 
       // Fetch missing data asynchronously
       objectsToFetch.forEach((objectId, i) => {
@@ -1172,6 +1177,9 @@ export default class DataBrowser extends React.Component {
       const newDisplayedObjectIds = prevState.displayedObjectIds.slice(0, -1);
 
       const newWidth = (prevState.panelWidth / prevState.panelCount) * newPanelCount;
+
+      window.localStorage?.setItem(AGGREGATION_PANEL_COUNT, newPanelCount);
+      window.localStorage?.setItem(AGGREGATION_PANEL_WIDTH, newWidth);
 
       return {
         panelCount: newPanelCount,


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Feature

Remember info panel width and count across browser sessions. Currently, this is lost when refreshing the browser page.


### Approach

Remember info panel width and count across browser sessions in local storage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Data Browser now remembers aggregation panel configuration, including panel width and count, across sessions. Panel layout adjustments are automatically saved when resizing or adding/removing panels.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->