### PR TITLE
feat: Add storing data browser filters on server

### DIFF
--- a/src/components/CategoryList/CategoryList.react.js
+++ b/src/components/CategoryList/CategoryList.react.js
@@ -36,7 +36,8 @@ export default class CategoryList extends React.Component {
 
   componentDidUpdate(prevProps) {
     // Auto-expand if the URL params changed (e.g., user navigated to a different filter)
-    if (prevProps.params !== this.props.params) {
+    // OR if categories changed (e.g., filters finished loading asynchronously)
+    if (prevProps.params !== this.props.params || prevProps.categories !== this.props.categories) {
       this._autoExpandForSelectedFilter();
     }
     this._updateHighlight();

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -1423,15 +1423,16 @@ class Browser extends DashboardView {
         });
       }
     } else {
-      // Check if this is updating a legacy filter (no filterId but filter content matches existing filter without ID)
-      const existingLegacyFilterIndex = preferences.filters.findIndex(filter =>
-        !filter.id && filter.name === name && filter.filter === _filters
+      // Check if this is updating an existing filter by name and content match
+      // (legacy filters get auto-assigned UUIDs when read, so we match by content)
+      const existingFilterIndex = preferences.filters.findIndex(filter =>
+        filter.name === name && filter.filter === _filters
       );
 
-      if (existingLegacyFilterIndex !== -1) {
-        // Convert legacy filter to modern filter by adding an ID
-        newFilterId = crypto.randomUUID();
-        preferences.filters[existingLegacyFilterIndex] = {
+      if (existingFilterIndex !== -1) {
+        // Update existing filter, keeping its ID
+        newFilterId = preferences.filters[existingFilterIndex].id;
+        preferences.filters[existingFilterIndex] = {
           name,
           id: newFilterId,
           filter: _filters,

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -312,16 +312,12 @@ class Browser extends DashboardView {
   }
 
   async loadAllClassFilters() {
-    console.log('[Browser] loadAllClassFilters - Starting...');
-
     if (!this.filterPreferencesManager) {
-      console.log('[Browser] loadAllClassFilters - No filterPreferencesManager, aborting');
       return;
     }
 
     const schema = this.props.schema;
     if (!schema || !schema.data) {
-      console.log('[Browser] loadAllClassFilters - No schema data, aborting');
       return;
     }
 
@@ -331,28 +327,23 @@ class Browser extends DashboardView {
     const classList = schema.data.get('classes');
     if (classList) {
       const classNames = Object.keys(classList.toObject());
-      console.log('[Browser] loadAllClassFilters - Loading filters for', classNames.length, 'classes:', classNames);
       await Promise.all(
         classNames.map(async (className) => {
-          console.log('[Browser] loadAllClassFilters - Loading filters for class:', className);
           try {
             const filters = await this.filterPreferencesManager.getFilters(
               this.context.applicationId,
               className
             );
-            console.log('[Browser] loadAllClassFilters - Filters loaded for', className, ':', filters);
             classFilters[className] = filters || [];
           } catch (error) {
-            console.error(`[Browser] loadAllClassFilters - Failed to load filters for class ${className}:`, error);
+            console.error(`Failed to load filters for class ${className}:`, error);
             classFilters[className] = [];
           }
         })
       );
     }
 
-    console.log('[Browser] loadAllClassFilters - Setting state with classFilters:', classFilters);
     this.setState({ classFilters });
-    console.log('[Browser] loadAllClassFilters - State updated');
   }
 
   componentWillUnmount() {
@@ -2384,23 +2375,18 @@ class Browser extends DashboardView {
     for (const row of [...special, ...categories]) {
       let filters = this.state.classFilters[row.name];
 
-      console.log('[Browser] Render - Processing class:', row.name, 'filters from state:', filters);
-
       // Fallback to local storage ONLY if not using server storage and filters not loaded yet
       if (filters === undefined &&
           (!this.filterPreferencesManager?.isServerConfigEnabled() ||
            !prefersServerStorage(this.context.applicationId))) {
         const prefs = ClassPreferences.getPreferences(this.context.applicationId, row.name);
         filters = prefs?.filters || [];
-        console.log('[Browser] Render - Using local fallback for', row.name, ':', filters);
       } else if (filters === undefined) {
         filters = [];
-        console.log('[Browser] Render - No filters available for', row.name, '(server mode, no fallback)');
       }
 
       // Set filters sorted alphabetically and create a new row object to trigger re-render
       const sortedFilters = filters.sort((a, b) => a.name.localeCompare(b.name));
-      console.log('[Browser] Render - Final filters for', row.name, ':', sortedFilters);
       allCategories.push({
         ...row,
         filters: sortedFilters

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -38,6 +38,7 @@ import { ActionTypes } from 'lib/stores/SchemaStore';
 import stringCompare from 'lib/stringCompare';
 import subscribeTo from 'lib/subscribeTo';
 import { withRouter } from 'lib/withRouter';
+import FilterPreferencesManager from 'lib/FilterPreferencesManager';
 import Parse from 'parse';
 import React from 'react';
 import { Helmet } from 'react-helmet';
@@ -129,6 +130,7 @@ class Browser extends DashboardView {
     this.subsection = 'Browser';
     this.noteTimeout = null;
     this.currentQuery = null;
+    this.filterPreferencesManager = null;
     const limit = window.localStorage?.getItem('browserLimit');
 
     this.state = {
@@ -298,6 +300,11 @@ class Browser extends DashboardView {
       this.setState({ configData: data });
       this.classAndCloudFuntionMap(this.state.configData);
     });
+
+    // Initialize FilterPreferencesManager
+    if (this.context) {
+      this.filterPreferencesManager = new FilterPreferencesManager(this.context);
+    }
   }
 
   componentWillUnmount() {
@@ -1294,7 +1301,7 @@ class Browser extends DashboardView {
     });
   }
 
-  saveFilters(filters, name, relativeDate, filterId = null) {
+  async saveFilters(filters, name, relativeDate, filterId = null) {
     const jsonFilters = filters.toJSON();
     if (relativeDate && jsonFilters?.length) {
       for (let i = 0; i < jsonFilters.length; i++) {
@@ -1388,11 +1395,28 @@ class Browser extends DashboardView {
       }
     }
 
-    ClassPreferences.updatePreferences(
-      preferences,
-      this.context.applicationId,
-      this.props.params.className
-    );
+    // Use FilterPreferencesManager if available, otherwise fallback to local storage
+    if (this.filterPreferencesManager) {
+      const filterToSave = {
+        id: newFilterId,
+        name,
+        className: this.props.params.className,
+        filter: _filters,
+      };
+      await this.filterPreferencesManager.saveFilter(
+        this.context.applicationId,
+        this.props.params.className,
+        filterToSave,
+        preferences.filters
+      );
+    } else {
+      // Fallback to local storage
+      ClassPreferences.updatePreferences(
+        preferences,
+        this.context.applicationId,
+        this.props.params.className
+      );
+    }
 
     super.forceUpdate();
 
@@ -1400,7 +1424,7 @@ class Browser extends DashboardView {
     return newFilterId;
   }
 
-  deleteFilter(filterIdOrObject) {
+  async deleteFilter(filterIdOrObject) {
     const preferences = ClassPreferences.getPreferences(
       this.context.applicationId,
       this.props.params.className
@@ -1425,11 +1449,22 @@ class Browser extends DashboardView {
         }
       }
 
-      ClassPreferences.updatePreferences(
-        { ...preferences, filters: updatedFilters },
-        this.context.applicationId,
-        this.props.params.className
-      );
+      // Use FilterPreferencesManager if available, otherwise fallback to local storage
+      if (this.filterPreferencesManager) {
+        await this.filterPreferencesManager.deleteFilter(
+          this.context.applicationId,
+          this.props.params.className,
+          filterIdOrObject,
+          updatedFilters
+        );
+      } else {
+        // Fallback to local storage
+        ClassPreferences.updatePreferences(
+          { ...preferences, filters: updatedFilters },
+          this.context.applicationId,
+          this.props.params.className
+        );
+      }
     }
 
     super.forceUpdate();

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -307,20 +307,14 @@ class Browser extends DashboardView {
     if (this.context) {
       this.filterPreferencesManager = new FilterPreferencesManager(this.context);
       // Load all class filters if schema is already available
-      console.log('[DEBUG] componentDidMount - schema available?', !!this.props.schema?.data?.get('classes'));
       if (this.props.schema?.data?.get('classes')) {
-        console.log('[DEBUG] componentDidMount - calling loadAllClassFilters');
         this.loadAllClassFilters();
-      } else {
-        console.log('[DEBUG] componentDidMount - schema not ready, waiting for componentWillReceiveProps');
       }
     }
   }
 
   async loadAllClassFilters(propsToUse) {
-    console.log('[DEBUG] loadAllClassFilters called');
     if (!this.filterPreferencesManager) {
-      console.log('[DEBUG] loadAllClassFilters - no filterPreferencesManager');
       return;
     }
 
@@ -328,7 +322,6 @@ class Browser extends DashboardView {
     const props = propsToUse || this.props;
     const schema = props.schema;
     if (!schema || !schema.data) {
-      console.log('[DEBUG] loadAllClassFilters - no schema or schema.data');
       return;
     }
 
@@ -338,7 +331,6 @@ class Browser extends DashboardView {
     const classList = schema.data.get('classes');
     if (classList) {
       const classNames = Object.keys(classList.toObject());
-      console.log('[DEBUG] loadAllClassFilters - loading filters for classes:', classNames);
       await Promise.all(
         classNames.map(async (className) => {
           try {
@@ -346,7 +338,6 @@ class Browser extends DashboardView {
               this.context.applicationId,
               className
             );
-            console.log(`[DEBUG] loadAllClassFilters - loaded ${filters?.length || 0} filters for ${className}`);
             classFilters[className] = filters || [];
           } catch (error) {
             console.error(`Failed to load filters for class ${className}:`, error);
@@ -356,7 +347,6 @@ class Browser extends DashboardView {
       );
     }
 
-    console.log('[DEBUG] loadAllClassFilters - setting state with classFilters:', classFilters);
     this.setState({ classFilters });
   }
 
@@ -402,19 +392,12 @@ class Browser extends DashboardView {
     }
 
     // Load filters when schema becomes available or changes
-    console.log('[DEBUG] componentWillReceiveProps - checking filters load condition');
-    console.log('[DEBUG] nextProps has schema?', !!nextProps.schema?.data?.get('classes'));
-    console.log('[DEBUG] this.props had schema?', !!this.props.schema?.data?.get('classes'));
-    console.log('[DEBUG] appId changed?', this.props.params.appId !== nextProps.params.appId);
     if (
       nextProps.schema?.data?.get('classes') &&
       (!this.props.schema?.data?.get('classes') ||
         this.props.params.appId !== nextProps.params.appId)
     ) {
-      console.log('[DEBUG] componentWillReceiveProps - calling loadAllClassFilters with nextProps');
       this.loadAllClassFilters(nextProps);
-    } else {
-      console.log('[DEBUG] componentWillReceiveProps - NOT calling loadAllClassFilters');
     }
   }
 
@@ -2393,10 +2376,8 @@ class Browser extends DashboardView {
       special.push({ type: 'separator', id: 'classSeparator' });
     }
     const allCategories = [];
-    console.log('[DEBUG] render - state.classFilters:', this.state.classFilters);
     for (const row of [...special, ...categories]) {
       let filters = this.state.classFilters[row.name];
-      console.log(`[DEBUG] render - ${row.name}: filters from state =`, filters);
 
       // Fallback to local storage ONLY if not using server storage and filters not loaded yet
       if (filters === undefined &&
@@ -2404,10 +2385,8 @@ class Browser extends DashboardView {
            !prefersServerStorage(this.context.applicationId))) {
         const prefs = ClassPreferences.getPreferences(this.context.applicationId, row.name);
         filters = prefs?.filters || [];
-        console.log(`[DEBUG] render - ${row.name}: using local fallback, filters =`, filters);
       } else if (filters === undefined) {
         filters = [];
-        console.log(`[DEBUG] render - ${row.name}: filters undefined, using empty array`);
       }
 
       // Set filters sorted alphabetically and create a new row object to trigger re-render

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -39,6 +39,7 @@ import stringCompare from 'lib/stringCompare';
 import subscribeTo from 'lib/subscribeTo';
 import { withRouter } from 'lib/withRouter';
 import FilterPreferencesManager from 'lib/FilterPreferencesManager';
+import { prefersServerStorage } from 'lib/StoragePreferences';
 import Parse from 'parse';
 import React from 'react';
 import { Helmet } from 'react-helmet';
@@ -190,6 +191,7 @@ class Browser extends DashboardView {
       AggregationPanelData: {},
       isLoadingInfoPanel: false,
       errorAggregatedData: {},
+      classFilters: {}, // Map of className -> filters array
     };
 
     this.addLocation = this.addLocation.bind(this);
@@ -304,7 +306,53 @@ class Browser extends DashboardView {
     // Initialize FilterPreferencesManager
     if (this.context) {
       this.filterPreferencesManager = new FilterPreferencesManager(this.context);
+      // Load all class filters
+      this.loadAllClassFilters();
     }
+  }
+
+  async loadAllClassFilters() {
+    console.log('[Browser] loadAllClassFilters - Starting...');
+
+    if (!this.filterPreferencesManager) {
+      console.log('[Browser] loadAllClassFilters - No filterPreferencesManager, aborting');
+      return;
+    }
+
+    const schema = this.props.schema;
+    if (!schema || !schema.data) {
+      console.log('[Browser] loadAllClassFilters - No schema data, aborting');
+      return;
+    }
+
+    const classFilters = {};
+
+    // Load filters for all classes
+    const classList = schema.data.get('classes');
+    if (classList) {
+      const classNames = Object.keys(classList.toObject());
+      console.log('[Browser] loadAllClassFilters - Loading filters for', classNames.length, 'classes:', classNames);
+      await Promise.all(
+        classNames.map(async (className) => {
+          console.log('[Browser] loadAllClassFilters - Loading filters for class:', className);
+          try {
+            const filters = await this.filterPreferencesManager.getFilters(
+              this.context.applicationId,
+              className
+            );
+            console.log('[Browser] loadAllClassFilters - Filters loaded for', className, ':', filters);
+            classFilters[className] = filters || [];
+          } catch (error) {
+            console.error(`[Browser] loadAllClassFilters - Failed to load filters for class ${className}:`, error);
+            classFilters[className] = [];
+          }
+        })
+      );
+    }
+
+    console.log('[Browser] loadAllClassFilters - Setting state with classFilters:', classFilters);
+    this.setState({ classFilters });
+    console.log('[Browser] loadAllClassFilters - State updated');
   }
 
   componentWillUnmount() {
@@ -346,6 +394,15 @@ class Browser extends DashboardView {
         nextProps.schema.data.get('classes')
       );
       this.redirectToFirstClass(nextProps.schema.data.get('classes'), nextContext);
+    }
+
+    // Load filters when schema becomes available or changes
+    if (
+      nextProps.schema?.data?.get('classes') &&
+      (!this.props.schema?.data?.get('classes') ||
+        this.props.params.appId !== nextProps.params.appId)
+    ) {
+      this.loadAllClassFilters();
     }
   }
 
@@ -1418,10 +1475,34 @@ class Browser extends DashboardView {
       );
     }
 
+    // Reload filters for this class to update the sidebar
+    await this.reloadClassFilters(this.props.params.className);
+
     super.forceUpdate();
 
     // Return the filter ID for new filters so the caller can apply them
     return newFilterId;
+  }
+
+  async reloadClassFilters(className) {
+    if (!this.filterPreferencesManager) {
+      return;
+    }
+
+    try {
+      const filters = await this.filterPreferencesManager.getFilters(
+        this.context.applicationId,
+        className
+      );
+      this.setState(prevState => ({
+        classFilters: {
+          ...prevState.classFilters,
+          [className]: filters || []
+        }
+      }));
+    } catch (error) {
+      console.error(`Failed to reload filters for class ${className}:`, error);
+    }
   }
 
   async deleteFilter(filterIdOrObject) {
@@ -1466,6 +1547,9 @@ class Browser extends DashboardView {
         );
       }
     }
+
+    // Reload filters for this class to update the sidebar
+    await this.reloadClassFilters(this.props.params.className);
 
     super.forceUpdate();
   }
@@ -2298,13 +2382,29 @@ class Browser extends DashboardView {
     }
     const allCategories = [];
     for (const row of [...special, ...categories]) {
-      const { filters = [] } = ClassPreferences.getPreferences(
-        this.context.applicationId,
-        row.name
-      );
-      // Set filters sorted alphabetically
-      row.filters = filters.sort((a, b) => a.name.localeCompare(b.name));
-      allCategories.push(row);
+      let filters = this.state.classFilters[row.name];
+
+      console.log('[Browser] Render - Processing class:', row.name, 'filters from state:', filters);
+
+      // Fallback to local storage ONLY if not using server storage and filters not loaded yet
+      if (filters === undefined &&
+          (!this.filterPreferencesManager?.isServerConfigEnabled() ||
+           !prefersServerStorage(this.context.applicationId))) {
+        const prefs = ClassPreferences.getPreferences(this.context.applicationId, row.name);
+        filters = prefs?.filters || [];
+        console.log('[Browser] Render - Using local fallback for', row.name, ':', filters);
+      } else if (filters === undefined) {
+        filters = [];
+        console.log('[Browser] Render - No filters available for', row.name, '(server mode, no fallback)');
+      }
+
+      // Set filters sorted alphabetically and create a new row object to trigger re-render
+      const sortedFilters = filters.sort((a, b) => a.name.localeCompare(b.name));
+      console.log('[Browser] Render - Final filters for', row.name, ':', sortedFilters);
+      allCategories.push({
+        ...row,
+        filters: sortedFilters
+      });
     }
 
     return (

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -306,18 +306,29 @@ class Browser extends DashboardView {
     // Initialize FilterPreferencesManager
     if (this.context) {
       this.filterPreferencesManager = new FilterPreferencesManager(this.context);
-      // Load all class filters
-      this.loadAllClassFilters();
+      // Load all class filters if schema is already available
+      console.log('[DEBUG] componentDidMount - schema available?', !!this.props.schema?.data?.get('classes'));
+      if (this.props.schema?.data?.get('classes')) {
+        console.log('[DEBUG] componentDidMount - calling loadAllClassFilters');
+        this.loadAllClassFilters();
+      } else {
+        console.log('[DEBUG] componentDidMount - schema not ready, waiting for componentWillReceiveProps');
+      }
     }
   }
 
-  async loadAllClassFilters() {
+  async loadAllClassFilters(propsToUse) {
+    console.log('[DEBUG] loadAllClassFilters called');
     if (!this.filterPreferencesManager) {
+      console.log('[DEBUG] loadAllClassFilters - no filterPreferencesManager');
       return;
     }
 
-    const schema = this.props.schema;
+    // Use provided props or fall back to this.props
+    const props = propsToUse || this.props;
+    const schema = props.schema;
     if (!schema || !schema.data) {
+      console.log('[DEBUG] loadAllClassFilters - no schema or schema.data');
       return;
     }
 
@@ -327,6 +338,7 @@ class Browser extends DashboardView {
     const classList = schema.data.get('classes');
     if (classList) {
       const classNames = Object.keys(classList.toObject());
+      console.log('[DEBUG] loadAllClassFilters - loading filters for classes:', classNames);
       await Promise.all(
         classNames.map(async (className) => {
           try {
@@ -334,6 +346,7 @@ class Browser extends DashboardView {
               this.context.applicationId,
               className
             );
+            console.log(`[DEBUG] loadAllClassFilters - loaded ${filters?.length || 0} filters for ${className}`);
             classFilters[className] = filters || [];
           } catch (error) {
             console.error(`Failed to load filters for class ${className}:`, error);
@@ -343,6 +356,7 @@ class Browser extends DashboardView {
       );
     }
 
+    console.log('[DEBUG] loadAllClassFilters - setting state with classFilters:', classFilters);
     this.setState({ classFilters });
   }
 
@@ -388,12 +402,19 @@ class Browser extends DashboardView {
     }
 
     // Load filters when schema becomes available or changes
+    console.log('[DEBUG] componentWillReceiveProps - checking filters load condition');
+    console.log('[DEBUG] nextProps has schema?', !!nextProps.schema?.data?.get('classes'));
+    console.log('[DEBUG] this.props had schema?', !!this.props.schema?.data?.get('classes'));
+    console.log('[DEBUG] appId changed?', this.props.params.appId !== nextProps.params.appId);
     if (
       nextProps.schema?.data?.get('classes') &&
       (!this.props.schema?.data?.get('classes') ||
         this.props.params.appId !== nextProps.params.appId)
     ) {
-      this.loadAllClassFilters();
+      console.log('[DEBUG] componentWillReceiveProps - calling loadAllClassFilters with nextProps');
+      this.loadAllClassFilters(nextProps);
+    } else {
+      console.log('[DEBUG] componentWillReceiveProps - NOT calling loadAllClassFilters');
     }
   }
 
@@ -2372,8 +2393,10 @@ class Browser extends DashboardView {
       special.push({ type: 'separator', id: 'classSeparator' });
     }
     const allCategories = [];
+    console.log('[DEBUG] render - state.classFilters:', this.state.classFilters);
     for (const row of [...special, ...categories]) {
       let filters = this.state.classFilters[row.name];
+      console.log(`[DEBUG] render - ${row.name}: filters from state =`, filters);
 
       // Fallback to local storage ONLY if not using server storage and filters not loaded yet
       if (filters === undefined &&
@@ -2381,8 +2404,10 @@ class Browser extends DashboardView {
            !prefersServerStorage(this.context.applicationId))) {
         const prefs = ClassPreferences.getPreferences(this.context.applicationId, row.name);
         filters = prefs?.filters || [];
+        console.log(`[DEBUG] render - ${row.name}: using local fallback, filters =`, filters);
       } else if (filters === undefined) {
         filters = [];
+        console.log(`[DEBUG] render - ${row.name}: filters undefined, using empty array`);
       }
 
       // Set filters sorted alphabetically and create a new row object to trigger re-render

--- a/src/dashboard/Settings/DashboardSettings/DashboardSettings.react.js
+++ b/src/dashboard/Settings/DashboardSettings/DashboardSettings.react.js
@@ -18,6 +18,7 @@ import Notification from 'dashboard/Data/Browser/Notification.react';
 import * as ColumnPreferences from 'lib/ColumnPreferences';
 import * as ClassPreferences from 'lib/ClassPreferences';
 import ViewPreferencesManager from 'lib/ViewPreferencesManager';
+import FilterPreferencesManager from 'lib/FilterPreferencesManager';
 import ScriptManager from 'lib/ScriptManager';
 import bcrypt from 'bcryptjs';
 import * as OTPAuth from 'otpauth';
@@ -29,6 +30,7 @@ export default class DashboardSettings extends DashboardView {
     this.section = 'App Settings';
     this.subsection = 'Dashboard Configuration';
     this.viewPreferencesManager = null;
+    this.filterPreferencesManager = null;
     this.scriptManager = null;
 
     this.state = {
@@ -65,6 +67,7 @@ export default class DashboardSettings extends DashboardView {
   initializeManagers() {
     if (this.context) {
       this.viewPreferencesManager = new ViewPreferencesManager(this.context);
+      this.filterPreferencesManager = new FilterPreferencesManager(this.context);
       this.scriptManager = new ScriptManager(this.context);
       this.loadStoragePreference();
     }
@@ -85,11 +88,21 @@ export default class DashboardSettings extends DashboardView {
       // Show a notification about the change
       this.showNote(`Storage preference changed to ${preference === 'server' ? 'server' : 'browser'}`);
     }
+
+    // Filters use the same storage preference as views
+    if (this.filterPreferencesManager) {
+      this.filterPreferencesManager.setStoragePreference(this.context.applicationId, preference);
+    }
   }
 
   async migrateToServer() {
     if (!this.viewPreferencesManager) {
       this.showNote('ViewPreferencesManager not initialized');
+      return;
+    }
+
+    if (!this.filterPreferencesManager) {
+      this.showNote('FilterPreferencesManager not initialized');
       return;
     }
 
@@ -101,16 +114,30 @@ export default class DashboardSettings extends DashboardView {
     this.setState({ migrationLoading: true });
 
     try {
-      const result = await this.viewPreferencesManager.migrateToServer(this.context.applicationId);
-      if (result.success) {
-        if (result.viewCount > 0) {
-          this.showNote(`Successfully migrated ${result.viewCount} view(s) to server storage.`);
+      // Migrate views
+      const viewsResult = await this.viewPreferencesManager.migrateToServer(this.context.applicationId);
+
+      // Migrate filters
+      const filtersResult = await this.filterPreferencesManager.migrateToServer(this.context.applicationId);
+
+      const totalItems = viewsResult.viewCount + filtersResult.filterCount;
+
+      if (viewsResult.success && filtersResult.success) {
+        if (totalItems > 0) {
+          const messages = [];
+          if (viewsResult.viewCount > 0) {
+            messages.push(`${viewsResult.viewCount} view(s)`);
+          }
+          if (filtersResult.filterCount > 0) {
+            messages.push(`${filtersResult.filterCount} filter(s)`);
+          }
+          this.showNote(`Successfully migrated ${messages.join(' and ')} to server storage.`);
         } else {
-          this.showNote('No views found to migrate.');
+          this.showNote('No views or filters found to migrate.');
         }
       }
     } catch (error) {
-      this.showNote(`Failed to migrate views: ${error.message}`);
+      this.showNote(`Failed to migrate settings: ${error.message}`);
     } finally {
       this.setState({ migrationLoading: false });
     }
@@ -126,15 +153,21 @@ export default class DashboardSettings extends DashboardView {
       return;
     }
 
+    if (!this.filterPreferencesManager) {
+      this.showNote('FilterPreferencesManager not initialized');
+      return;
+    }
+
     if (!this.scriptManager) {
       this.showNote('ScriptManager not initialized');
       return;
     }
 
     const viewsSuccess = this.viewPreferencesManager.deleteFromBrowser(this.context.applicationId);
+    const filtersSuccess = this.filterPreferencesManager.deleteFromBrowser(this.context.applicationId);
     const scriptsSuccess = this.scriptManager.deleteFromBrowser(this.context.applicationId);
 
-    if (viewsSuccess && scriptsSuccess) {
+    if (viewsSuccess && filtersSuccess && scriptsSuccess) {
       this.showNote('Successfully deleted dashboard settings from browser storage.');
     } else {
       this.showNote('Failed to delete all dashboard settings from browser storage.');
@@ -474,7 +507,7 @@ export default class DashboardSettings extends DashboardView {
         {this.viewPreferencesManager && this.scriptManager && this.viewPreferencesManager.isServerConfigEnabled() && (
           <Fieldset legend="Settings Storage">
             <div style={{ marginBottom: '20px', color: '#666', fontSize: '14px', textAlign: 'center' }}>
-              Storing dashboard settings on the server rather than locally in the browser storage makes the settings available across devices and browsers. It also prevents them from getting lost when resetting the browser website data. Settings that can be stored on the server are currently Views, Keyboard Shortcuts and JS Console scripts.
+              Storing dashboard settings on the server rather than locally in the browser storage makes the settings available across devices and browsers. It also prevents them from getting lost when resetting the browser website data. Settings that can be stored on the server are currently Views, DataBrowser Filters, Keyboard Shortcuts and JS Console scripts.
             </div>
             <Field
               label={

--- a/src/dashboard/Settings/DashboardSettings/DashboardSettings.react.js
+++ b/src/dashboard/Settings/DashboardSettings/DashboardSettings.react.js
@@ -507,7 +507,7 @@ export default class DashboardSettings extends DashboardView {
         {this.viewPreferencesManager && this.scriptManager && this.viewPreferencesManager.isServerConfigEnabled() && (
           <Fieldset legend="Settings Storage">
             <div style={{ marginBottom: '20px', color: '#666', fontSize: '14px', textAlign: 'center' }}>
-              Storing dashboard settings on the server rather than locally in the browser storage makes the settings available across devices and browsers. It also prevents them from getting lost when resetting the browser website data. Settings that can be stored on the server are currently Views, DataBrowser Filters, Keyboard Shortcuts and JS Console scripts.
+              Storing dashboard settings on the server rather than locally in the browser storage makes the settings available across devices and browsers. It also prevents them from getting lost when resetting the browser website data. Settings that can be stored on the server are currently Data Browser Filters, Views, Keyboard Shortcuts and JS Console scripts.
             </div>
             <Field
               label={

--- a/src/lib/ClassPreferences.js
+++ b/src/lib/ClassPreferences.js
@@ -25,7 +25,7 @@ export function getPreferences(appId, className) {
   try {
     const preferences = JSON.parse(entry);
 
-    // Ensure all filters have UUIDs
+    // Ensure all filters have UUIDs - legacy filters are automatically upgraded
     if (preferences.filters && Array.isArray(preferences.filters)) {
       let needsUpdate = false;
       preferences.filters = preferences.filters.map(filter => {

--- a/src/lib/ClassPreferences.js
+++ b/src/lib/ClassPreferences.js
@@ -23,7 +23,26 @@ export function getPreferences(appId, className) {
     return null;
   }
   try {
-    return JSON.parse(entry);
+    const preferences = JSON.parse(entry);
+
+    // Ensure all filters have UUIDs
+    if (preferences.filters && Array.isArray(preferences.filters)) {
+      let needsUpdate = false;
+      preferences.filters = preferences.filters.map(filter => {
+        if (!filter.id) {
+          needsUpdate = true;
+          return { ...filter, id: crypto.randomUUID() };
+        }
+        return filter;
+      });
+
+      // If we added UUIDs to any filters, save the updated preferences
+      if (needsUpdate) {
+        updatePreferences(preferences, appId, className);
+      }
+    }
+
+    return preferences;
   } catch {
     return null;
   }

--- a/src/lib/FilterPreferencesManager.js
+++ b/src/lib/FilterPreferencesManager.js
@@ -29,21 +29,37 @@ export default class FilterPreferencesManager {
    * @returns {Promise<Array>} Array of filters
    */
   async getFilters(appId, className) {
+    console.log('[FilterPreferencesManager] getFilters called:', { appId, className });
+
+    const serverConfigEnabled = this.serverStorage.isServerConfigEnabled();
+    const prefersServer = prefersServerStorage(appId);
+
+    console.log('[FilterPreferencesManager] Storage configuration:', {
+      serverConfigEnabled,
+      prefersServer,
+      willUseServer: serverConfigEnabled && prefersServer
+    });
+
     // Check if server storage is enabled and user prefers it
-    if (this.serverStorage.isServerConfigEnabled() && prefersServerStorage(appId)) {
+    if (serverConfigEnabled && prefersServer) {
       try {
+        console.log('[FilterPreferencesManager] Fetching filters from server...');
         const serverFilters = await this._getFiltersFromServer(appId, className);
+        console.log('[FilterPreferencesManager] Server filters retrieved:', serverFilters);
         // Always return server filters (even if empty) when server storage is preferred
         return serverFilters || [];
       } catch (error) {
-        console.error('Failed to get filters from server:', error);
+        console.error('[FilterPreferencesManager] Failed to get filters from server:', error);
         // When server storage is preferred, return empty array instead of falling back to local
         return [];
       }
     }
 
     // Use local storage when server storage is not preferred
-    return this._getFiltersFromLocal(appId, className);
+    console.log('[FilterPreferencesManager] Fetching filters from local storage...');
+    const localFilters = this._getFiltersFromLocal(appId, className);
+    console.log('[FilterPreferencesManager] Local filters retrieved:', localFilters);
+    return localFilters;
   }
 
   /**
@@ -184,45 +200,54 @@ export default class FilterPreferencesManager {
    */
   async _getFiltersFromServer(appId, className) {
     try {
+      console.log('[FilterPreferencesManager] _getFiltersFromServer - Fetching configs with prefix "dataBrowser.filter."');
       const filterConfigs = await this.serverStorage.getConfigsByPrefix(
         'dataBrowser.filter.',
         appId
       );
+      console.log('[FilterPreferencesManager] _getFiltersFromServer - Raw configs from server:', filterConfigs);
+
       const filters = [];
 
       Object.entries(filterConfigs).forEach(([key, config]) => {
+        console.log('[FilterPreferencesManager] _getFiltersFromServer - Processing config:', { key, config });
+
         if (config && typeof config === 'object') {
           // Only include filters for this class
           if (config.className !== className) {
+            console.log('[FilterPreferencesManager] _getFiltersFromServer - Skipping filter (wrong class):', {
+              key,
+              configClassName: config.className,
+              targetClassName: className
+            });
             return;
           }
 
           // Extract filter ID from key (dataBrowser.filter.{FILTER_ID})
           const filterId = key.replace('dataBrowser.filter.', '');
 
-          // Parse the filter if it's a string (it was stringified for storage)
           const filterConfig = { ...config };
-          if (filterConfig.filter && typeof filterConfig.filter === 'string') {
-            try {
-              filterConfig.filter = JSON.parse(filterConfig.filter);
-            } catch (e) {
-              console.warn('Failed to parse filter from server storage:', e);
-              console.error(`Skipping filter ${filterId} due to corrupted filter data`);
-              // Skip filters with corrupted data
-              return;
-            }
-          }
 
-          filters.push({
+          // Remove className from the filter object (it's only used for server-side filtering)
+          delete filterConfig.className;
+
+          // Note: We keep the filter property as a string (not parsed) to match the format
+          // returned by _getFiltersFromLocal, which uses getPreferences that stores filters as strings
+
+          const filter = {
             id: filterId,
             ...filterConfig
-          });
+          };
+
+          console.log('[FilterPreferencesManager] _getFiltersFromServer - Adding filter:', filter);
+          filters.push(filter);
         }
       });
 
+      console.log('[FilterPreferencesManager] _getFiltersFromServer - Final filters array:', filters);
       return filters;
     } catch (error) {
-      console.error('Failed to get filters from server:', error);
+      console.error('[FilterPreferencesManager] _getFiltersFromServer - Error:', error);
       return [];
     }
   }

--- a/src/lib/FilterPreferencesManager.js
+++ b/src/lib/FilterPreferencesManager.js
@@ -185,7 +185,7 @@ export default class FilterPreferencesManager {
   async _getFiltersFromServer(appId, className) {
     try {
       const filterConfigs = await this.serverStorage.getConfigsByPrefix(
-        'dataBrowser.filter.',
+        'browser.filters.filter.',
         appId
       );
       const filters = [];
@@ -197,8 +197,8 @@ export default class FilterPreferencesManager {
             return;
           }
 
-          // Extract filter ID from key (dataBrowser.filter.{FILTER_ID})
-          const filterId = key.replace('dataBrowser.filter.', '');
+          // Extract filter ID from key (browser.filters.filter.{FILTER_ID})
+          const filterId = key.replace('browser.filters.filter.', '');
 
           const filterConfig = { ...config };
 
@@ -230,14 +230,14 @@ export default class FilterPreferencesManager {
     try {
       // First, get existing filters from server to know which ones to delete
       const existingFilterConfigs = await this.serverStorage.getConfigsByPrefix(
-        'dataBrowser.filter.',
+        'browser.filters.filter.',
         appId
       );
 
       // Filter to only this class's filters
       const existingFilterIds = Object.entries(existingFilterConfigs)
         .filter(([key, config]) => config.className === className)
-        .map(([key]) => key.replace('dataBrowser.filter.', ''));
+        .map(([key]) => key.replace('browser.filters.filter.', ''));
 
       // Delete filters that are no longer in the new filters array
       const newFilterIds = filters.map(filter => filter.id || this._generateFilterId());
@@ -245,7 +245,7 @@ export default class FilterPreferencesManager {
 
       await Promise.all(
         filtersToDelete.map(id =>
-          this.serverStorage.deleteConfig(`dataBrowser.filter.${id}`, appId)
+          this.serverStorage.deleteConfig(`browser.filters.filter.${id}`, appId)
         )
       );
 
@@ -272,7 +272,7 @@ export default class FilterPreferencesManager {
           }
 
           return this.serverStorage.setConfig(
-            `dataBrowser.filter.${filterId}`,
+            `browser.filters.filter.${filterId}`,
             filterConfig,
             appId
           );
@@ -310,7 +310,7 @@ export default class FilterPreferencesManager {
       }
 
       await this.serverStorage.setConfig(
-        `dataBrowser.filter.${filterId}`,
+        `browser.filters.filter.${filterId}`,
         filterConfig,
         appId
       );
@@ -326,7 +326,7 @@ export default class FilterPreferencesManager {
    */
   async _deleteFilterFromServer(appId, className, filterId) {
     try {
-      await this.serverStorage.deleteConfig(`dataBrowser.filter.${filterId}`, appId);
+      await this.serverStorage.deleteConfig(`browser.filters.filter.${filterId}`, appId);
     } catch (error) {
       console.error('Failed to delete filter from server:', error);
       throw error;

--- a/src/lib/FilterPreferencesManager.js
+++ b/src/lib/FilterPreferencesManager.js
@@ -55,15 +55,13 @@ export default class FilterPreferencesManager {
    * @returns {Promise}
    */
   async saveFilter(appId, className, filter, allFilters) {
-    // Ensure filter has a UUID
-    if (!filter.id) {
-      filter.id = this._generateFilterId();
-    }
+    // Ensure filter has a UUID (create new object to avoid mutating input)
+    const filterWithId = filter.id ? filter : { ...filter, id: this._generateFilterId() };
 
     // Check if server storage is enabled and user prefers it
     if (this.serverStorage.isServerConfigEnabled() && prefersServerStorage(appId)) {
       try {
-        return await this._saveFilterToServer(appId, className, filter);
+        return await this._saveFilterToServer(appId, className, filterWithId);
       } catch (error) {
         console.error('Failed to save filter to server:', error);
         // On error, fallback to local storage
@@ -86,7 +84,7 @@ export default class FilterPreferencesManager {
     // Check if server storage is enabled and user prefers it
     if (this.serverStorage.isServerConfigEnabled() && prefersServerStorage(appId)) {
       try {
-        return await this._deleteFilterFromServer(appId, className, filterId);
+        return await this._deleteFilterFromServer(appId, filterId);
       } catch (error) {
         console.error('Failed to delete filter from server:', error);
         // On error, fallback to local storage
@@ -239,8 +237,15 @@ export default class FilterPreferencesManager {
       const existingFilterIds = Object.keys(existingFilterConfigs)
         .map(key => key.replace('browser.filters.filter.', ''));
 
+      // Validate all filters have IDs before proceeding
+      filters.forEach((filter, index) => {
+        if (!filter.id) {
+          throw new Error(`Filter at index ${index} is missing an ID. All filters must have IDs before saving to server.`);
+        }
+      });
+
       // Delete filters that are no longer in the new filters array
-      const newFilterIds = filters.map(filter => filter.id || this._generateFilterId());
+      const newFilterIds = filters.map(filter => filter.id);
       const filtersToDelete = existingFilterIds.filter(id => !newFilterIds.includes(id));
 
       await Promise.all(
@@ -252,7 +257,7 @@ export default class FilterPreferencesManager {
       // Save or update current filters
       await Promise.all(
         filters.map(filter => {
-          const filterId = filter.id || this._generateFilterId();
+          const filterId = filter.id;
           const filterConfig = { ...filter };
           delete filterConfig.id; // Don't store ID in the config itself
 
@@ -324,7 +329,7 @@ export default class FilterPreferencesManager {
    * Deletes a single filter from server storage
    * @private
    */
-  async _deleteFilterFromServer(appId, className, filterId) {
+  async _deleteFilterFromServer(appId, filterId) {
     try {
       await this.serverStorage.deleteConfig(`browser.filters.filter.${filterId}`, appId);
     } catch (error) {
@@ -339,17 +344,8 @@ export default class FilterPreferencesManager {
    */
   _getFiltersFromLocal(appId, className) {
     const preferences = getPreferences(appId, className);
-    if (!preferences || !preferences.filters) {
-      return [];
-    }
-
-    // Ensure all filters have UUIDs
-    return preferences.filters.map(filter => {
-      if (!filter.id) {
-        return { ...filter, id: this._generateFilterId() };
-      }
-      return filter;
-    });
+    // getPreferences() already ensures all filters have UUIDs
+    return preferences?.filters || [];
   }
 
   /**

--- a/src/lib/FilterPreferencesManager.js
+++ b/src/lib/FilterPreferencesManager.js
@@ -29,37 +29,21 @@ export default class FilterPreferencesManager {
    * @returns {Promise<Array>} Array of filters
    */
   async getFilters(appId, className) {
-    console.log('[FilterPreferencesManager] getFilters called:', { appId, className });
-
-    const serverConfigEnabled = this.serverStorage.isServerConfigEnabled();
-    const prefersServer = prefersServerStorage(appId);
-
-    console.log('[FilterPreferencesManager] Storage configuration:', {
-      serverConfigEnabled,
-      prefersServer,
-      willUseServer: serverConfigEnabled && prefersServer
-    });
-
     // Check if server storage is enabled and user prefers it
-    if (serverConfigEnabled && prefersServer) {
+    if (this.serverStorage.isServerConfigEnabled() && prefersServerStorage(appId)) {
       try {
-        console.log('[FilterPreferencesManager] Fetching filters from server...');
         const serverFilters = await this._getFiltersFromServer(appId, className);
-        console.log('[FilterPreferencesManager] Server filters retrieved:', serverFilters);
         // Always return server filters (even if empty) when server storage is preferred
         return serverFilters || [];
       } catch (error) {
-        console.error('[FilterPreferencesManager] Failed to get filters from server:', error);
+        console.error('Failed to get filters from server:', error);
         // When server storage is preferred, return empty array instead of falling back to local
         return [];
       }
     }
 
     // Use local storage when server storage is not preferred
-    console.log('[FilterPreferencesManager] Fetching filters from local storage...');
-    const localFilters = this._getFiltersFromLocal(appId, className);
-    console.log('[FilterPreferencesManager] Local filters retrieved:', localFilters);
-    return localFilters;
+    return this._getFiltersFromLocal(appId, className);
   }
 
   /**
@@ -200,26 +184,16 @@ export default class FilterPreferencesManager {
    */
   async _getFiltersFromServer(appId, className) {
     try {
-      console.log('[FilterPreferencesManager] _getFiltersFromServer - Fetching configs with prefix "dataBrowser.filter."');
       const filterConfigs = await this.serverStorage.getConfigsByPrefix(
         'dataBrowser.filter.',
         appId
       );
-      console.log('[FilterPreferencesManager] _getFiltersFromServer - Raw configs from server:', filterConfigs);
-
       const filters = [];
 
       Object.entries(filterConfigs).forEach(([key, config]) => {
-        console.log('[FilterPreferencesManager] _getFiltersFromServer - Processing config:', { key, config });
-
         if (config && typeof config === 'object') {
           // Only include filters for this class
           if (config.className !== className) {
-            console.log('[FilterPreferencesManager] _getFiltersFromServer - Skipping filter (wrong class):', {
-              key,
-              configClassName: config.className,
-              targetClassName: className
-            });
             return;
           }
 
@@ -234,20 +208,16 @@ export default class FilterPreferencesManager {
           // Note: We keep the filter property as a string (not parsed) to match the format
           // returned by _getFiltersFromLocal, which uses getPreferences that stores filters as strings
 
-          const filter = {
+          filters.push({
             id: filterId,
             ...filterConfig
-          };
-
-          console.log('[FilterPreferencesManager] _getFiltersFromServer - Adding filter:', filter);
-          filters.push(filter);
+          });
         }
       });
 
-      console.log('[FilterPreferencesManager] _getFiltersFromServer - Final filters array:', filters);
       return filters;
     } catch (error) {
-      console.error('[FilterPreferencesManager] _getFiltersFromServer - Error:', error);
+      console.error('Failed to get filters from server:', error);
       return [];
     }
   }

--- a/src/lib/FilterPreferencesManager.js
+++ b/src/lib/FilterPreferencesManager.js
@@ -184,19 +184,17 @@ export default class FilterPreferencesManager {
    */
   async _getFiltersFromServer(appId, className) {
     try {
+      // Query server with className filter to only fetch filters for this class
       const filterConfigs = await this.serverStorage.getConfigsByPrefix(
         'browser.filters.filter.',
-        appId
+        appId,
+        null,
+        { className } // Filter by className in the object field
       );
       const filters = [];
 
       Object.entries(filterConfigs).forEach(([key, config]) => {
         if (config && typeof config === 'object') {
-          // Only include filters for this class
-          if (config.className !== className) {
-            return;
-          }
-
           // Extract filter ID from key (browser.filters.filter.{FILTER_ID})
           const filterId = key.replace('browser.filters.filter.', '');
 
@@ -229,15 +227,17 @@ export default class FilterPreferencesManager {
   async _saveFiltersToServer(appId, className, filters) {
     try {
       // First, get existing filters from server to know which ones to delete
+      // Only fetch filters for this specific class
       const existingFilterConfigs = await this.serverStorage.getConfigsByPrefix(
         'browser.filters.filter.',
-        appId
+        appId,
+        null,
+        { className } // Filter by className in the object field
       );
 
-      // Filter to only this class's filters
-      const existingFilterIds = Object.entries(existingFilterConfigs)
-        .filter(([key, config]) => config.className === className)
-        .map(([key]) => key.replace('browser.filters.filter.', ''));
+      // Extract filter IDs
+      const existingFilterIds = Object.keys(existingFilterConfigs)
+        .map(key => key.replace('browser.filters.filter.', ''));
 
       // Delete filters that are no longer in the new filters array
       const newFilterIds = filters.map(filter => filter.id || this._generateFilterId());

--- a/src/lib/FilterPreferencesManager.js
+++ b/src/lib/FilterPreferencesManager.js
@@ -1,0 +1,402 @@
+/*
+ * Copyright (c) 2016-present, Parse, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+import ServerConfigStorage from './ServerConfigStorage';
+import { prefersServerStorage, setStoragePreference } from './StoragePreferences';
+import { getPreferences, updatePreferences, getAllPreferences } from './ClassPreferences';
+
+const VERSION = 1;
+
+/**
+ * FilterPreferencesManager with server-side storage support
+ * Manages DataBrowser filters for specific classes
+ */
+export default class FilterPreferencesManager {
+  constructor(app) {
+    this.app = app;
+    this.serverStorage = new ServerConfigStorage(app);
+  }
+
+  /**
+   * Gets filters for a specific class from either server or local storage
+   * @param {string} appId - The application ID
+   * @param {string} className - The class name
+   * @returns {Promise<Array>} Array of filters
+   */
+  async getFilters(appId, className) {
+    // Check if server storage is enabled and user prefers it
+    if (this.serverStorage.isServerConfigEnabled() && prefersServerStorage(appId)) {
+      try {
+        const serverFilters = await this._getFiltersFromServer(appId, className);
+        // Always return server filters (even if empty) when server storage is preferred
+        return serverFilters || [];
+      } catch (error) {
+        console.error('Failed to get filters from server:', error);
+        // When server storage is preferred, return empty array instead of falling back to local
+        return [];
+      }
+    }
+
+    // Use local storage when server storage is not preferred
+    return this._getFiltersFromLocal(appId, className);
+  }
+
+  /**
+   * Saves a filter to either server or local storage
+   * @param {string} appId - The application ID
+   * @param {string} className - The class name
+   * @param {Object} filter - The filter to save
+   * @param {Array} allFilters - All filters (required for local storage fallback)
+   * @returns {Promise}
+   */
+  async saveFilter(appId, className, filter, allFilters) {
+    // Ensure filter has a UUID
+    if (!filter.id) {
+      filter.id = this._generateFilterId();
+    }
+
+    // Check if server storage is enabled and user prefers it
+    if (this.serverStorage.isServerConfigEnabled() && prefersServerStorage(appId)) {
+      try {
+        return await this._saveFilterToServer(appId, className, filter);
+      } catch (error) {
+        console.error('Failed to save filter to server:', error);
+        // On error, fallback to local storage
+      }
+    }
+
+    // Use local storage (either by preference or as fallback)
+    return this._saveFiltersToLocal(appId, className, allFilters);
+  }
+
+  /**
+   * Deletes a filter from either server or local storage
+   * @param {string} appId - The application ID
+   * @param {string} className - The class name
+   * @param {string} filterId - The ID of the filter to delete
+   * @param {Array} allFilters - All filters (required for local storage fallback)
+   * @returns {Promise}
+   */
+  async deleteFilter(appId, className, filterId, allFilters) {
+    // Check if server storage is enabled and user prefers it
+    if (this.serverStorage.isServerConfigEnabled() && prefersServerStorage(appId)) {
+      try {
+        return await this._deleteFilterFromServer(appId, className, filterId);
+      } catch (error) {
+        console.error('Failed to delete filter from server:', error);
+        // On error, fallback to local storage
+      }
+    }
+
+    // Use local storage (either by preference or as fallback)
+    return this._saveFiltersToLocal(appId, className, allFilters);
+  }
+
+  /**
+   * Migrates filters from local storage to server storage for all classes
+   * @param {string} appId - The application ID
+   * @returns {Promise<{success: boolean, filterCount: number}>}
+   */
+  async migrateToServer(appId) {
+    if (!this.serverStorage.isServerConfigEnabled()) {
+      throw new Error('Server configuration is not enabled for this app');
+    }
+
+    const allPreferences = getAllPreferences(appId);
+    let totalFilterCount = 0;
+
+    try {
+      for (const [className, preferences] of Object.entries(allPreferences)) {
+        if (preferences.filters && preferences.filters.length > 0) {
+          // Ensure all filters have UUIDs before migrating
+          const filtersWithIds = preferences.filters.map(filter => {
+            if (!filter.id) {
+              return { ...filter, id: this._generateFilterId() };
+            }
+            return filter;
+          });
+
+          await this._saveFiltersToServer(appId, className, filtersWithIds);
+          totalFilterCount += filtersWithIds.length;
+        }
+      }
+
+      return { success: true, filterCount: totalFilterCount };
+    } catch (error) {
+      console.error('Failed to migrate filters to server:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Deletes filters from local storage for all classes
+   * @param {string} appId - The application ID
+   * @returns {boolean} True if deletion was successful
+   */
+  deleteFromBrowser(appId) {
+    try {
+      const allPreferences = getAllPreferences(appId);
+      for (const className of Object.keys(allPreferences)) {
+        const path = this._getLocalPath(appId, className);
+        localStorage.removeItem(path);
+      }
+      return true;
+    } catch (error) {
+      console.error('Failed to delete filters from browser:', error);
+      return false;
+    }
+  }
+
+  /**
+   * Sets the storage preference for the app
+   * @param {string} appId - The application ID
+   * @param {string} preference - The storage preference ('local' or 'server')
+   */
+  setStoragePreference(appId, preference) {
+    setStoragePreference(appId, preference);
+  }
+
+  /**
+   * Gets the current storage preference for the app
+   * @param {string} appId - The application ID
+   * @returns {string} The storage preference ('local' or 'server')
+   */
+  getStoragePreference(appId) {
+    return prefersServerStorage(appId) ? 'server' : 'local';
+  }
+
+  /**
+   * Checks if server configuration is enabled for this app
+   * @returns {boolean} True if server config is enabled
+   */
+  isServerConfigEnabled() {
+    return this.serverStorage.isServerConfigEnabled();
+  }
+
+  /**
+   * Gets filters for a specific class from server storage
+   * @private
+   */
+  async _getFiltersFromServer(appId, className) {
+    try {
+      const filterConfigs = await this.serverStorage.getConfigsByPrefix(
+        'dataBrowser.filter.',
+        appId
+      );
+      const filters = [];
+
+      Object.entries(filterConfigs).forEach(([key, config]) => {
+        if (config && typeof config === 'object') {
+          // Only include filters for this class
+          if (config.className !== className) {
+            return;
+          }
+
+          // Extract filter ID from key (dataBrowser.filter.{FILTER_ID})
+          const filterId = key.replace('dataBrowser.filter.', '');
+
+          // Parse the filter if it's a string (it was stringified for storage)
+          const filterConfig = { ...config };
+          if (filterConfig.filter && typeof filterConfig.filter === 'string') {
+            try {
+              filterConfig.filter = JSON.parse(filterConfig.filter);
+            } catch (e) {
+              console.warn('Failed to parse filter from server storage:', e);
+              console.error(`Skipping filter ${filterId} due to corrupted filter data`);
+              // Skip filters with corrupted data
+              return;
+            }
+          }
+
+          filters.push({
+            id: filterId,
+            ...filterConfig
+          });
+        }
+      });
+
+      return filters;
+    } catch (error) {
+      console.error('Failed to get filters from server:', error);
+      return [];
+    }
+  }
+
+  /**
+   * Saves filters for a specific class to server storage
+   * @private
+   */
+  async _saveFiltersToServer(appId, className, filters) {
+    try {
+      // First, get existing filters from server to know which ones to delete
+      const existingFilterConfigs = await this.serverStorage.getConfigsByPrefix(
+        'dataBrowser.filter.',
+        appId
+      );
+
+      // Filter to only this class's filters
+      const existingFilterIds = Object.entries(existingFilterConfigs)
+        .filter(([key, config]) => config.className === className)
+        .map(([key]) => key.replace('dataBrowser.filter.', ''));
+
+      // Delete filters that are no longer in the new filters array
+      const newFilterIds = filters.map(filter => filter.id || this._generateFilterId());
+      const filtersToDelete = existingFilterIds.filter(id => !newFilterIds.includes(id));
+
+      await Promise.all(
+        filtersToDelete.map(id =>
+          this.serverStorage.deleteConfig(`dataBrowser.filter.${id}`, appId)
+        )
+      );
+
+      // Save or update current filters
+      await Promise.all(
+        filters.map(filter => {
+          const filterId = filter.id || this._generateFilterId();
+          const filterConfig = { ...filter };
+          delete filterConfig.id; // Don't store ID in the config itself
+
+          // Add className to the object
+          filterConfig.className = className;
+
+          // Remove null and undefined values to keep the storage clean
+          Object.keys(filterConfig).forEach(key => {
+            if (filterConfig[key] === null || filterConfig[key] === undefined) {
+              delete filterConfig[key];
+            }
+          });
+
+          // Stringify the filter if it exists and is an array/object
+          if (filterConfig.filter && (Array.isArray(filterConfig.filter) || typeof filterConfig.filter === 'object')) {
+            filterConfig.filter = JSON.stringify(filterConfig.filter);
+          }
+
+          return this.serverStorage.setConfig(
+            `dataBrowser.filter.${filterId}`,
+            filterConfig,
+            appId
+          );
+        })
+      );
+    } catch (error) {
+      console.error('Failed to save filters to server:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Saves a single filter to server storage
+   * @private
+   */
+  async _saveFilterToServer(appId, className, filter) {
+    try {
+      const filterId = filter.id || this._generateFilterId();
+      const filterConfig = { ...filter };
+      delete filterConfig.id; // Don't store ID in the config itself
+
+      // Add className to the object
+      filterConfig.className = className;
+
+      // Remove null and undefined values to keep the storage clean
+      Object.keys(filterConfig).forEach(key => {
+        if (filterConfig[key] === null || filterConfig[key] === undefined) {
+          delete filterConfig[key];
+        }
+      });
+
+      // Stringify the filter if it exists and is an array/object
+      if (filterConfig.filter && (Array.isArray(filterConfig.filter) || typeof filterConfig.filter === 'object')) {
+        filterConfig.filter = JSON.stringify(filterConfig.filter);
+      }
+
+      await this.serverStorage.setConfig(
+        `dataBrowser.filter.${filterId}`,
+        filterConfig,
+        appId
+      );
+    } catch (error) {
+      console.error('Failed to save filter to server:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Deletes a single filter from server storage
+   * @private
+   */
+  async _deleteFilterFromServer(appId, className, filterId) {
+    try {
+      await this.serverStorage.deleteConfig(`dataBrowser.filter.${filterId}`, appId);
+    } catch (error) {
+      console.error('Failed to delete filter from server:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Gets filters from local storage (original implementation)
+   * @private
+   */
+  _getFiltersFromLocal(appId, className) {
+    const preferences = getPreferences(appId, className);
+    if (!preferences || !preferences.filters) {
+      return [];
+    }
+
+    // Ensure all filters have UUIDs
+    return preferences.filters.map(filter => {
+      if (!filter.id) {
+        return { ...filter, id: this._generateFilterId() };
+      }
+      return filter;
+    });
+  }
+
+  /**
+   * Saves filters to local storage (original implementation)
+   * @private
+   */
+  _saveFiltersToLocal(appId, className, filters) {
+    const preferences = getPreferences(appId, className) || { filters: [] };
+
+    // Ensure all filters have UUIDs before saving
+    const filtersWithIds = filters.map(filter => {
+      if (!filter.id) {
+        return { ...filter, id: this._generateFilterId() };
+      }
+      return filter;
+    });
+
+    preferences.filters = filtersWithIds;
+    updatePreferences(preferences, appId, className);
+  }
+
+  /**
+   * Gets the local storage path for class preferences
+   * @private
+   */
+  _getLocalPath(appId, className) {
+    return `ParseDashboard:${VERSION}:${appId}:ClassPreference:${className}`;
+  }
+
+  /**
+   * Generates a unique ID for a new filter
+   * @returns {string} A UUID string
+   */
+  generateFilterId() {
+    return this._generateFilterId();
+  }
+
+  /**
+   * Generates a unique ID for a filter using UUID
+   * @private
+   */
+  _generateFilterId() {
+    return crypto.randomUUID();
+  }
+}

--- a/src/lib/ServerConfigStorage.js
+++ b/src/lib/ServerConfigStorage.js
@@ -112,7 +112,7 @@ export default class ServerConfigStorage {
     }
 
     // Add nested object field filters if provided
-    if (objectFilter && typeof objectFilter === 'object') {
+    if (objectFilter && typeof objectFilter === 'object' && !Array.isArray(objectFilter)) {
       Object.entries(objectFilter).forEach(([field, value]) => {
         query.equalTo(`object.${field}`, value);
       });

--- a/src/lib/ServerConfigStorage.js
+++ b/src/lib/ServerConfigStorage.js
@@ -97,9 +97,10 @@ export default class ServerConfigStorage {
    * @param {string} keyPrefix - The key prefix to filter by
    * @param {string} appId - The app ID
    * @param {string | null} userId - The user ID (optional)
+   * @param {Object | null} objectFilter - Optional filter for object field properties (e.g., {className: '_User'})
    * @returns {Promise<Object>} Object with keys and values
    */
-  async getConfigsByPrefix(keyPrefix, appId, userId = null) {
+  async getConfigsByPrefix(keyPrefix, appId, userId = null, objectFilter = null) {
     const query = new Parse.Query(this.className);
     query.equalTo('appId', appId);
     query.startsWith('key', keyPrefix);
@@ -108,6 +109,13 @@ export default class ServerConfigStorage {
       query.equalTo('user', new Parse.User({ objectId: userId }));
     } else {
       query.doesNotExist('user');
+    }
+
+    // Add nested object field filters if provided
+    if (objectFilter && typeof objectFilter === 'object') {
+      Object.entries(objectFilter).forEach(([field, value]) => {
+        query.equalTo(`object.${field}`, value);
+      });
     }
 
     const results = await query.find({ useMasterKey: true });


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-backed filter persistence with per-app storage preference and seamless sync for class-specific filters.
  * Settings now include filters in migration, deletion, and storage-preference controls so filters move to/from server alongside views.
  * Save and delete operations are asynchronous and refresh class filter lists in the sidebar after changes.

* **Bug Fixes**
  * Filters missing IDs are auto-assigned stable UUIDs; updates preserve existing IDs rather than replacing them.
  * Category lists now auto-expand when category data updates (in addition to URL changes).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->