### PR TITLE
fix: Some context menu sub-menu lists don't change background color on mouse hover in Safari browser

### DIFF
--- a/src/components/ContextMenu/ContextMenu.scss
+++ b/src/components/ContextMenu/ContextMenu.scss
@@ -3,9 +3,6 @@
 .menu {
 	position: absolute;
 	font-size: 14px;
-	// To be shown above the toolbar with also z-index set
-	// src/components/Toolbar/Toolbar.scss
-	z-index: 6;
 
 	ul {
 		background: $purple;
@@ -33,6 +30,8 @@
 
 	.category {
 		position: absolute;
+		// Keep above the toolbar (src/components/Toolbar/Toolbar.scss).
+		z-index: 6;
 
 		.item {
 			width: 100%;


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed context menu stacking order to display correctly above the toolbar and other interface elements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->