### PR TITLE
fix: Info panel not refreshing on script execution

### DIFF
--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -275,7 +275,8 @@ export default class DataBrowser extends React.Component {
         selectedObjectId: undefined,
         showAggregatedData: true, // Keep true to show "No object selected" message
         multiPanelData: {},
-        displayedObjectIds: []
+        displayedObjectIds: [],
+        prefetchCache: {}, // Clear cache when switching classes to prevent memory leak
       });
     }
 
@@ -293,7 +294,8 @@ export default class DataBrowser extends React.Component {
         selectedObjectId: undefined,
         showAggregatedData: true, // Keep true to show "No object selected" message
         multiPanelData: {},
-        displayedObjectIds: []
+        displayedObjectIds: [],
+        prefetchCache: {}, // Clear cache to prevent memory leak
       });
     }
 

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -263,30 +263,17 @@ export default class DataBrowser extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    // Clear panels immediately when className changes
-    if (
-      this.props.className !== prevProps.className &&
-      this.state.isPanelVisible
-    ) {
-      // Clear panel data and selection to show "No object selected"
-      this.props.setAggregationPanelData({});
-      this.props.setLoadingInfoPanel(false);
-      this.setState({
-        selectedObjectId: undefined,
-        showAggregatedData: true, // Keep true to show "No object selected" message
-        multiPanelData: {},
-        displayedObjectIds: [],
-        prefetchCache: {}, // Clear cache when switching classes to prevent memory leak
-      });
-    }
+    // Clear panels when className changes, data becomes null, or data reloads
+    const shouldClearPanels = this.state.isPanelVisible && (
+      // Class changed
+      this.props.className !== prevProps.className ||
+      // Data became null (filter change, loading state)
+      (this.props.data === null && prevProps.data !== null) ||
+      // Data reloaded (script execution, refresh)
+      (this.props.data !== null && prevProps.data !== null && this.props.data !== prevProps.data)
+    );
 
-    // Clear panels when data becomes null (filter change, class change, etc.)
-    if (
-      this.props.data === null &&
-      prevProps.data !== null &&
-      this.state.isPanelVisible &&
-      this.state.selectedObjectId !== undefined
-    ) {
+    if (shouldClearPanels) {
       // Clear panel data and selection to show "No object selected"
       this.props.setAggregationPanelData({});
       this.props.setLoadingInfoPanel(false);
@@ -296,26 +283,6 @@ export default class DataBrowser extends React.Component {
         multiPanelData: {},
         displayedObjectIds: [],
         prefetchCache: {}, // Clear cache to prevent memory leak
-      });
-    }
-
-    // Clear panels when data reloads (e.g., after script execution, refresh, filter change)
-    if (
-      this.props.data !== null &&
-      prevProps.data !== null &&
-      this.props.data !== prevProps.data &&
-      this.state.isPanelVisible &&
-      (this.state.selectedObjectId !== undefined || this.state.displayedObjectIds.length > 0)
-    ) {
-      // Clear panel data and selection to show "No object selected"
-      this.props.setAggregationPanelData({});
-      this.props.setLoadingInfoPanel(false);
-      this.setState({
-        selectedObjectId: undefined,
-        showAggregatedData: true, // Keep true to show "No object selected" message
-        multiPanelData: {},
-        displayedObjectIds: [],
-        prefetchCache: {}, // Also clear the cache since data has changed
       });
     }
 

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -297,6 +297,26 @@ export default class DataBrowser extends React.Component {
       });
     }
 
+    // Clear panels when data reloads (e.g., after script execution, refresh, filter change)
+    if (
+      this.props.data !== null &&
+      prevProps.data !== null &&
+      this.props.data !== prevProps.data &&
+      this.state.isPanelVisible &&
+      (this.state.selectedObjectId !== undefined || this.state.displayedObjectIds.length > 0)
+    ) {
+      // Clear panel data and selection to show "No object selected"
+      this.props.setAggregationPanelData({});
+      this.props.setLoadingInfoPanel(false);
+      this.setState({
+        selectedObjectId: undefined,
+        showAggregatedData: true, // Keep true to show "No object selected" message
+        multiPanelData: {},
+        displayedObjectIds: [],
+        prefetchCache: {}, // Also clear the cache since data has changed
+      });
+    }
+
     if (
       this.state.current === null &&
       this.state.selectedObjectId !== undefined &&


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description

The info panel is not refreshing on script execution, even though the data in the data browser table may have changed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced data state handling in the Data Browser component to safely clear aggregation panels during data transitions, including when data becomes null or is reloaded, improving stability.

* **Refactor**
  * Consolidated aggregation panel clearing logic for improved maintainability and memory efficiency through optimized cache and data invalidation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->