### PR TITLE
fix: Data browser table headers misaligned when scrolling horizontally

### DIFF
--- a/src/components/DataBrowserHeaderBar/DataBrowserHeaderBar.scss
+++ b/src/components/DataBrowserHeaderBar/DataBrowserHeaderBar.scss
@@ -15,10 +15,12 @@
   height: 0;
   background: #66637a;
   white-space: nowrap;
-  display: inline-block;
+  display: block;
   min-width: 100%;
+  width: max-content;
   // to resolve rendering issue with retina displays
   -webkit-transform: translate3d(0, 0, 0);
+  will-change: transform;
 }
 
 .wrap {

--- a/src/dashboard/Data/Browser/Browser.scss
+++ b/src/dashboard/Data/Browser/Browser.scss
@@ -94,6 +94,7 @@ body:global(.expanded) {
   white-space: nowrap;
   height: 30px;
   border-bottom: 1px solid #e3e3ea;
+  will-change: transform;
 
   &:nth-child(odd) {
     background: #f4f5f7;


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description

1. Open class and scroll to right.
2. Click on other class and headers appear are misaligned.

### Approach

Improve pos calc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Optimized CSS rendering performance and adjusted layout efficiency for data browser interface components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->