### PR TITLE
fix: Info panel may show stale data of previous objects when refreshing the data table or navigating between classes

### DIFF
--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -264,6 +264,23 @@ export default class DataBrowser extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
+    // Clear panels when data becomes null (filter change, class change, etc.)
+    if (
+      this.props.data === null &&
+      prevProps.data !== null &&
+      this.state.isPanelVisible &&
+      this.state.selectedObjectId !== undefined
+    ) {
+      // Clear panel data and selection to show "No object selected"
+      this.props.setAggregationPanelData({});
+      this.props.setLoadingInfoPanel(false);
+      this.setState({
+        selectedObjectId: undefined,
+        multiPanelData: {},
+        displayedObjectIds: []
+      });
+    }
+
     if (
       this.state.current === null &&
       this.state.selectedObjectId !== undefined &&

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -489,6 +489,7 @@ export default class DataBrowser extends React.Component {
         pendingPanelRefresh: true,
         prefetchCache: newPrefetchCache,
         multiPanelData: {}, // Clear multi-panel data as well
+        displayedObjectIds: [], // Clear displayed object IDs
         selectedObjectId: undefined, // Clear selection to show "No object selected"
         showAggregatedData: true, // Keep true to show "No object selected" message
       });

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -264,6 +264,21 @@ export default class DataBrowser extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
+    // Clear panels immediately when className changes
+    if (
+      this.props.className !== prevProps.className &&
+      this.state.isPanelVisible
+    ) {
+      // Clear panel data and selection to show "No object selected"
+      this.props.setAggregationPanelData({});
+      this.props.setLoadingInfoPanel(false);
+      this.setState({
+        selectedObjectId: undefined,
+        multiPanelData: {},
+        displayedObjectIds: []
+      });
+    }
+
     // Clear panels when data becomes null (filter change, class change, etc.)
     if (
       this.props.data === null &&
@@ -288,7 +303,7 @@ export default class DataBrowser extends React.Component {
     ) {
       this.setState({
         selectedObjectId: undefined,
-        showAggregatedData: false,
+        showAggregatedData: true, // Keep true to show "No object selected" message
       });
       this.props.setAggregationPanelData({});
       if (this.props.errorAggregatedData != {}) {

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -433,10 +433,8 @@ export default class DataBrowser extends React.Component {
   }
 
   async handleRefresh() {
-    const shouldReload = await this.props.onRefresh();
-
-    // If panel is visible and we have selected objects, set flag to refresh panels after data loads
-    if (shouldReload && this.state.isPanelVisible) {
+    // If panel is visible, clear it immediately and show "No object selected"
+    if (this.state.isPanelVisible) {
       // Clear the cache for all selected objects so they will be refreshed
       const newPrefetchCache = { ...this.state.prefetchCache };
 
@@ -450,11 +448,22 @@ export default class DataBrowser extends React.Component {
         });
       }
 
-      // Set the flag to refresh panels after data loads, and update the cache
+      // Clear panel data immediately (shows "No object selected" message)
+      this.props.setAggregationPanelData({});
+      this.props.setLoadingInfoPanel(false);
       this.setState({
         pendingPanelRefresh: true,
-        prefetchCache: newPrefetchCache
+        prefetchCache: newPrefetchCache,
+        multiPanelData: {}, // Clear multi-panel data as well
+        selectedObjectId: undefined, // Clear selection to show "No object selected"
       });
+    }
+
+    const shouldReload = await this.props.onRefresh();
+
+    // If refresh was cancelled, reset the pending refresh state
+    if (!shouldReload && this.state.isPanelVisible) {
+      this.setState({ pendingPanelRefresh: false });
     }
   }
 

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -274,6 +274,7 @@ export default class DataBrowser extends React.Component {
       this.props.setLoadingInfoPanel(false);
       this.setState({
         selectedObjectId: undefined,
+        showAggregatedData: true, // Keep true to show "No object selected" message
         multiPanelData: {},
         displayedObjectIds: []
       });
@@ -291,6 +292,7 @@ export default class DataBrowser extends React.Component {
       this.props.setLoadingInfoPanel(false);
       this.setState({
         selectedObjectId: undefined,
+        showAggregatedData: true, // Keep true to show "No object selected" message
         multiPanelData: {},
         displayedObjectIds: []
       });
@@ -488,6 +490,7 @@ export default class DataBrowser extends React.Component {
         prefetchCache: newPrefetchCache,
         multiPanelData: {}, // Clear multi-panel data as well
         selectedObjectId: undefined, // Clear selection to show "No object selected"
+        showAggregatedData: true, // Keep true to show "No object selected" message
       });
     }
 
@@ -1615,6 +1618,24 @@ export default class DataBrowser extends React.Component {
                     ref={this.setMultiPanelWrapperRef}
                   >
                     {(() => {
+                      // If no objects are displayed, show a single panel with "No object selected"
+                      if (this.state.displayedObjectIds.length === 0) {
+                        return (
+                          <AggregationPanel
+                            data={{}}
+                            isLoadingCloudFunction={false}
+                            showAggregatedData={true}
+                            errorAggregatedData={{}}
+                            showNote={this.props.showNote}
+                            setErrorAggregatedData={this.props.setErrorAggregatedData}
+                            setSelectedObjectId={this.setSelectedObjectId}
+                            selectedObjectId={undefined}
+                            appName={this.props.appName}
+                            className={this.props.className}
+                          />
+                        );
+                      }
+
                       // Initialize refs array if needed
                       if (this.panelColumnRefs.length !== this.state.displayedObjectIds.length) {
                         this.panelColumnRefs = this.state.displayedObjectIds.map(() => React.createRef());

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -141,6 +141,7 @@ export default class DataBrowser extends React.Component {
       multiPanelData: {}, // Object mapping objectId to panel data
       _objectsToFetch: [], // Temporary field for async fetch handling
       loadingObjectIds: new Set(),
+      pendingPanelRefresh: false, // Flag to track if panel refresh is pending after data reload
     };
 
     this.handleResizeDiv = this.handleResizeDiv.bind(this);
@@ -315,6 +316,40 @@ export default class DataBrowser extends React.Component {
       );
     }
 
+    // Handle pending panel refresh after data has loaded
+    if (
+      this.state.pendingPanelRefresh &&
+      this.props.data !== prevProps.data &&
+      this.props.data !== null
+    ) {
+      // Data has been refreshed, now refresh the panels based on the new data
+      this.setState({ pendingPanelRefresh: false });
+
+      // Refresh current selected object if it still exists in the new data
+      if (this.state.selectedObjectId) {
+        const objectStillExists = this.props.data.some(obj => obj.id === this.state.selectedObjectId);
+        if (objectStillExists) {
+          this.handleCallCloudFunction(
+            this.state.selectedObjectId,
+            this.props.className,
+            this.props.app.applicationId
+          );
+        }
+      }
+
+      // Refresh other displayed objects if in multi-panel mode
+      if (this.state.panelCount > 1 && this.state.displayedObjectIds.length > 0) {
+        this.state.displayedObjectIds.forEach(objectId => {
+          if (objectId !== this.state.selectedObjectId) {
+            const objectStillExists = this.props.data.some(obj => obj.id === objectId);
+            if (objectStillExists) {
+              this.fetchDataForMultiPanel(objectId);
+            }
+          }
+        });
+      }
+    }
+
     if (
       (this.props.AggregationPanelData !== prevProps.AggregationPanelData ||
         this.state.selectedObjectId !== prevState.selectedObjectId) &&
@@ -400,39 +435,26 @@ export default class DataBrowser extends React.Component {
   async handleRefresh() {
     const shouldReload = await this.props.onRefresh();
 
-    // If panel is visible and we have selected objects, refresh their data
+    // If panel is visible and we have selected objects, set flag to refresh panels after data loads
     if (shouldReload && this.state.isPanelVisible) {
-      // Refresh current selected object
+      // Clear the cache for all selected objects so they will be refreshed
+      const newPrefetchCache = { ...this.state.prefetchCache };
+
       if (this.state.selectedObjectId) {
-        // Clear from cache to force reload
-        this.setState(prev => {
-          const n = { ...prev.prefetchCache };
-          delete n[this.state.selectedObjectId];
-          return { prefetchCache: n };
-        }, () => {
-          this.handleCallCloudFunction(
-            this.state.selectedObjectId,
-            this.props.className,
-            this.props.app.applicationId
-          );
+        delete newPrefetchCache[this.state.selectedObjectId];
+      }
+
+      if (this.state.panelCount > 1 && this.state.displayedObjectIds.length > 0) {
+        this.state.displayedObjectIds.forEach(objectId => {
+          delete newPrefetchCache[objectId];
         });
       }
 
-      // Refresh other displayed objects if in multi-panel mode
-      if (this.state.panelCount > 1 && this.state.displayedObjectIds.length > 0) {
-        this.state.displayedObjectIds.forEach(objectId => {
-          if (objectId !== this.state.selectedObjectId) {
-            // Clear from cache
-            this.setState(prev => {
-              const n = { ...prev.prefetchCache };
-              delete n[objectId];
-              return { prefetchCache: n };
-            }, () => {
-              this.fetchDataForMultiPanel(objectId);
-            });
-          }
-        });
-      }
+      // Set the flag to refresh panels after data loads, and update the cache
+      this.setState({
+        pendingPanelRefresh: true,
+        prefetchCache: newPrefetchCache
+      });
     }
   }
 

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -141,7 +141,6 @@ export default class DataBrowser extends React.Component {
       multiPanelData: {}, // Object mapping objectId to panel data
       _objectsToFetch: [], // Temporary field for async fetch handling
       loadingObjectIds: new Set(),
-      pendingPanelRefresh: false, // Flag to track if panel refresh is pending after data reload
     };
 
     this.handleResizeDiv = this.handleResizeDiv.bind(this);
@@ -350,40 +349,6 @@ export default class DataBrowser extends React.Component {
       );
     }
 
-    // Handle pending panel refresh after data has loaded
-    if (
-      this.state.pendingPanelRefresh &&
-      this.props.data !== prevProps.data &&
-      this.props.data !== null
-    ) {
-      // Data has been refreshed, now refresh the panels based on the new data
-      this.setState({ pendingPanelRefresh: false });
-
-      // Refresh current selected object if it still exists in the new data
-      if (this.state.selectedObjectId) {
-        const objectStillExists = this.props.data.some(obj => obj.id === this.state.selectedObjectId);
-        if (objectStillExists) {
-          this.handleCallCloudFunction(
-            this.state.selectedObjectId,
-            this.props.className,
-            this.props.app.applicationId
-          );
-        }
-      }
-
-      // Refresh other displayed objects if in multi-panel mode
-      if (this.state.panelCount > 1 && this.state.displayedObjectIds.length > 0) {
-        this.state.displayedObjectIds.forEach(objectId => {
-          if (objectId !== this.state.selectedObjectId) {
-            const objectStillExists = this.props.data.some(obj => obj.id === objectId);
-            if (objectStillExists) {
-              this.fetchDataForMultiPanel(objectId);
-            }
-          }
-        });
-      }
-    }
-
     if (
       (this.props.AggregationPanelData !== prevProps.AggregationPanelData ||
         this.state.selectedObjectId !== prevState.selectedObjectId) &&
@@ -486,7 +451,6 @@ export default class DataBrowser extends React.Component {
       this.props.setAggregationPanelData({});
       this.props.setLoadingInfoPanel(false);
       this.setState({
-        pendingPanelRefresh: true,
         prefetchCache: newPrefetchCache,
         multiPanelData: {}, // Clear multi-panel data as well
         displayedObjectIds: [], // Clear displayed object IDs
@@ -495,12 +459,7 @@ export default class DataBrowser extends React.Component {
       });
     }
 
-    const shouldReload = await this.props.onRefresh();
-
-    // If refresh was cancelled, reset the pending refresh state
-    if (!shouldReload && this.state.isPanelVisible) {
-      this.setState({ pendingPanelRefresh: false });
-    }
+    await this.props.onRefresh();
   }
 
   togglePanelVisibility() {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description

Info panel may show stale data of unrelated objects when navigating between classes.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved panel refresh behavior to immediately clear and reset panel state when refreshing while a panel is visible.
  * Fixed UI state management to automatically clear selections and loading indicators when data changes or becomes unavailable.
  * Ensured a consistent "No object selected" display when multi-panel views have no items.

* **Enhancements**
  * Render an aggregation panel with an explicit empty state in multi-panel mode to avoid blank areas.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->