### PR TITLE
feat: Add confirmation dialog to handle conflicts when migrating settings to server

### DIFF
--- a/src/dashboard/Settings/DashboardSettings/DashboardSettings.react.js
+++ b/src/dashboard/Settings/DashboardSettings/DashboardSettings.react.js
@@ -15,6 +15,7 @@ import Option from 'components/Dropdown/Option.react';
 import Toolbar from 'components/Toolbar/Toolbar.react';
 import CodeSnippet from 'components/CodeSnippet/CodeSnippet.react';
 import Notification from 'dashboard/Data/Browser/Notification.react';
+import Modal from 'components/Modal/Modal.react';
 import * as ColumnPreferences from 'lib/ColumnPreferences';
 import * as ClassPreferences from 'lib/ClassPreferences';
 import ViewPreferencesManager from 'lib/ViewPreferencesManager';
@@ -47,6 +48,8 @@ export default class DashboardSettings extends DashboardView {
       passwordHidden: true,
       migrationLoading: false,
       storagePreference: 'local', // Will be updated in componentDidMount
+      showConflictModal: false,
+      migrationConflicts: [],
       copyData: {
         data: '',
         show: false,
@@ -95,7 +98,7 @@ export default class DashboardSettings extends DashboardView {
     }
   }
 
-  async migrateToServer() {
+  async migrateToServer(overwriteConflicts = false) {
     if (!this.viewPreferencesManager) {
       this.showNote('ViewPreferencesManager not initialized');
       return;
@@ -115,10 +118,22 @@ export default class DashboardSettings extends DashboardView {
 
     try {
       // Migrate views
-      const viewsResult = await this.viewPreferencesManager.migrateToServer(this.context.applicationId);
+      const viewsResult = await this.viewPreferencesManager.migrateToServer(this.context.applicationId, overwriteConflicts);
 
       // Migrate filters
-      const filtersResult = await this.filterPreferencesManager.migrateToServer(this.context.applicationId);
+      const filtersResult = await this.filterPreferencesManager.migrateToServer(this.context.applicationId, overwriteConflicts);
+
+      // Check for conflicts
+      const allConflicts = [
+        ...(viewsResult.conflicts || []),
+        ...(filtersResult.conflicts || [])
+      ];
+
+      if (allConflicts.length > 0 && !overwriteConflicts) {
+        // Show conflict dialog
+        this.showConflictDialog(allConflicts);
+        return;
+      }
 
       const totalItems = viewsResult.viewCount + filtersResult.filterCount;
 
@@ -141,6 +156,25 @@ export default class DashboardSettings extends DashboardView {
     } finally {
       this.setState({ migrationLoading: false });
     }
+  }
+
+  showConflictDialog(conflicts) {
+    this.setState({
+      migrationLoading: false,
+      showConflictModal: true,
+      migrationConflicts: conflicts
+    });
+  }
+
+  handleConflictOverwrite() {
+    this.setState({ showConflictModal: false });
+    // User chose to overwrite - retry migration with overwrite flag
+    this.migrateToServer(true);
+  }
+
+  handleConflictCancel() {
+    this.setState({ showConflictModal: false, migrationConflicts: [] });
+    this.showNote('Migration aborted. Server settings were not modified.');
   }
 
   async deleteFromBrowser() {
@@ -533,7 +567,7 @@ export default class DashboardSettings extends DashboardView {
               label={
                 <Label
                   text="Migrate Settings to Server"
-                  description="Migrates browser-stored settings to the server. ⚠️ This overwrites existing dashboard settings on the server."
+                  description="Migrates browser-stored settings to the server. If conflicts are detected, you'll be asked whether to overwrite or abort."
                 />
               }
               input={
@@ -565,9 +599,96 @@ export default class DashboardSettings extends DashboardView {
         {this.state.copyData.show && copyData}
         {this.state.createUserInput && createUserInput}
         {this.state.newUser.show && userData}
+        {this.state.showConflictModal && this.renderConflictModal()}
         <Toolbar section="Settings" subsection="Dashboard Configuration" />
         <Notification note={this.state.message} isErrorNote={false} />
       </div>
+    );
+  }
+
+  renderConflictModal() {
+    const { migrationConflicts } = this.state;
+
+    // Format conflict details
+    const viewConflicts = migrationConflicts.filter(c => c.type === 'view');
+    const filterConflicts = migrationConflicts.filter(c => c.type === 'filter');
+
+    const conflictList = (
+      <div style={{ padding: '20px', fontSize: '14px' }}>
+        <p style={{ marginBottom: '15px' }}>
+          The following settings already exist on the server:
+        </p>
+
+        <div style={{
+          maxHeight: '300px',
+          overflowY: 'auto',
+          marginBottom: '15px',
+          border: '1px solid #e0e0e0',
+          borderRadius: '4px',
+          padding: '10px'
+        }}>
+          {viewConflicts.length > 0 && (
+            <div style={{ marginBottom: filterConflicts.length > 0 ? '15px' : '0' }}>
+              <strong>Views ({viewConflicts.length}):</strong>
+              <ul style={{ marginTop: '5px', marginBottom: '0', paddingLeft: '20px' }}>
+                {viewConflicts.map(conflict => {
+                  const viewName = conflict.local?.name || conflict.server?.name || '';
+                  return (
+                    <li key={conflict.id}>
+                      {viewName || 'Unnamed view'}
+                      <span style={{ fontFamily: 'monospace', fontSize: '12px', color: '#666', marginLeft: '8px' }}>
+                        [{conflict.id}]
+                      </span>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
+
+          {filterConflicts.length > 0 && (
+            <div>
+              <strong>Filters ({filterConflicts.length}):</strong>
+              <ul style={{ marginTop: '5px', marginBottom: '0', paddingLeft: '20px' }}>
+                {filterConflicts.map(conflict => {
+                  const filterName = conflict.local?.name || conflict.server?.name || '';
+                  const className = conflict.className || 'Unknown class';
+                  const displayText = filterName
+                    ? `${filterName} (${className})`
+                    : className;
+                  return (
+                    <li key={conflict.id}>
+                      {displayText}
+                      <span style={{ fontFamily: 'monospace', fontSize: '12px', color: '#666', marginLeft: '8px' }}>
+                        [{conflict.id}]
+                      </span>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
+        </div>
+
+        <p style={{ marginTop: '15px', fontWeight: 'bold' }}>
+          Do you want to overwrite the server settings with your local settings?
+        </p>
+      </div>
+    );
+
+    return (
+      <Modal
+        type={Modal.Types.DANGER}
+        icon="warn-outline"
+        title="Migration Conflicts Detected"
+        subtitle="Settings with the same ID already exist on the server"
+        confirmText="Overwrite Server Settings"
+        cancelText="Cancel Migration"
+        onConfirm={() => this.handleConflictOverwrite()}
+        onCancel={() => this.handleConflictCancel()}
+      >
+        {conflictList}
+      </Modal>
     );
   }
 

--- a/src/dashboard/Settings/DashboardSettings/DashboardSettings.react.js
+++ b/src/dashboard/Settings/DashboardSettings/DashboardSettings.react.js
@@ -109,6 +109,11 @@ export default class DashboardSettings extends DashboardView {
       return;
     }
 
+    if (!this.scriptManager) {
+      this.showNote('ScriptManager not initialized');
+      return;
+    }
+
     if (!this.viewPreferencesManager.isServerConfigEnabled()) {
       this.showNote('Server configuration is not enabled for this app. Please add a "config" section to your app configuration.');
       return;
@@ -123,10 +128,14 @@ export default class DashboardSettings extends DashboardView {
       // Migrate filters
       const filtersResult = await this.filterPreferencesManager.migrateToServer(this.context.applicationId, overwriteConflicts);
 
+      // Migrate scripts
+      const scriptsResult = await this.scriptManager.migrateToServer(this.context.applicationId, overwriteConflicts);
+
       // Check for conflicts
       const allConflicts = [
         ...(viewsResult.conflicts || []),
-        ...(filtersResult.conflicts || [])
+        ...(filtersResult.conflicts || []),
+        ...(scriptsResult.conflicts || [])
       ];
 
       if (allConflicts.length > 0 && !overwriteConflicts) {
@@ -135,9 +144,9 @@ export default class DashboardSettings extends DashboardView {
         return;
       }
 
-      const totalItems = viewsResult.viewCount + filtersResult.filterCount;
+      const totalItems = viewsResult.viewCount + filtersResult.filterCount + scriptsResult.scriptCount;
 
-      if (viewsResult.success && filtersResult.success) {
+      if (viewsResult.success && filtersResult.success && scriptsResult.success) {
         if (totalItems > 0) {
           const messages = [];
           if (viewsResult.viewCount > 0) {
@@ -146,9 +155,12 @@ export default class DashboardSettings extends DashboardView {
           if (filtersResult.filterCount > 0) {
             messages.push(`${filtersResult.filterCount} filter(s)`);
           }
-          this.showNote(`Successfully migrated ${messages.join(' and ')} to server storage.`);
+          if (scriptsResult.scriptCount > 0) {
+            messages.push(`${scriptsResult.scriptCount} script(s)`);
+          }
+          this.showNote(`Successfully migrated ${messages.join(', ')} to server storage.`);
         } else {
-          this.showNote('No views or filters found to migrate.');
+          this.showNote('No views, filters, or scripts found to migrate.');
         }
       }
     } catch (error) {
@@ -612,6 +624,7 @@ export default class DashboardSettings extends DashboardView {
     // Format conflict details
     const viewConflicts = migrationConflicts.filter(c => c.type === 'view');
     const filterConflicts = migrationConflicts.filter(c => c.type === 'filter');
+    const scriptConflicts = migrationConflicts.filter(c => c.type === 'script');
 
     const conflictList = (
       <div style={{ padding: '20px', fontSize: '14px' }}>
@@ -628,7 +641,7 @@ export default class DashboardSettings extends DashboardView {
           padding: '10px'
         }}>
           {viewConflicts.length > 0 && (
-            <div style={{ marginBottom: filterConflicts.length > 0 ? '15px' : '0' }}>
+            <div style={{ marginBottom: (filterConflicts.length > 0 || scriptConflicts.length > 0) ? '15px' : '0' }}>
               <strong>Views ({viewConflicts.length}):</strong>
               <ul style={{ marginTop: '5px', marginBottom: '0', paddingLeft: '20px' }}>
                 {viewConflicts.map(conflict => {
@@ -647,7 +660,7 @@ export default class DashboardSettings extends DashboardView {
           )}
 
           {filterConflicts.length > 0 && (
-            <div>
+            <div style={{ marginBottom: scriptConflicts.length > 0 ? '15px' : '0' }}>
               <strong>Filters ({filterConflicts.length}):</strong>
               <ul style={{ marginTop: '5px', marginBottom: '0', paddingLeft: '20px' }}>
                 {filterConflicts.map(conflict => {
@@ -659,6 +672,25 @@ export default class DashboardSettings extends DashboardView {
                   return (
                     <li key={conflict.id}>
                       {displayText}
+                      <span style={{ fontFamily: 'monospace', fontSize: '12px', color: '#666', marginLeft: '8px' }}>
+                        [{conflict.id}]
+                      </span>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
+
+          {scriptConflicts.length > 0 && (
+            <div>
+              <strong>Scripts ({scriptConflicts.length}):</strong>
+              <ul style={{ marginTop: '5px', marginBottom: '0', paddingLeft: '20px' }}>
+                {scriptConflicts.map(conflict => {
+                  const scriptName = conflict.local?.name || conflict.server?.name || '';
+                  return (
+                    <li key={conflict.id}>
+                      {scriptName || 'Unnamed script'}
                       <span style={{ fontFamily: 'monospace', fontSize: '12px', color: '#666', marginLeft: '8px' }}>
                         [{conflict.id}]
                       </span>


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description

When migrating settings from local to server storage, any conflicting server-stored setting is overwritten and any non-conflicting server-stored setting is deleted.

### Approach

Show conflict dialog to let user handle migration:

<img width="540" height="425" alt="image" src="https://github.com/user-attachments/assets/2a6405bb-5b9b-47c7-a2ab-33309b8237ca" />

This also fixes an issue where JS console scripts are not migrated to the server.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Migration now detects conflicts across settings, filters, views, and scripts; when conflicts are found a detailed modal lists them and lets you overwrite or cancel the migration.
  * Success/failure messaging updated to report totals including scripts and to indicate when nothing was migrated.
  * Migration can now proceed in overwrite mode to replace conflicting server items.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->