### PR TITLE
fix: Context menu in data browser disappears behind menu bar

### DIFF
--- a/src/components/ContextMenu/ContextMenu.scss
+++ b/src/components/ContextMenu/ContextMenu.scss
@@ -3,6 +3,9 @@
 .menu {
 	position: absolute;
 	font-size: 14px;
+	// To be shown above the toolbar with also z-index set
+	// src/components/Toolbar/Toolbar.scss
+	z-index: 6;
 
 	ul {
 		background: $purple;

--- a/src/components/ContextMenu/ContextMenu.scss
+++ b/src/components/ContextMenu/ContextMenu.scss
@@ -11,6 +11,8 @@
 		background: $purple;
 		@include animation('fade-in .2s linear');
 		opacity: 0;
+		border: 1px solid rgba(255, 255, 255, 0.15);
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
 	}
 
 	li {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

### Issue Description
As described here: https://github.com/parse-community/parse-dashboard/issues/2854

Closes: https://github.com/parse-community/parse-dashboard/issues/2854

### Approach
Setting a higher `z-index` than on Toolbar.

### TODOs before merging
n/a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed context menu layering so it reliably appears above toolbars and other UI elements.

* **Style**
  * Improved context menu borders and shadow for clearer separation and better visual contrast.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->