### PR TITLE
feat: Add getting related records to context menu of info panel header

### DIFF
--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -1097,11 +1097,9 @@ export default class DataBrowser extends React.Component {
             text: `${className}`,
             subtext: `${field}`,
             callback: () => {
-              const relatedObject = new Parse.Object(pointerClassName);
-              relatedObject.id = objectId;
               onPointerCmdClick({
                 className,
-                id: relatedObject.toPointer(),
+                id: objectId,
                 field,
               });
             },

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -1074,9 +1074,9 @@ export default class DataBrowser extends React.Component {
   }
 
   getRelatedObjectsMenuItemForPanel(objectId, pointerClassName) {
-    const { schema, onPointerClick } = this.props;
+    const { schema, onPointerCmdClick } = this.props;
 
-    if (!pointerClassName || !schema || !onPointerClick) {
+    if (!pointerClassName || !schema || !onPointerCmdClick) {
       return undefined;
     }
 
@@ -1099,7 +1099,7 @@ export default class DataBrowser extends React.Component {
             callback: () => {
               const relatedObject = new Parse.Object(pointerClassName);
               relatedObject.id = objectId;
-              onPointerClick({
+              onPointerCmdClick({
                 className,
                 id: relatedObject.toPointer(),
                 field,

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -1031,6 +1031,12 @@ export default class DataBrowser extends React.Component {
 
     const menuItems = [];
 
+    // Add "Get related records from..." menu item
+    const relatedRecordsMenuItem = this.getRelatedObjectsMenuItemForPanel(objectId, className);
+    if (relatedRecordsMenuItem) {
+      menuItems.push(relatedRecordsMenuItem);
+    }
+
     // Add Scripts menu if there are valid scripts
     if (validScripts.length && this.props.onEditSelectedRow) {
       menuItems.push({
@@ -1065,6 +1071,45 @@ export default class DataBrowser extends React.Component {
     if (menuItems.length) {
       this.setContextMenu(pageX, pageY, menuItems);
     }
+  }
+
+  getRelatedObjectsMenuItemForPanel(objectId, pointerClassName) {
+    const { schema, onPointerClick } = this.props;
+
+    if (!pointerClassName || !schema || !onPointerClick) {
+      return undefined;
+    }
+
+    const relatedRecordsMenuItem = {
+      text: 'Get related records from...',
+      items: [],
+    };
+
+    schema.data
+      .get('classes')
+      .sortBy((v, k) => k)
+      .forEach((cl, className) => {
+        cl.forEach((column, field) => {
+          if (column.targetClass !== pointerClassName) {
+            return;
+          }
+          relatedRecordsMenuItem.items.push({
+            text: `${className}`,
+            subtext: `${field}`,
+            callback: () => {
+              const relatedObject = new Parse.Object(pointerClassName);
+              relatedObject.id = objectId;
+              onPointerClick({
+                className,
+                id: relatedObject.toPointer(),
+                field,
+              });
+            },
+          });
+        });
+      });
+
+    return relatedRecordsMenuItem.items.length ? relatedRecordsMenuItem : undefined;
   }
 
   freezeColumns(index) {

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -1097,9 +1097,11 @@ export default class DataBrowser extends React.Component {
             text: `${className}`,
             subtext: `${field}`,
             callback: () => {
+              const relatedObject = new Parse.Object(pointerClassName);
+              relatedObject.id = objectId;
               onPointerCmdClick({
                 className,
-                id: objectId,
+                id: relatedObject.toPointer(),
                 field,
               });
             },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added context menu options in the Data Browser to quickly access related records. Users can open related data from both the panel header and main header menus, making it easier to navigate connected records directly from context menus. The new items appear alongside existing menu options for faster data exploration and discovery.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->