### PR TITLE
fix: Saved filter is not recognized in data browser filter dialog

### DIFF
--- a/src/components/BrowserFilter/BrowserFilter.react.js
+++ b/src/components/BrowserFilter/BrowserFilter.react.js
@@ -17,7 +17,6 @@ import Popover from 'components/Popover/Popover.react';
 import TextInput from 'components/TextInput/TextInput.react';
 import { CurrentApp } from 'context/currentApp';
 import { List, Map as ImmutableMap } from 'immutable';
-import * as ClassPreferences from 'lib/ClassPreferences';
 import * as Filters from 'lib/Filters';
 import Position from 'lib/Position';
 import React from 'react';

--- a/src/components/BrowserFilter/BrowserFilter.react.js
+++ b/src/components/BrowserFilter/BrowserFilter.react.js
@@ -97,15 +97,15 @@ export default class BrowserFilter extends React.Component {
     }
   }
 
-  componentWillReceiveProps(props) {
-    if (props.className !== this.props.className) {
+  componentDidUpdate(prevProps) {
+    // Close dialog when className changes
+    if (prevProps.className !== this.props.className) {
       this.setState({ open: false });
     }
 
+    // Reinitialize edit mode when props change
     this.initializeEditFilterMode();
-  }
 
-  componentDidUpdate(prevProps) {
     // Update filter info when savedFilters prop changes (async loading completed)
     if (prevProps.savedFilters !== this.props.savedFilters) {
       this.updateFilterInfoIfNeeded();
@@ -159,9 +159,9 @@ export default class BrowserFilter extends React.Component {
 
       const matchingFilter = savedFilters.find(savedFilter => {
         try {
-          const savedFilters = JSON.parse(savedFilter.filter);
+          const parsedFilterData = JSON.parse(savedFilter.filter);
           // Normalize saved filters for comparison (remove class property if it matches current className)
-          const normalizedSavedFilters = savedFilters.map(filter => {
+          const normalizedSavedFilters = parsedFilterData.map(filter => {
             const normalizedFilter = { ...filter };
             if (normalizedFilter.class === urlClassName) {
               delete normalizedFilter.class;
@@ -246,9 +246,9 @@ export default class BrowserFilter extends React.Component {
 
       const matchingFilter = savedFilters.find(savedFilter => {
         try {
-          const savedFilters = JSON.parse(savedFilter.filter);
+          const parsedFilterData = JSON.parse(savedFilter.filter);
           // Normalize saved filters for comparison (remove class property if it matches current className)
-          const normalizedSavedFilters = savedFilters.map(filter => {
+          const normalizedSavedFilters = parsedFilterData.map(filter => {
             const normalizedFilter = { ...filter };
             if (normalizedFilter.class === urlClassName) {
               delete normalizedFilter.class;
@@ -544,9 +544,9 @@ export default class BrowserFilter extends React.Component {
         const matchingFilter = savedFilters.find(filter => {
           if (!filter.id && filter.name === currentFilterInfo.name) {
             try {
-              const savedFilters = JSON.parse(filter.filter);
+              const parsedFilterData = JSON.parse(filter.filter);
               // Normalize saved filters for comparison
-              const normalizedSavedFilters = savedFilters.map(savedFilter => {
+              const normalizedSavedFilters = parsedFilterData.map(savedFilter => {
                 const normalizedFilter = { ...savedFilter };
                 if (normalizedFilter.class === this.props.className) {
                   delete normalizedFilter.class;

--- a/src/components/BrowserFilter/BrowserFilter.react.js
+++ b/src/components/BrowserFilter/BrowserFilter.react.js
@@ -81,12 +81,36 @@ export default class BrowserFilter extends React.Component {
     }
   }
 
+  updateFilterInfoIfNeeded() {
+    // If dialog is open in showMore mode and we don't have a filter name yet,
+    // but now we have savedFilters available, update the filter info
+    if (this.state.open && this.state.showMore && !this.state.name) {
+      const currentFilter = this.getCurrentFilterInfo();
+
+      if (currentFilter.name) {
+        this.setState({
+          name: currentFilter.name,
+          originalFilterName: currentFilter.name,
+          relativeDates: currentFilter.hasRelativeDates || false,
+          originalRelativeDates: currentFilter.hasRelativeDates || false,
+        });
+      }
+    }
+  }
+
   componentWillReceiveProps(props) {
     if (props.className !== this.props.className) {
       this.setState({ open: false });
     }
 
     this.initializeEditFilterMode();
+  }
+
+  componentDidUpdate(prevProps) {
+    // Update filter info when savedFilters prop changes (async loading completed)
+    if (prevProps.savedFilters !== this.props.savedFilters) {
+      this.updateFilterInfoIfNeeded();
+    }
   }
 
   componentDidMount() {
@@ -100,18 +124,14 @@ export default class BrowserFilter extends React.Component {
 
     const urlClassName = this.getClassNameFromURL();
 
-    if (filterId) {
-      const preferences = ClassPreferences.getPreferences(
-        this.context.applicationId,
-        urlClassName
-      );
+    // Use savedFilters prop instead of ClassPreferences
+    const savedFilters = this.props.savedFilters || [];
 
-      if (preferences.filters) {
-        // If filterId exists in saved filters, it's definitely a saved filter
-        const savedFilter = preferences.filters.find(filter => filter.id === filterId);
-        if (savedFilter) {
-          return true;
-        }
+    if (filterId) {
+      // If filterId exists in saved filters, it's definitely a saved filter
+      const savedFilter = savedFilters.find(filter => filter.id === filterId);
+      if (savedFilter) {
+        return true;
       }
       // If filterId is in URL but not found in saved filters, it's not saved
       return false;
@@ -120,50 +140,43 @@ export default class BrowserFilter extends React.Component {
     // Check for legacy filters (filters parameter without filterId)
     const filtersParam = urlParams.get('filters');
     if (filtersParam) {
-      const preferences = ClassPreferences.getPreferences(
-        this.context.applicationId,
-        urlClassName
-      );
+      // Parse the URL filters parameter to get the actual filter data
+      let urlFilters;
+      try {
+        urlFilters = JSON.parse(filtersParam);
+      } catch {
+        return false;
+      }
 
-      if (preferences.filters) {
-        // Parse the URL filters parameter to get the actual filter data
-        let urlFilters;
+      // Normalize URL filters for comparison (remove class property if it matches current className)
+      const normalizedUrlFilters = urlFilters.map(filter => {
+        const normalizedFilter = { ...filter };
+        if (normalizedFilter.class === urlClassName) {
+          delete normalizedFilter.class;
+        }
+        return normalizedFilter;
+      });
+      const urlFiltersString = JSON.stringify(normalizedUrlFilters);
+
+      const matchingFilter = savedFilters.find(savedFilter => {
         try {
-          urlFilters = JSON.parse(filtersParam);
+          const savedFilters = JSON.parse(savedFilter.filter);
+          // Normalize saved filters for comparison (remove class property if it matches current className)
+          const normalizedSavedFilters = savedFilters.map(filter => {
+            const normalizedFilter = { ...filter };
+            if (normalizedFilter.class === urlClassName) {
+              delete normalizedFilter.class;
+            }
+            return normalizedFilter;
+          });
+          const savedFiltersString = JSON.stringify(normalizedSavedFilters);
+          return savedFiltersString === urlFiltersString;
         } catch {
           return false;
         }
+      });
 
-        // Normalize URL filters for comparison (remove class property if it matches current className)
-        const normalizedUrlFilters = urlFilters.map(filter => {
-          const normalizedFilter = { ...filter };
-          if (normalizedFilter.class === urlClassName) {
-            delete normalizedFilter.class;
-          }
-          return normalizedFilter;
-        });
-        const urlFiltersString = JSON.stringify(normalizedUrlFilters);
-
-        const matchingFilter = preferences.filters.find(savedFilter => {
-          try {
-            const savedFilters = JSON.parse(savedFilter.filter);
-            // Normalize saved filters for comparison (remove class property if it matches current className)
-            const normalizedSavedFilters = savedFilters.map(filter => {
-              const normalizedFilter = { ...filter };
-              if (normalizedFilter.class === urlClassName) {
-                delete normalizedFilter.class;
-              }
-              return normalizedFilter;
-            });
-            const savedFiltersString = JSON.stringify(normalizedSavedFilters);
-            return savedFiltersString === urlFiltersString;
-          } catch {
-            return false;
-          }
-        });
-
-        return !!matchingFilter;
-      }
+      return !!matchingFilter;
     }
 
     return false;
@@ -177,110 +190,99 @@ export default class BrowserFilter extends React.Component {
 
     const urlClassName = this.getClassNameFromURL();
 
+    // Use savedFilters prop instead of ClassPreferences
+    const savedFilters = this.props.savedFilters || [];
+
     if (filterId) {
-      const preferences = ClassPreferences.getPreferences(
-        this.context.applicationId,
-        urlClassName
-      );
-
-      if (preferences.filters) {
-        const savedFilter = preferences.filters.find(filter => filter.id === filterId);
-        if (savedFilter) {
-          // Check if the filter has relative dates
-          let hasRelativeDates = false;
-          try {
-            const filterData = JSON.parse(savedFilter.filter);
-            hasRelativeDates = filterData.some(filter =>
-              filter.compareTo && filter.compareTo.__type === 'RelativeDate'
-            );
-          } catch (error) {
-            // Log parsing errors for debugging
-            console.warn('Failed to parse saved filter:', error);
-            hasRelativeDates = false;
-          }
-
-          return {
-            id: savedFilter.id,
-            name: savedFilter.name,
-            isApplied: true,
-            hasRelativeDates: hasRelativeDates
-          };
+      const savedFilter = savedFilters.find(filter => filter.id === filterId);
+      if (savedFilter) {
+        // Check if the filter has relative dates
+        let hasRelativeDates = false;
+        try {
+          const filterData = JSON.parse(savedFilter.filter);
+          hasRelativeDates = filterData.some(filter =>
+            filter.compareTo && filter.compareTo.__type === 'RelativeDate'
+          );
+        } catch (error) {
+          // Log parsing errors for debugging
+          console.warn('Failed to parse saved filter:', error);
+          hasRelativeDates = false;
         }
+
+        return {
+          id: savedFilter.id,
+          name: savedFilter.name,
+          isApplied: true,
+          hasRelativeDates: hasRelativeDates
+        };
       }
     }
 
     // Check for legacy filters (filters parameter without filterId)
     if (filtersParam) {
-      const preferences = ClassPreferences.getPreferences(
-        this.context.applicationId,
-        urlClassName
-      );
+      // Parse the URL filters parameter to get the actual filter data
+      let urlFilters;
+      try {
+        urlFilters = JSON.parse(filtersParam);
+      } catch (error) {
+        console.warn('Failed to parse URL filters:', error);
+        return {
+          id: null,
+          name: '',
+          isApplied: false,
+          hasRelativeDates: false,
+          isLegacy: false
+        };
+      }
 
-      if (preferences.filters) {
-        // Parse the URL filters parameter to get the actual filter data
-        let urlFilters;
+      // Normalize URL filters for comparison (remove class property if it matches current className)
+      const normalizedUrlFilters = urlFilters.map(filter => {
+        const normalizedFilter = { ...filter };
+        if (normalizedFilter.class === urlClassName) {
+          delete normalizedFilter.class;
+        }
+        return normalizedFilter;
+      });
+      const urlFiltersString = JSON.stringify(normalizedUrlFilters);
+
+      const matchingFilter = savedFilters.find(savedFilter => {
         try {
-          urlFilters = JSON.parse(filtersParam);
+          const savedFilters = JSON.parse(savedFilter.filter);
+          // Normalize saved filters for comparison (remove class property if it matches current className)
+          const normalizedSavedFilters = savedFilters.map(filter => {
+            const normalizedFilter = { ...filter };
+            if (normalizedFilter.class === urlClassName) {
+              delete normalizedFilter.class;
+            }
+            return normalizedFilter;
+          });
+          const savedFiltersString = JSON.stringify(normalizedSavedFilters);
+          return savedFiltersString === urlFiltersString;
+        } catch {
+          return false;
+        }
+      });
+
+      if (matchingFilter) {
+        // Check if the filter has relative dates
+        let hasRelativeDates = false;
+        try {
+          const filterData = JSON.parse(matchingFilter.filter);
+          hasRelativeDates = filterData.some(filter =>
+            filter.compareTo && filter.compareTo.__type === 'RelativeDate'
+          );
         } catch (error) {
-          console.warn('Failed to parse URL filters:', error);
-          return {
-            id: null,
-            name: '',
-            isApplied: false,
-            hasRelativeDates: false,
-            isLegacy: false
-          };
+          console.warn('Failed to parse saved filter:', error);
+          hasRelativeDates = false;
         }
 
-        // Normalize URL filters for comparison (remove class property if it matches current className)
-        const normalizedUrlFilters = urlFilters.map(filter => {
-          const normalizedFilter = { ...filter };
-          if (normalizedFilter.class === urlClassName) {
-            delete normalizedFilter.class;
-          }
-          return normalizedFilter;
-        });
-        const urlFiltersString = JSON.stringify(normalizedUrlFilters);
-
-        const matchingFilter = preferences.filters.find(savedFilter => {
-          try {
-            const savedFilters = JSON.parse(savedFilter.filter);
-            // Normalize saved filters for comparison (remove class property if it matches current className)
-            const normalizedSavedFilters = savedFilters.map(filter => {
-              const normalizedFilter = { ...filter };
-              if (normalizedFilter.class === urlClassName) {
-                delete normalizedFilter.class;
-              }
-              return normalizedFilter;
-            });
-            const savedFiltersString = JSON.stringify(normalizedSavedFilters);
-            return savedFiltersString === urlFiltersString;
-          } catch {
-            return false;
-          }
-        });
-
-        if (matchingFilter) {
-          // Check if the filter has relative dates
-          let hasRelativeDates = false;
-          try {
-            const filterData = JSON.parse(matchingFilter.filter);
-            hasRelativeDates = filterData.some(filter =>
-              filter.compareTo && filter.compareTo.__type === 'RelativeDate'
-            );
-          } catch (error) {
-            console.warn('Failed to parse saved filter:', error);
-            hasRelativeDates = false;
-          }
-
-          return {
-            id: matchingFilter.id || null, // Legacy filters might not have an id
-            name: matchingFilter.name,
-            isApplied: true,
-            hasRelativeDates: hasRelativeDates,
-            isLegacy: !matchingFilter.id // Mark as legacy if no id
-          };
-        }
+        return {
+          id: matchingFilter.id || null, // Legacy filters might not have an id
+          name: matchingFilter.name,
+          isApplied: true,
+          hasRelativeDates: hasRelativeDates,
+          isLegacy: !matchingFilter.id // Mark as legacy if no id
+        };
       }
     }
 
@@ -300,25 +302,21 @@ export default class BrowserFilter extends React.Component {
 
     const urlClassName = this.getClassNameFromURL();
 
+    // Use savedFilters prop instead of ClassPreferences
+    const savedFilters = this.props.savedFilters || [];
+
     // If we have a filterId, load from saved filters
     if (filterId) {
-      const preferences = ClassPreferences.getPreferences(
-        this.context.applicationId,
-        urlClassName
-      );
-
-      if (preferences.filters) {
-        const savedFilter = preferences.filters.find(filter => filter.id === filterId);
-        if (savedFilter) {
-          try {
-            const filterData = JSON.parse(savedFilter.filter);
-            return new List(filterData.map(filter => {
-              const processedFilter = { ...filter, class: filter.class || urlClassName };
-              return new ImmutableMap(processedFilter);
-            }));
-          } catch (error) {
-            console.warn('Failed to parse saved filter:', error);
-          }
+      const savedFilter = savedFilters.find(filter => filter.id === filterId);
+      if (savedFilter) {
+        try {
+          const filterData = JSON.parse(savedFilter.filter);
+          return new List(filterData.map(filter => {
+            const processedFilter = { ...filter, class: filter.class || urlClassName };
+            return new ImmutableMap(processedFilter);
+          }));
+        } catch (error) {
+          console.warn('Failed to parse saved filter:', error);
         }
       }
     }
@@ -376,16 +374,12 @@ export default class BrowserFilter extends React.Component {
   }
 
   isFilterNameExists(name) {
-    const urlClassName = this.getClassNameFromURL();
+    // Use savedFilters prop instead of ClassPreferences
+    const savedFilters = this.props.savedFilters || [];
 
-    const preferences = ClassPreferences.getPreferences(
-      this.context.applicationId,
-      urlClassName
-    );
-
-    if (preferences.filters && name) {
+    if (savedFilters && name) {
       const currentFilterInfo = this.getCurrentFilterInfo();
-      return preferences.filters.some(filter => {
+      return savedFilters.some(filter => {
         // For filters with the same name, check if it's not the current filter
         if (filter.name === name) {
           // If current filter has an ID, exclude it by ID
@@ -535,42 +529,42 @@ export default class BrowserFilter extends React.Component {
     if (this.props.onDeleteFilter) {
       // For legacy filters, we need to pass the entire filter object for the parent to match
       if (currentFilterInfo.isLegacy) {
-        const preferences = ClassPreferences.getPreferences(this.context.applicationId, this.props.className);
-        if (preferences.filters) {
-          // Normalize current filters for comparison
-          const currentFilters = this.props.filters.toJS().map(filter => {
-            const normalizedFilter = { ...filter };
-            if (normalizedFilter.class === this.props.className) {
-              delete normalizedFilter.class;
-            }
-            return normalizedFilter;
-          });
-          const currentFiltersString = JSON.stringify(currentFilters);
+        // Use savedFilters prop instead of ClassPreferences
+        const savedFilters = this.props.savedFilters || [];
 
-          const matchingFilter = preferences.filters.find(filter => {
-            if (!filter.id && filter.name === currentFilterInfo.name) {
-              try {
-                const savedFilters = JSON.parse(filter.filter);
-                // Normalize saved filters for comparison
-                const normalizedSavedFilters = savedFilters.map(savedFilter => {
-                  const normalizedFilter = { ...savedFilter };
-                  if (normalizedFilter.class === this.props.className) {
-                    delete normalizedFilter.class;
-                  }
-                  return normalizedFilter;
-                });
-                const savedFiltersString = JSON.stringify(normalizedSavedFilters);
-                return savedFiltersString === currentFiltersString;
-              } catch {
-                return false;
-              }
-            }
-            return false;
-          });
-
-          if (matchingFilter) {
-            this.props.onDeleteFilter(matchingFilter);
+        // Normalize current filters for comparison
+        const currentFilters = this.props.filters.toJS().map(filter => {
+          const normalizedFilter = { ...filter };
+          if (normalizedFilter.class === this.props.className) {
+            delete normalizedFilter.class;
           }
+          return normalizedFilter;
+        });
+        const currentFiltersString = JSON.stringify(currentFilters);
+
+        const matchingFilter = savedFilters.find(filter => {
+          if (!filter.id && filter.name === currentFilterInfo.name) {
+            try {
+              const savedFilters = JSON.parse(filter.filter);
+              // Normalize saved filters for comparison
+              const normalizedSavedFilters = savedFilters.map(savedFilter => {
+                const normalizedFilter = { ...savedFilter };
+                if (normalizedFilter.class === this.props.className) {
+                  delete normalizedFilter.class;
+                }
+                return normalizedFilter;
+              });
+              const savedFiltersString = JSON.stringify(normalizedSavedFilters);
+              return savedFiltersString === currentFiltersString;
+            } catch {
+              return false;
+            }
+          }
+          return false;
+        });
+
+        if (matchingFilter) {
+          this.props.onDeleteFilter(matchingFilter);
         }
       } else if (currentFilterInfo.id) {
         // For modern filters with ID, just pass the ID
@@ -687,7 +681,7 @@ export default class BrowserFilter extends React.Component {
     this.props.onChange(formatted);
   }
 
-  save() {
+  async save() {
     // Store the original UI-friendly filters before any conversion
     const originalUIFilters = this.state.filters;
 
@@ -737,7 +731,7 @@ export default class BrowserFilter extends React.Component {
       filterId = `legacy:${currentFilterInfo.name}`;
     }
 
-    const savedFilterId = this.props.onSaveFilter(formatted, this.state.name, this.state.relativeDates, filterId);
+    const savedFilterId = await this.props.onSaveFilter(formatted, this.state.name, this.state.relativeDates, filterId);
 
     // Only close the dialog if we're not in edit mode (showMore)
     if (!this.state.showMore) {

--- a/src/components/Filter/Filter.react.js
+++ b/src/components/Filter/Filter.react.js
@@ -129,7 +129,7 @@ const Filter = ({
           gap: '10px',
           padding: '12px 15px 0px 15px',
           color: '#343445',
-          'font-weight': '600',
+          fontWeight: '600',
         }}
       >
         <div style={{ width: '140px' }}>Class</div>

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -195,6 +195,8 @@ class Browser extends DashboardView {
       classFilters: {}, // Map of className -> filters array
     };
 
+    this._isMounted = false;
+
     this.addLocation = this.addLocation.bind(this);
     this.allClassesSchema = this.getAllClassesSchema.bind(this);
     this.removeLocation = this.removeLocation.bind(this);
@@ -298,6 +300,7 @@ class Browser extends DashboardView {
   }
 
   componentDidMount() {
+    this._isMounted = true;
     this.addLocation(this.props.params.appId);
     window.addEventListener('mouseup', this.onMouseUpRowCheckBox);
     get('/parse-dashboard-config.json').then(data => {
@@ -349,10 +352,14 @@ class Browser extends DashboardView {
       );
     }
 
-    this.setState({ classFilters });
+    // Check if component is still mounted before updating state
+    if (this._isMounted) {
+      this.setState({ classFilters });
+    }
   }
 
   componentWillUnmount() {
+    this._isMounted = false;
     if (this.currentQuery) {
       this.currentQuery.cancel();
     }
@@ -1459,8 +1466,8 @@ class Browser extends DashboardView {
 
     // Merge server filters into preferences for the update logic
     // Use server filters as source of truth
-    const serverFilterIds = new Set(existingFilters.map(f => f.id));
-    const localOnlyFilters = preferences.filters.filter(f => !serverFilterIds.has(f.id));
+    const serverFilterIds = new Set(existingFilters.filter(f => f.id).map(f => f.id));
+    const localOnlyFilters = preferences.filters.filter(f => !f.id || !serverFilterIds.has(f.id));
     preferences.filters = [...existingFilters, ...localOnlyFilters];
 
     let newFilterId = filterId;

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -47,6 +47,7 @@ import { useBeforeUnload } from 'react-router-dom';
 import BrowserFooter from './BrowserFooter.react';
 
 const SELECTED_ROWS_MESSAGE = 'There are selected rows. Are you sure you want to leave this page?';
+const EMPTY_FILTERS_ARRAY = [];
 
 function SelectedRowsNavigationPrompt({ when }) {
   const message = SELECTED_ROWS_MESSAGE;
@@ -1441,10 +1442,26 @@ class Browser extends DashboardView {
     }
 
     const _filters = JSON.stringify(jsonFilters);
+    const className = this.props.params.className;
+
+    // Use server-loaded filters from state if available, otherwise fallback to local storage
+    const existingFilters = this.state.classFilters[className] || [];
+
     const preferences = ClassPreferences.getPreferences(
       this.context.applicationId,
-      this.props.params.className
+      className
     );
+
+    // Initialize preferences.filters from state if needed
+    if (!preferences.filters) {
+      preferences.filters = [];
+    }
+
+    // Merge server filters into preferences for the update logic
+    // Use server filters as source of truth
+    const serverFilterIds = new Set(existingFilters.map(f => f.id));
+    const localOnlyFilters = preferences.filters.filter(f => !serverFilterIds.has(f.id));
+    preferences.filters = [...existingFilters, ...localOnlyFilters];
 
     let newFilterId = filterId;
 
@@ -2652,6 +2669,7 @@ class Browser extends DashboardView {
               perms={this.state.clp[className]}
               schema={this.props.schema}
               filters={this.state.filters}
+              savedFilters={this.state.classFilters[className] || EMPTY_FILTERS_ARRAY}
               onFilterChange={this.updateFilters}
               onFilterSave={(...args) => this.saveFilters(...args)}
               onDeleteFilter={this.deleteFilter}

--- a/src/dashboard/Data/Browser/BrowserToolbar.react.js
+++ b/src/dashboard/Data/Browser/BrowserToolbar.react.js
@@ -27,6 +27,7 @@ const BrowserToolbar = ({
   perms,
   schema,
   filters,
+  savedFilters,
   selection,
   relation,
   setCurrent,
@@ -490,6 +491,7 @@ const BrowserToolbar = ({
         setCurrent={setCurrent}
         schema={schemaSimplifiedData}
         filters={filters}
+        savedFilters={savedFilters}
         onChange={onFilterChange}
         onSaveFilter={onFilterSave}
         onDeleteFilter={onDeleteFilter}


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a saved-filters prop and server-synced per-class filters with a reload path.
  * Filter UI now receives saved filters from the toolbar; save flow is async and awaits results for reliable UI/state sync.

* **Bug Fixes**
  * Better handling and normalization of legacy (URL) vs modern filters.
  * Improved date conversion between display and storage formats.
  * Graceful merge/recovery when saved filters are missing or out of sync.

* **Style**
  * Minor inline style key corrected for consistent rendering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->