### PR TITLE
fix: Right-click on info panel header selects the object

### DIFF
--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -1783,6 +1783,10 @@ export default class DataBrowser extends React.Component {
                                 <div
                                   className={styles.panelHeader}
                                   onMouseDown={(e) => {
+                                    // Ignore right-click (button 2) and middle-click (button 1)
+                                    if (e.button !== 0) {
+                                      return;
+                                    }
                                     e.preventDefault();
                                     this.onMouseDownPanelCheckBox(objectId, isRowSelected);
                                   }}


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description

Right-click on info panel header selects the object, but it should only be selected on left-click.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Data Browser checkbox interaction handling. Checkboxes in the panel header now respond exclusively to left-click inputs, with right-click and middle-click properly ignored. This prevents accidental checkbox toggling from alternative mouse button interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->