### PR TITLE
fix: Graph panel covers right-most columns of data browser table

### DIFF
--- a/src/dashboard/Data/Browser/BrowserTable.react.js
+++ b/src/dashboard/Data/Browser/BrowserTable.react.js
@@ -565,8 +565,12 @@ export default class BrowserTable extends React.Component {
         );
       }
     }
-    const rightValue =
-      this.props.panelWidth && this.props.isPanelVisible ? `${this.props.panelWidth}px` : '0px';
+    const aggregationPanelWidth =
+      this.props.panelWidth && this.props.isPanelVisible ? this.props.panelWidth : 0;
+    const graphPanelWidth =
+      this.props.graphPanelWidth && this.props.isGraphPanelVisible ? this.props.graphPanelWidth : 0;
+    const totalRightOffset = aggregationPanelWidth + graphPanelWidth;
+    const rightValue = `${totalRightOffset}px`;
 
     return (
       <div

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -1868,6 +1868,8 @@ export default class DataBrowser extends React.Component {
             skip={this.props.skip}
             limit={this.props.limit}
             firstSelectedCell={this.state.firstSelectedCell}
+            isGraphPanelVisible={this.state.isGraphPanelVisible && !!this.state.graphConfig}
+            graphPanelWidth={this.state.graphPanelWidth}
             {...other}
           />
           {this.state.isPanelVisible && (


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layout calculations to properly handle multiple panels displayed simultaneously, ensuring correct spacing and alignment when graph and data panels are shown together.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->