### PR TITLE
fix: Batch-navigation is active even if info panels are not visible

### DIFF
--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -740,7 +740,7 @@ export default class DataBrowser extends React.Component {
         // or with ctrl/meta (excel style - move to the first row)
         const prevObjectID = this.state.selectedObjectId;
         // Calculate step size based on batch navigation mode
-        const stepSize = this.state.panelCount > 1 && this.state.batchNavigate ? this.state.panelCount : 1;
+        const stepSize = this.state.panelCount > 1 && this.state.batchNavigate && this.state.isPanelVisible ? this.state.panelCount : 1;
         const newRow = e.ctrlKey || e.metaKey ? 0 : Math.max(this.state.current.row - stepSize, 0);
         this.setState({
           current: {
@@ -785,7 +785,7 @@ export default class DataBrowser extends React.Component {
         // or with ctrl/meta (excel style - move to the last row)
         const prevObjectID = this.state.selectedObjectId;
         // Calculate step size based on batch navigation mode
-        const stepSizeDown = this.state.panelCount > 1 && this.state.batchNavigate ? this.state.panelCount : 1;
+        const stepSizeDown = this.state.panelCount > 1 && this.state.batchNavigate && this.state.isPanelVisible ? this.state.panelCount : 1;
         const newRow =
           e.ctrlKey || e.metaKey
             ? this.props.data.length - 1


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

When option "Batch-navigate panels" is enabled, then even if panels are not visible, the navigation happens in batches. Instead, if panels are hidden, or a class has no panels at all, then navigation should not be in batches.

### Approach

Now the batch navigation will only occur when all three conditions are met:

- panelCount > 1 (multiple panels are configured)
- batchNavigate is enabled (user has enabled the "Batch-navigate panels" option)
- isPanelVisible is true (panels are actually visible/shown)

If panels are hidden or a class has no panels at all, navigation will happen one row at a time, as expected.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved row navigation behavior: arrow key navigation now adjusts based on panel visibility, enabling batch navigation when panels are visible and single-step navigation when panels are hidden.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->