### PR TITLE
feat: Auto-expand filter list when clicking on class in data browser

### DIFF
--- a/src/components/CategoryList/CategoryList.react.js
+++ b/src/components/CategoryList/CategoryList.react.js
@@ -88,7 +88,7 @@ export default class CategoryList extends React.Component {
 
           // If a matching filter is found, auto-expand this class
           if (matchIndex !== -1 && !this.state.openClasses.includes(id)) {
-            this.setState({ openClasses: [id] });
+            this.setState({ openClasses: [...this.state.openClasses, id] });
           }
           break;
         }

--- a/src/components/CategoryList/CategoryList.react.js
+++ b/src/components/CategoryList/CategoryList.react.js
@@ -175,7 +175,13 @@ export default class CategoryList extends React.Component {
                   title={c.name}
                   to={{ pathname: link }}
                   className={className}
-                  onClick={() => this.props.classClicked()}
+                  onClick={() => {
+                    this.props.classClicked();
+                    // Auto-expand filter list when clicking on a class that has filters
+                    if ((c.filters || []).length > 0 && !this.state.openClasses.includes(id)) {
+                      this.setState({ openClasses: [...this.state.openClasses, id] });
+                    }
+                  }}
                 >
                   {c.name}
                 </Link>

--- a/src/components/CategoryList/CategoryList.react.js
+++ b/src/components/CategoryList/CategoryList.react.js
@@ -88,7 +88,7 @@ export default class CategoryList extends React.Component {
 
           // If a matching filter is found, auto-expand this class
           if (matchIndex !== -1 && !this.state.openClasses.includes(id)) {
-            this.setState({ openClasses: [...this.state.openClasses, id] });
+            this.setState(prevState => ({ openClasses: [...prevState.openClasses, id] }));
           }
           break;
         }
@@ -176,10 +176,16 @@ export default class CategoryList extends React.Component {
                   to={{ pathname: link }}
                   className={className}
                   onClick={() => {
-                    this.props.classClicked();
+                    if (typeof this.props.classClicked === 'function') {
+                      this.props.classClicked();
+                    }
                     // Auto-expand filter list when clicking on a class that has filters
-                    if ((c.filters || []).length > 0 && !this.state.openClasses.includes(id)) {
-                      this.setState({ openClasses: [...this.state.openClasses, id] });
+                    if ((c.filters || []).length > 0) {
+                      this.setState(prevState => ({
+                        openClasses: prevState.openClasses.includes(id)
+                          ? prevState.openClasses
+                          : [...prevState.openClasses, id]
+                      }));
                     }
                   }}
                 >
@@ -255,5 +261,6 @@ CategoryList.propTypes = {
   ),
   current: PropTypes.string.describe('Id of current category to be highlighted.'),
   linkPrefix: PropTypes.string.describe('Link prefix used to generate link path.'),
+  classClicked: PropTypes.func.describe('Callback function invoked when a class is clicked.'),
   onEditFilter: PropTypes.func.describe('Callback function for editing a filter.'),
 };


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Category sections with available filters now auto-expand when clicked, making it faster to access filter options.
  * Auto-expansion preserves already-open sections (it appends new open sections instead of replacing them), preventing accidental collapse of other open categories.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->