### PR TITLE
feat: Add storing data browser graphs to support multiple graphs per class

### DIFF
--- a/src/components/GraphPanel/GraphPanel.react.js
+++ b/src/components/GraphPanel/GraphPanel.react.js
@@ -72,10 +72,15 @@ const GraphPanel = ({
   onRefresh,
   onEdit,
   onClose,
+  availableGraphs = [],
+  onGraphSelect,
+  onNewGraph,
 }) => {
   const chartRef = useRef(null);
   const containerRef = useRef(null);
+  const dropdownRef = useRef(null);
   const [containerHeight, setContainerHeight] = useState(0);
+  const [showGraphDropdown, setShowGraphDropdown] = useState(false);
 
   // Measure container height for dynamic label sizing
   useEffect(() => {
@@ -89,6 +94,22 @@ const GraphPanel = ({
     window.addEventListener('resize', updateHeight);
     return () => window.removeEventListener('resize', updateHeight);
   }, []);
+
+  // Handle click outside to close dropdown
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+        setShowGraphDropdown(false);
+      }
+    };
+
+    if (showGraphDropdown) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [showGraphDropdown]);
 
   // Validate configuration and process data
   const { processedData, validationError } = useMemo(() => {
@@ -404,17 +425,74 @@ const GraphPanel = ({
     );
   }
 
+  const currentGraphTitle = graphConfig?.title || 'Untitled Graph';
+  // Show dropdown when there are saved graphs OR when onGraphSelect is provided
+  // This allows users to see "New Graph" option even with no saved graphs
+  const showDropdown = (availableGraphs && availableGraphs.length > 0) || onGraphSelect;
+
+  const handleGraphSelect = (graph) => {
+    if (onGraphSelect) {
+      onGraphSelect(graph);
+    }
+    setShowGraphDropdown(false);
+  };
+
+  const handleNewGraph = () => {
+    if (onNewGraph) {
+      onNewGraph();
+    } else if (onEdit) {
+      onEdit();
+    }
+    setShowGraphDropdown(false);
+  };
+
   return (
     <div className={styles.container}>
       <div className={styles.header}>
-        <h2 className={styles.title}>
-          Graph
-        </h2>
+        <h2 className={styles.title}>{currentGraphTitle}</h2>
         <div className={styles.headerButtons}>
+          {showDropdown && (
+            <div className={styles.dropdown} ref={dropdownRef}>
+              <button
+                className={styles.dropdownTrigger}
+                onClick={() => setShowGraphDropdown(!showGraphDropdown)}
+                aria-label="Select graph"
+                title="Select graph"
+              >
+                <Icon name="down-solid" width={14} height={14} fill="#ffffff" />
+              </button>
+              {showGraphDropdown && (
+                <div className={styles.dropdownMenu}>
+                  {availableGraphs.map((graph) => (
+                    <button
+                      key={graph.id}
+                      className={`${styles.dropdownItem} ${graph.id === graphConfig?.id ? styles.dropdownItemActive : ''}`}
+                      onClick={() => handleGraphSelect(graph)}
+                    >
+                      <span className={styles.dropdownItemTitle}>
+                        {graph.title || 'Untitled Graph'}
+                      </span>
+                      <span className={styles.dropdownItemType}>
+                        {graph.chartType}
+                      </span>
+                    </button>
+                  ))}
+                  <div className={styles.dropdownSeparator} />
+                  <button
+                    className={styles.dropdownItem}
+                    onClick={handleNewGraph}
+                  >
+                    <Icon name="plus" width={12} height={12} />
+                    <span>New Graph</span>
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
           {onEdit && (
             <button
               type="button"
-              onClick={onEdit}
+              onClick={() => onEdit()}
               className={styles.editButton}
               aria-label="Edit graph configuration"
               title="Edit graph"
@@ -425,7 +503,7 @@ const GraphPanel = ({
           {onRefresh && (
             <button
               type="button"
-              onClick={onRefresh}
+              onClick={() => onRefresh()}
               className={styles.refreshButton}
               aria-label="Refresh graph data"
               title="Refresh graph"
@@ -436,7 +514,7 @@ const GraphPanel = ({
           {onClose && (
             <button
               type="button"
-              onClick={onClose}
+              onClick={() => onClose()}
               className={styles.closeButton}
               aria-label="Close graph panel"
               title="Close graph"

--- a/src/components/GraphPanel/GraphPanel.react.js
+++ b/src/components/GraphPanel/GraphPanel.react.js
@@ -445,9 +445,9 @@ const GraphPanel = ({
   }
 
   const currentGraphTitle = graphConfig?.title || 'Graph';
-  // Show dropdown when there are saved graphs OR when onGraphSelect is provided
-  // This allows users to see "New Graph" option even with no saved graphs
-  const showDropdown = (availableGraphs && availableGraphs.length > 0) || onGraphSelect;
+  // Only show dropdown/buttons when there's an active graph configuration
+  const hasActiveGraph = !!graphConfig;
+  const showDropdown = hasActiveGraph && availableGraphs && availableGraphs.length > 0;
 
   const handleGraphSelect = (graph) => {
     if (onGraphSelect) {
@@ -506,7 +506,7 @@ const GraphPanel = ({
               )}
             </div>
           )}
-          {onEdit && (
+          {hasActiveGraph && onEdit && (
             <button
               type="button"
               onClick={() => onEdit()}
@@ -517,7 +517,7 @@ const GraphPanel = ({
               <Icon name="edit-solid" width={14} height={14} fill="#ffffff" />
             </button>
           )}
-          {onRefresh && (
+          {hasActiveGraph && onRefresh && (
             <button
               type="button"
               onClick={() => onRefresh()}

--- a/src/components/GraphPanel/GraphPanel.react.js
+++ b/src/components/GraphPanel/GraphPanel.react.js
@@ -368,11 +368,16 @@ const GraphPanel = ({
       return (
         <div className={styles.noData}>
           <Icon name="chart-line" width={48} height={48} fill="#ffffff" />
-          <p>No graph configured</p>
+          <p>No graph configured.</p>
           {onNewGraph && (
-            <button className={styles.createGraphButton} onClick={() => onNewGraph()}>
-              Create Graph
-            </button>
+            <>
+              <button className={styles.createGraphButton} onClick={() => onNewGraph()}>
+                Create Graph
+              </button>
+              <p className={styles.previewNotice}>
+                Graph is a preview feature. Future versions may introduce breaking changes without announcement.
+              </p>
+            </>
           )}
         </div>
       );
@@ -439,7 +444,7 @@ const GraphPanel = ({
     );
   }
 
-  const currentGraphTitle = graphConfig?.title || 'Untitled Graph';
+  const currentGraphTitle = graphConfig?.title || 'Graph';
   // Show dropdown when there are saved graphs OR when onGraphSelect is provided
   // This allows users to see "New Graph" option even with no saved graphs
   const showDropdown = (availableGraphs && availableGraphs.length > 0) || onGraphSelect;
@@ -484,7 +489,7 @@ const GraphPanel = ({
                       onClick={() => handleGraphSelect(graph)}
                     >
                       <span className={styles.dropdownItemTitle}>
-                        {graph.title || 'Untitled Graph'}
+                        {graph.title || 'Graph'}
                       </span>
                       <span className={styles.dropdownItemType}>
                         {graph.chartType}
@@ -497,7 +502,7 @@ const GraphPanel = ({
                     onClick={handleNewGraph}
                   >
                     <Icon name="plus" width={12} height={12} />
-                    <span>New Graph</span>
+                    <span>Create Graph</span>
                   </button>
                 </div>
               )}

--- a/src/components/GraphPanel/GraphPanel.react.js
+++ b/src/components/GraphPanel/GraphPanel.react.js
@@ -459,8 +459,6 @@ const GraphPanel = ({
   const handleNewGraph = () => {
     if (onNewGraph) {
       onNewGraph();
-    } else if (onEdit) {
-      onEdit();
     }
     setShowGraphDropdown(false);
   };

--- a/src/components/GraphPanel/GraphPanel.react.js
+++ b/src/components/GraphPanel/GraphPanel.react.js
@@ -364,7 +364,21 @@ const GraphPanel = ({
       );
     }
 
-    if (!processedData || !graphConfig) {
+    if (!graphConfig) {
+      return (
+        <div className={styles.noData}>
+          <Icon name="chart-line" width={48} height={48} fill="#ffffff" />
+          <p>No graph configured</p>
+          {onNewGraph && (
+            <button className={styles.createGraphButton} onClick={() => onNewGraph()}>
+              Create Graph
+            </button>
+          )}
+        </div>
+      );
+    }
+
+    if (!processedData) {
       return (
         <div className={styles.noData}>
           <Icon name="chart-line" width={48} height={48} fill="#ffffff" />

--- a/src/components/GraphPanel/GraphPanel.scss
+++ b/src/components/GraphPanel/GraphPanel.scss
@@ -241,6 +241,32 @@
   }
 }
 
+.createGraphButton {
+  margin-top: 16px;
+  padding: 10px 20px;
+  background: #169cee;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  color: white;
+  transition: background 0.2s;
+
+  &:hover {
+    background: #147abd;
+  }
+
+  &:focus {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(22, 156, 238, 0.3);
+  }
+
+  &:active {
+    background: #0f5a8e;
+  }
+}
+
 .configInfo {
   padding: 8px 16px;
   background: #f8f8f8;

--- a/src/components/GraphPanel/GraphPanel.scss
+++ b/src/components/GraphPanel/GraphPanel.scss
@@ -31,6 +31,102 @@
   vertical-align: middle;
 }
 
+.dropdown {
+  position: relative;
+  display: inline-block;
+}
+
+.dropdownTrigger {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 3px;
+  color: white;
+  opacity: 0.8;
+  vertical-align: middle;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.1);
+    opacity: 1;
+  }
+
+  &:focus {
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.5);
+  }
+}
+
+.dropdownMenu {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 4px;
+  background: white;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  min-width: 220px;
+  max-width: 300px;
+  max-height: 400px;
+  overflow-y: auto;
+  z-index: 1000;
+}
+
+.dropdownItem {
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 8px 12px;
+  text-align: left;
+  cursor: pointer;
+  color: #333;
+  font-size: 13px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  &:hover {
+    background: #f5f5f5;
+  }
+
+  &:focus {
+    outline: none;
+    background: #e8e8e8;
+  }
+}
+
+.dropdownItemActive {
+  background: #e3f2fd;
+
+  &:hover {
+    background: #bbdefb;
+  }
+}
+
+.dropdownItemTitle {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 500;
+}
+
+.dropdownItemType {
+  font-size: 11px;
+  color: #666;
+  text-transform: capitalize;
+  background: #f0f0f0;
+  padding: 2px 6px;
+  border-radius: 3px;
+}
+
+.dropdownSeparator {
+  height: 1px;
+  background: #e0e0e0;
+  margin: 4px 0;
+}
+
 .headerButtons {
   gap: 8px;
   padding-right: 8px;

--- a/src/components/GraphPanel/GraphPanel.scss
+++ b/src/components/GraphPanel/GraphPanel.scss
@@ -267,6 +267,15 @@
   }
 }
 
+.previewNotice {
+  margin-top: 24px !important;
+  padding-top: 4px;
+  font-size: 11px;
+  color: #999;
+  max-width: 400px;
+  line-height: 1.4;
+}
+
 .configInfo {
   padding: 8px 16px;
   background: #f8f8f8;

--- a/src/dashboard/Data/Browser/BrowserToolbar.react.js
+++ b/src/dashboard/Data/Browser/BrowserToolbar.react.js
@@ -99,8 +99,6 @@ const BrowserToolbar = ({
   toggleShowPanelCheckbox,
   toggleGraphPanel,
   isGraphPanelVisible,
-  showGraphDialog,
-  hasGraphConfig,
 }) => {
   const selectionLength = Object.keys(selection).length;
   const isPendingEditCloneRows = editCloneRows && editCloneRows.length > 0;
@@ -487,27 +485,24 @@ const BrowserToolbar = ({
       </BrowserMenu>
       <div className={styles.toolbarSeparator} />
       <BrowserMenu setCurrent={setCurrent} title="Graph" icon="analytics-solid">
-        <MenuItem text="Configure Graph" onClick={showGraphDialog} />
-        {hasGraphConfig && (
-          <MenuItem
-            text={
-              <span>
-                {isGraphPanelVisible && (
-                  <Icon
-                    name="check"
-                    width={12}
-                    height={12}
-                    fill="#ffffffff"
-                    className="menuCheck"
-                  />
-                )}
-                Show Graph Panel
-              </span>
-            }
-            onClick={toggleGraphPanel}
-            disableMouseDown={true}
-          />
-        )}
+        <MenuItem
+          text={
+            <span>
+              {isGraphPanelVisible && (
+                <Icon
+                  name="check"
+                  width={12}
+                  height={12}
+                  fill="#ffffffff"
+                  className="menuCheck"
+                />
+              )}
+              Show Graph Panel
+            </span>
+          }
+          onClick={toggleGraphPanel}
+          disableMouseDown={true}
+        />
       </BrowserMenu>
       <div className={styles.toolbarSeparator} />
       <a className={classes.join(' ')} onClick={isPendingEditCloneRows ? null : onRefresh}>

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -37,12 +37,6 @@ const AGGREGATION_PANEL_WIDTH = 'aggregationPanelWidth';
 const AGGREGATION_PANEL_COUNT = 'aggregationPanelCount';
 const GRAPH_PANEL_VISIBLE = 'graphPanelVisible';
 const GRAPH_PANEL_WIDTH = 'graphPanelWidth';
-const GRAPH_PANEL_CONFIG = 'graphPanelConfig';
-
-// Helper to get scoped localStorage key for graph config
-function getGraphConfigKey(appId, appName, className) {
-  return `${GRAPH_PANEL_CONFIG}_${appId}${appName}_${className}`;
-}
 
 function formatValueForCopy(value, type) {
   if (value === undefined) {
@@ -130,18 +124,10 @@ export default class DataBrowser extends React.Component {
     const storedGraphPanelWidth = window.localStorage?.getItem(GRAPH_PANEL_WIDTH);
     const parsedWidth = storedGraphPanelWidth ? parseInt(storedGraphPanelWidth, 10) : 400;
     const parsedGraphPanelWidth = !isNaN(parsedWidth) && parsedWidth > 0 ? parsedWidth : 400;
-    const graphConfigKey = getGraphConfigKey(props.app.applicationId, props.appName, props.className);
-    const storedGraphConfig = window.localStorage?.getItem(graphConfigKey);
-    let parsedGraphConfig = null;
-    if (storedGraphConfig) {
-      try {
-        parsedGraphConfig = JSON.parse(storedGraphConfig);
-      } catch (error) {
-        console.error('Failed to parse graph panel config from localStorage:', error);
-        // Remove the corrupted config from localStorage
-        window.localStorage?.removeItem(graphConfigKey);
-      }
-    }
+
+    // Note: We don't load graphConfig from localStorage here anymore.
+    // Graphs are now loaded from server/localStorage via GraphPreferencesManager in componentDidMount
+    // and componentDidUpdate. This ensures we use the new server-based storage system.
 
     this.state = {
       order: order,
@@ -186,8 +172,10 @@ export default class DataBrowser extends React.Component {
       draggedPanelSelection: false,
       isGraphPanelVisible: storedGraphPanelVisible,
       graphPanelWidth: parsedGraphPanelWidth,
-      graphConfig: parsedGraphConfig,
+      graphConfig: null, // Will be loaded from server in componentDidMount
+      availableGraphs: [],
       showGraphDialog: false,
+      isCreatingNewGraph: false,
     };
 
     this.handleResizeDiv = this.handleResizeDiv.bind(this);
@@ -229,9 +217,11 @@ export default class DataBrowser extends React.Component {
     this.handleGraphResizeStop = this.handleGraphResizeStop.bind(this);
     this.handleGraphResizeDiv = this.handleGraphResizeDiv.bind(this);
     this.showGraphDialog = this.showGraphDialog.bind(this);
+    this.showNewGraphDialog = this.showNewGraphDialog.bind(this);
     this.hideGraphDialog = this.hideGraphDialog.bind(this);
     this.saveGraphConfig = this.saveGraphConfig.bind(this);
     this.deleteGraphConfig = this.deleteGraphConfig.bind(this);
+    this.selectGraph = this.selectGraph.bind(this);
     this.saveOrderTimeout = null;
     this.aggregationPanelRef = React.createRef();
     this.panelColumnRefs = [];
@@ -322,6 +312,23 @@ export default class DataBrowser extends React.Component {
     } catch (error) {
       console.warn('Failed to load keyboard shortcuts:', error);
     }
+
+    // Load graphs on initial mount
+    try {
+      const graphs = await this.graphPreferencesManager.getGraphs(
+        this.props.app.applicationId,
+        this.props.className
+      );
+      // Set the first graph as the current graph if any exist
+      const graphConfig = graphs && graphs.length > 0 ? graphs[0] : null;
+      this.setState({
+        availableGraphs: graphs || [],
+        graphConfig: graphConfig
+      });
+    } catch (error) {
+      console.error('Failed to load graphs on mount:', error);
+      this.setState({ availableGraphs: [], graphConfig: null });
+    }
   }
 
   componentWillUnmount() {
@@ -342,29 +349,20 @@ export default class DataBrowser extends React.Component {
           this.props.app.applicationId,
           this.props.className
         );
-        // For now, we'll use the first graph if any exists
-        // In future, we could add UI to select from multiple saved graphs
+        // Use the first graph if any exists, or null
         const graphConfig = graphs && graphs.length > 0 ? graphs[0] : null;
-        this.setState({ graphConfig });
+        this.setState({
+          graphConfig,
+          availableGraphs: graphs || []
+        });
       } catch (error) {
-        console.error('Failed to load graph config from server, trying localStorage:', error);
-        // Fallback to localStorage
-        const graphConfigKey = getGraphConfigKey(
-          this.props.app.applicationId,
-          this.props.appName,
-          this.props.className
-        );
-        const storedGraphConfig = window.localStorage?.getItem(graphConfigKey);
-        let parsedGraphConfig = null;
-        if (storedGraphConfig) {
-          try {
-            parsedGraphConfig = JSON.parse(storedGraphConfig);
-          } catch (error) {
-            console.error('Failed to parse graph panel config from localStorage:', error);
-            window.localStorage?.removeItem(graphConfigKey);
-          }
-        }
-        this.setState({ graphConfig: parsedGraphConfig });
+        console.error('Failed to load graphs on className change:', error);
+        // GraphPreferencesManager handles its own localStorage fallback
+        // Just clear the state on error
+        this.setState({
+          graphConfig: null,
+          availableGraphs: []
+        });
       }
     }
 
@@ -1265,8 +1263,18 @@ export default class DataBrowser extends React.Component {
     this.setState({ graphPanelWidth: size.width });
   }
 
-  showGraphDialog() {
-    this.setState({ showGraphDialog: true });
+  showGraphDialog(isNewGraph = false) {
+    this.setState({
+      showGraphDialog: true,
+      isCreatingNewGraph: isNewGraph
+    });
+  }
+
+  showNewGraphDialog() {
+    this.setState({
+      showGraphDialog: true,
+      isCreatingNewGraph: true
+    });
   }
 
   hideGraphDialog() {
@@ -1280,9 +1288,22 @@ export default class DataBrowser extends React.Component {
       id: config.id || this.graphPreferencesManager.generateGraphId()
     };
 
+    // Optimistically update availableGraphs to include the new/updated graph
+    const existingGraphIndex = this.state.availableGraphs.findIndex(g => g.id === configWithId.id);
+    let updatedAvailableGraphs;
+    if (existingGraphIndex >= 0) {
+      // Update existing graph
+      updatedAvailableGraphs = [...this.state.availableGraphs];
+      updatedAvailableGraphs[existingGraphIndex] = configWithId;
+    } else {
+      // Add new graph
+      updatedAvailableGraphs = [...this.state.availableGraphs, configWithId];
+    }
+
     this.setState({
       graphConfig: configWithId,
       showGraphDialog: false,
+      availableGraphs: updatedAvailableGraphs,
     });
 
     // Try to save to server first (if enabled), fallback to localStorage
@@ -1293,16 +1314,28 @@ export default class DataBrowser extends React.Component {
         configWithId,
         [] // allGraphs not needed for single save
       );
-    } catch (error) {
-      console.error('Failed to save graph to server, falling back to localStorage:', error);
-      // Fallback: save to localStorage
-      const graphConfigKey = getGraphConfigKey(
+
+      // Reload all graphs to update the dropdown from server
+      const graphs = await this.graphPreferencesManager.getGraphs(
         this.props.app.applicationId,
-        this.props.appName,
         this.props.className
       );
-      window.localStorage?.setItem(graphConfigKey, JSON.stringify(configWithId));
+      this.setState({ availableGraphs: graphs || [] });
+    } catch (error) {
+      console.error('Failed to save/reload graphs:', error);
+      // GraphPreferencesManager handles its own localStorage fallback
+      // Just ensure the graph is in availableGraphs for UI consistency
+      const existingGraphIndex = this.state.availableGraphs.findIndex(g => g.id === configWithId.id);
+      if (existingGraphIndex >= 0) {
+        const updatedGraphs = [...this.state.availableGraphs];
+        updatedGraphs[existingGraphIndex] = configWithId;
+        this.setState({ availableGraphs: updatedGraphs });
+      }
     }
+  }
+
+  selectGraph(graph) {
+    this.setState({ graphConfig: graph });
   }
 
   async deleteGraphConfig(graphId) {
@@ -1321,15 +1354,19 @@ export default class DataBrowser extends React.Component {
         graphId,
         [] // allGraphs not needed for single delete
       );
-    } catch (error) {
-      console.error('Failed to delete graph from server, falling back to localStorage:', error);
-      // Fallback: delete from localStorage
-      const graphConfigKey = getGraphConfigKey(
+
+      // Reload all graphs to update the dropdown
+      const graphs = await this.graphPreferencesManager.getGraphs(
         this.props.app.applicationId,
-        this.props.appName,
         this.props.className
       );
-      window.localStorage?.removeItem(graphConfigKey);
+      this.setState({ availableGraphs: graphs || [] });
+    } catch (error) {
+      console.error('Failed to delete/reload graphs:', error);
+      // GraphPreferencesManager handles its own localStorage fallback
+      // Just remove from availableGraphs for UI consistency
+      const updatedGraphs = this.state.availableGraphs.filter(g => g.id !== graphId);
+      this.setState({ availableGraphs: updatedGraphs });
     }
 
     // Also clear the graph panel visibility from localStorage
@@ -2066,7 +2103,7 @@ export default class DataBrowser extends React.Component {
               </div>
             </ResizableBox>
           )}
-          {this.state.isGraphPanelVisible && this.state.graphConfig && (() => {
+          {this.state.isGraphPanelVisible && (() => {
             // Calculate max width for graph panel, accounting for aggregation panel when visible
             const aggregationPanelWidth = this.state.isPanelVisible ? effectivePanelWidth : 0;
             const graphMaxWidth = Math.max(300, this.state.maxWidth - aggregationPanelWidth);
@@ -2094,6 +2131,9 @@ export default class DataBrowser extends React.Component {
                   onRefresh={this.handleRefresh}
                   onEdit={this.showGraphDialog}
                   onClose={this.toggleGraphPanelVisibility}
+                  availableGraphs={this.state.availableGraphs}
+                  onGraphSelect={this.selectGraph}
+                  onNewGraph={this.showNewGraphDialog}
                 />
               </ResizableBox>
             );
@@ -2177,7 +2217,7 @@ export default class DataBrowser extends React.Component {
           <GraphDialog
             columns={this.props.columns}
             className={this.props.className}
-            initialConfig={this.state.graphConfig}
+            initialConfig={this.state.isCreatingNewGraph ? null : this.state.graphConfig}
             onConfirm={this.saveGraphConfig}
             onCancel={this.hideGraphDialog}
             onDelete={this.deleteGraphConfig}

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -2184,8 +2184,6 @@ export default class DataBrowser extends React.Component {
           toggleShowPanelCheckbox={this.toggleShowPanelCheckbox}
           toggleGraphPanel={this.toggleGraphPanelVisibility}
           isGraphPanelVisible={this.state.isGraphPanelVisible}
-          showGraphDialog={this.showGraphDialog}
-          hasGraphConfig={!!this.state.graphConfig}
           {...other}
           onRefresh={this.handleRefresh}
         />

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -231,6 +231,7 @@ export default class DataBrowser extends React.Component {
     this.showGraphDialog = this.showGraphDialog.bind(this);
     this.hideGraphDialog = this.hideGraphDialog.bind(this);
     this.saveGraphConfig = this.saveGraphConfig.bind(this);
+    this.deleteGraphConfig = this.deleteGraphConfig.bind(this);
     this.saveOrderTimeout = null;
     this.aggregationPanelRef = React.createRef();
     this.panelColumnRefs = [];
@@ -1304,6 +1305,37 @@ export default class DataBrowser extends React.Component {
     }
   }
 
+  async deleteGraphConfig(graphId) {
+    // Close the dialog and clear the graph config
+    this.setState({
+      graphConfig: null,
+      showGraphDialog: false,
+      isGraphPanelVisible: false,
+    });
+
+    // Try to delete from server first (if enabled), fallback to localStorage
+    try {
+      await this.graphPreferencesManager.deleteGraph(
+        this.props.app.applicationId,
+        this.props.className,
+        graphId,
+        [] // allGraphs not needed for single delete
+      );
+    } catch (error) {
+      console.error('Failed to delete graph from server, falling back to localStorage:', error);
+      // Fallback: delete from localStorage
+      const graphConfigKey = getGraphConfigKey(
+        this.props.app.applicationId,
+        this.props.appName,
+        this.props.className
+      );
+      window.localStorage?.removeItem(graphConfigKey);
+    }
+
+    // Also clear the graph panel visibility from localStorage
+    window.localStorage?.setItem(GRAPH_PANEL_VISIBLE, 'false');
+  }
+
   handlePanelScroll(event, index) {
     if (!this.state.syncPanelScroll || this.state.panelCount <= 1) {
       return;
@@ -2148,6 +2180,7 @@ export default class DataBrowser extends React.Component {
             initialConfig={this.state.graphConfig}
             onConfirm={this.saveGraphConfig}
             onCancel={this.hideGraphDialog}
+            onDelete={this.deleteGraphConfig}
           />
         )}
       </div>

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -1288,6 +1288,10 @@ export default class DataBrowser extends React.Component {
       id: config.id || this.graphPreferencesManager.generateGraphId()
     };
 
+    // Store previous state for potential rollback
+    const previousGraphConfig = this.state.graphConfig;
+    const previousAvailableGraphs = this.state.availableGraphs;
+
     // Optimistically update availableGraphs to include the new/updated graph
     const existingGraphIndex = this.state.availableGraphs.findIndex(g => g.id === configWithId.id);
     let updatedAvailableGraphs;
@@ -1306,7 +1310,7 @@ export default class DataBrowser extends React.Component {
       availableGraphs: updatedAvailableGraphs,
     });
 
-    // Try to save to server first (if enabled), fallback to localStorage
+    // Try to save to server/localStorage
     try {
       await this.graphPreferencesManager.saveGraph(
         this.props.app.applicationId,
@@ -1322,14 +1326,15 @@ export default class DataBrowser extends React.Component {
       );
       this.setState({ availableGraphs: graphs || [] });
     } catch (error) {
-      console.error('Failed to save/reload graphs:', error);
-      // GraphPreferencesManager handles its own localStorage fallback
-      // Just ensure the graph is in availableGraphs for UI consistency
-      const existingGraphIndex = this.state.availableGraphs.findIndex(g => g.id === configWithId.id);
-      if (existingGraphIndex >= 0) {
-        const updatedGraphs = [...this.state.availableGraphs];
-        updatedGraphs[existingGraphIndex] = configWithId;
-        this.setState({ availableGraphs: updatedGraphs });
+      console.error('Failed to save graph:', error);
+      // Revert optimistic update on error
+      this.setState({
+        graphConfig: previousGraphConfig,
+        availableGraphs: previousAvailableGraphs
+      });
+      // Show error notification to user
+      if (this.props.showNote) {
+        this.props.showNote('Failed to save graph. Please try again.', true);
       }
     }
   }
@@ -1339,14 +1344,19 @@ export default class DataBrowser extends React.Component {
   }
 
   async deleteGraphConfig(graphId) {
-    // Close the dialog and clear the graph config
+    // Store previous state for potential rollback
+    const previousGraphConfig = this.state.graphConfig;
+    const previousAvailableGraphs = this.state.availableGraphs;
+    const previousIsGraphPanelVisible = this.state.isGraphPanelVisible;
+
+    // Optimistically update UI
     this.setState({
       graphConfig: null,
       showGraphDialog: false,
       isGraphPanelVisible: false,
     });
 
-    // Try to delete from server first (if enabled), fallback to localStorage
+    // Try to delete from server/localStorage
     try {
       await this.graphPreferencesManager.deleteGraph(
         this.props.app.applicationId,
@@ -1361,16 +1371,22 @@ export default class DataBrowser extends React.Component {
         this.props.className
       );
       this.setState({ availableGraphs: graphs || [] });
-    } catch (error) {
-      console.error('Failed to delete/reload graphs:', error);
-      // GraphPreferencesManager handles its own localStorage fallback
-      // Just remove from availableGraphs for UI consistency
-      const updatedGraphs = this.state.availableGraphs.filter(g => g.id !== graphId);
-      this.setState({ availableGraphs: updatedGraphs });
-    }
 
-    // Also clear the graph panel visibility from localStorage
-    window.localStorage?.setItem(GRAPH_PANEL_VISIBLE, 'false');
+      // Clear the graph panel visibility from localStorage
+      window.localStorage?.setItem(GRAPH_PANEL_VISIBLE, 'false');
+    } catch (error) {
+      console.error('Failed to delete graph:', error);
+      // Revert optimistic update on error
+      this.setState({
+        graphConfig: previousGraphConfig,
+        availableGraphs: previousAvailableGraphs,
+        isGraphPanelVisible: previousIsGraphPanelVisible
+      });
+      // Show error notification to user
+      if (this.props.showNote) {
+        this.props.showNote('Failed to delete graph. Please try again.', true);
+      }
+    }
   }
 
   handlePanelScroll(event, index) {

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -14,6 +14,7 @@ import { CurrentApp } from 'context/currentApp';
 import { dateStringUTC } from 'lib/DateUtils';
 import GraphDialog from 'dashboard/Data/Browser/GraphDialog.react';
 import GraphPanel from 'components/GraphPanel/GraphPanel.react';
+import GraphPreferencesManager from 'lib/GraphPreferencesManager';
 import getFileName from 'lib/getFileName';
 import { getValidScripts, executeScript } from '../../../lib/ScriptUtils';
 import Parse from 'parse';
@@ -237,6 +238,7 @@ export default class DataBrowser extends React.Component {
     this.isWheelScrolling = false;
     this.multiPanelWrapperElement = null;
     this.setMultiPanelWrapperRef = this.setMultiPanelWrapperRef.bind(this);
+    this.graphPreferencesManager = new GraphPreferencesManager(props.app);
   }
 
   setMultiPanelWrapperRef(element) {
@@ -330,25 +332,39 @@ export default class DataBrowser extends React.Component {
     }
   }
 
-  componentDidUpdate(prevProps, prevState) {
+  async componentDidUpdate(prevProps, prevState) {
     // Reload graphConfig when className changes
     if (this.props.className !== prevProps.className) {
-      const graphConfigKey = getGraphConfigKey(
-        this.props.app.applicationId,
-        this.props.appName,
-        this.props.className
-      );
-      const storedGraphConfig = window.localStorage?.getItem(graphConfigKey);
-      let parsedGraphConfig = null;
-      if (storedGraphConfig) {
-        try {
-          parsedGraphConfig = JSON.parse(storedGraphConfig);
-        } catch (error) {
-          console.error('Failed to parse graph panel config from localStorage:', error);
-          window.localStorage?.removeItem(graphConfigKey);
+      // Try to load from server first, fallback to localStorage
+      try {
+        const graphs = await this.graphPreferencesManager.getGraphs(
+          this.props.app.applicationId,
+          this.props.className
+        );
+        // For now, we'll use the first graph if any exists
+        // In future, we could add UI to select from multiple saved graphs
+        const graphConfig = graphs && graphs.length > 0 ? graphs[0] : null;
+        this.setState({ graphConfig });
+      } catch (error) {
+        console.error('Failed to load graph config from server, trying localStorage:', error);
+        // Fallback to localStorage
+        const graphConfigKey = getGraphConfigKey(
+          this.props.app.applicationId,
+          this.props.appName,
+          this.props.className
+        );
+        const storedGraphConfig = window.localStorage?.getItem(graphConfigKey);
+        let parsedGraphConfig = null;
+        if (storedGraphConfig) {
+          try {
+            parsedGraphConfig = JSON.parse(storedGraphConfig);
+          } catch (error) {
+            console.error('Failed to parse graph panel config from localStorage:', error);
+            window.localStorage?.removeItem(graphConfigKey);
+          }
         }
+        this.setState({ graphConfig: parsedGraphConfig });
       }
-      this.setState({ graphConfig: parsedGraphConfig });
     }
 
     // Clear panels when className changes, data becomes null, or data reloads
@@ -1256,17 +1272,36 @@ export default class DataBrowser extends React.Component {
     this.setState({ showGraphDialog: false });
   }
 
-  saveGraphConfig(config) {
+  async saveGraphConfig(config) {
+    // Ensure config has an ID for server storage
+    const configWithId = {
+      ...config,
+      id: config.id || this.graphPreferencesManager.generateGraphId()
+    };
+
     this.setState({
-      graphConfig: config,
+      graphConfig: configWithId,
       showGraphDialog: false,
     });
-    const graphConfigKey = getGraphConfigKey(
-      this.props.app.applicationId,
-      this.props.appName,
-      this.props.className
-    );
-    window.localStorage?.setItem(graphConfigKey, JSON.stringify(config));
+
+    // Try to save to server first (if enabled), fallback to localStorage
+    try {
+      await this.graphPreferencesManager.saveGraph(
+        this.props.app.applicationId,
+        this.props.className,
+        configWithId,
+        [] // allGraphs not needed for single save
+      );
+    } catch (error) {
+      console.error('Failed to save graph to server, falling back to localStorage:', error);
+      // Fallback: save to localStorage
+      const graphConfigKey = getGraphConfigKey(
+        this.props.app.applicationId,
+        this.props.appName,
+        this.props.className
+      );
+      window.localStorage?.setItem(graphConfigKey, JSON.stringify(configWithId));
+    }
   }
 
   handlePanelScroll(event, index) {
@@ -2109,6 +2144,7 @@ export default class DataBrowser extends React.Component {
         {this.state.showGraphDialog && (
           <GraphDialog
             columns={this.props.columns}
+            className={this.props.className}
             initialConfig={this.state.graphConfig}
             onConfirm={this.saveGraphConfig}
             onCancel={this.hideGraphDialog}

--- a/src/dashboard/Data/Browser/GraphDialog.react.js
+++ b/src/dashboard/Data/Browser/GraphDialog.react.js
@@ -79,6 +79,7 @@ export default class GraphDialog extends React.Component {
       isStacked: initialConfig.isStacked || false,
       maxDataPoints: initialConfig.maxDataPoints || 1000,
       maxDataPointsInput: null,
+      showDeleteConfirmation: false,
     };
   }
 
@@ -116,9 +117,17 @@ export default class GraphDialog extends React.Component {
   };
 
   handleDelete = () => {
+    this.setState({ showDeleteConfirmation: true });
+  };
+
+  confirmDelete = () => {
     if (this.state.id && this.props.onDelete) {
       this.props.onDelete(this.state.id);
     }
+  };
+
+  cancelDelete = () => {
+    this.setState({ showDeleteConfirmation: false });
   };
 
   getColumnsByType(types) {
@@ -584,9 +593,21 @@ export default class GraphDialog extends React.Component {
   render() {
     const isEditing = this.props.initialConfig && Object.keys(this.props.initialConfig).length > 0;
 
-    const customFooter = (
+    const customFooter = this.state.showDeleteConfirmation ? (
       <div style={{ textAlign: 'center' }} className={styles.footer}>
-        <Button value="Reset" onClick={this.handleReset} color="red" />
+        <Button value="Cancel" onClick={this.cancelDelete} />
+        <Button
+          primary={true}
+          value="Confirm Delete"
+          color="red"
+          onClick={this.confirmDelete}
+        />
+      </div>
+    ) : (
+      <div style={{ textAlign: 'center' }} className={styles.footer}>
+        {isEditing && this.state.id && (
+          <Button value="Delete" onClick={this.handleDelete} color="red" />
+        )}
         <Button value="Cancel" onClick={this.props.onCancel} />
         <Button
           primary={true}

--- a/src/dashboard/Data/Browser/GraphDialog.react.js
+++ b/src/dashboard/Data/Browser/GraphDialog.react.js
@@ -46,7 +46,7 @@ const CALCULATED_VALUE_OPERATORS = [
 
 export default class GraphDialog extends React.Component {
   constructor(props) {
-    super();
+    super(props);
 
     const initialConfig = props.initialConfig || {};
 

--- a/src/dashboard/Data/Browser/GraphDialog.react.js
+++ b/src/dashboard/Data/Browser/GraphDialog.react.js
@@ -64,6 +64,7 @@ export default class GraphDialog extends React.Component {
     const calculatedValues = initialConfig.calculatedValues || [];
 
     this.state = {
+      id: initialConfig.id || null, // Preserve existing ID for updates
       chartType: initialConfig.chartType || 'bar',
       xColumn: initialConfig.xColumn || '',
       yColumn: initialConfig.yColumn || '',
@@ -104,6 +105,7 @@ export default class GraphDialog extends React.Component {
     if (this.valid()) {
       this.props.onConfirm({
         ...this.state,
+        className: this.props.className,
         xColumn: this.state.xColumn || null,
         yColumn: this.state.yColumn || null,
         valueColumn: this.state.valueColumn.length > 0 ? this.state.valueColumn : null,
@@ -113,23 +115,10 @@ export default class GraphDialog extends React.Component {
     }
   };
 
-  handleReset = () => {
-    this.setState({
-      chartType: 'bar',
-      xColumn: '',
-      yColumn: '',
-      valueColumn: [],
-      groupByColumn: [],
-      calculatedValues: [],
-      aggregationType: 'count',
-      title: '',
-      showLegend: true,
-      showGrid: true,
-      showAxisLabels: true,
-      isStacked: false,
-      maxDataPoints: 1000,
-      maxDataPointsInput: null,
-    });
+  handleDelete = () => {
+    if (this.state.id && this.props.onDelete) {
+      this.props.onDelete(this.state.id);
+    }
   };
 
   getColumnsByType(types) {

--- a/src/dashboard/Settings/DashboardSettings/DashboardSettings.react.js
+++ b/src/dashboard/Settings/DashboardSettings/DashboardSettings.react.js
@@ -553,7 +553,7 @@ export default class DashboardSettings extends DashboardView {
         {this.viewPreferencesManager && this.scriptManager && this.viewPreferencesManager.isServerConfigEnabled() && (
           <Fieldset legend="Settings Storage">
             <div style={{ marginBottom: '20px', color: '#666', fontSize: '14px', textAlign: 'center' }}>
-              Storing dashboard settings on the server rather than locally in the browser storage makes the settings available across devices and browsers. It also prevents them from getting lost when resetting the browser website data. Settings that can be stored on the server are currently Data Browser Filters, Views, Keyboard Shortcuts and JS Console scripts.
+              Storing dashboard settings on the server rather than locally in the browser storage makes the settings available across devices and browsers. It also prevents them from getting lost when resetting the browser website data. Settings that can be stored on the server are currently Data Browser Filters, Data Browser Graphs, Views, Keyboard Shortcuts and JS Console scripts.
             </div>
             <Field
               label={

--- a/src/lib/GraphPreferencesManager.js
+++ b/src/lib/GraphPreferencesManager.js
@@ -1,0 +1,427 @@
+/*
+ * Copyright (c) 2016-present, Parse, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
+import ServerConfigStorage from './ServerConfigStorage';
+import { prefersServerStorage, setStoragePreference } from './StoragePreferences';
+
+const VERSION = 1;
+
+/**
+ * In-memory cache for graphs fetched from server storage
+ * Cache persists for the lifetime of the page (until browser reload)
+ * Structure: { appId: { className: graphs[] } }
+ */
+const serverGraphsCache = {};
+
+/**
+ * GraphPreferences with server-side storage support
+ */
+export default class GraphPreferencesManager {
+  constructor(app) {
+    this.app = app;
+    this.serverStorage = new ServerConfigStorage(app);
+  }
+
+  /**
+   * Gets graphs from either server or local storage based on configuration and user preference
+   * @param {string} appId - The application ID
+   * @param {string} className - The Parse class name
+   * @returns {Promise<Array>} Array of graphs
+   */
+  async getGraphs(appId, className) {
+    // Check if server storage is enabled and user prefers it
+    if (this.serverStorage.isServerConfigEnabled() && prefersServerStorage(appId)) {
+      try {
+        // Check cache first
+        if (serverGraphsCache[appId]?.[className]) {
+          return serverGraphsCache[appId][className];
+        }
+
+        // Fetch from server and cache the result
+        const serverGraphs = await this._getGraphsFromServer(appId, className);
+        // Always return server graphs (even if empty) when server storage is preferred
+        const graphs = serverGraphs || [];
+
+        // Cache the fetched graphs
+        if (!serverGraphsCache[appId]) {
+          serverGraphsCache[appId] = {};
+        }
+        serverGraphsCache[appId][className] = graphs;
+
+        return graphs;
+      } catch (error) {
+        console.error('Failed to get graphs from server:', error);
+        // When server storage is preferred, return empty array instead of falling back to local
+        return [];
+      }
+    }
+
+    // Use local storage when server storage is not preferred
+    return this._getGraphsFromLocal(appId, className);
+  }
+
+  /**
+   * Saves a single graph to either server or local storage based on configuration and user preference
+   * @param {string} appId - The application ID
+   * @param {string} className - The Parse class name
+   * @param {Object} graph - The graph to save
+   * @param {Array} allGraphs - All graphs (required for local storage fallback)
+   * @returns {Promise}
+   */
+  async saveGraph(appId, className, graph, allGraphs) {
+    // Check if server storage is enabled and user prefers it
+    if (this.serverStorage.isServerConfigEnabled() && prefersServerStorage(appId)) {
+      try {
+        await this._saveGraphToServer(appId, className, graph);
+
+        // Invalidate cache - will be reloaded on next getGraphs call
+        if (serverGraphsCache[appId]) {
+          delete serverGraphsCache[appId][className];
+        }
+
+        return;
+      } catch (error) {
+        console.error('Failed to save graph to server:', error);
+        // On error, fallback to local storage
+      }
+    }
+
+    // Use local storage (either by preference or as fallback)
+    return this._saveGraphsToLocal(appId, className, allGraphs);
+  }
+
+  /**
+   * Deletes a single graph from either server or local storage based on configuration and user preference
+   * @param {string} appId - The application ID
+   * @param {string} className - The Parse class name
+   * @param {string} graphId - The ID of the graph to delete
+   * @param {Array} allGraphs - All graphs (required for local storage fallback)
+   * @returns {Promise}
+   */
+  async deleteGraph(appId, className, graphId, allGraphs) {
+    // Check if server storage is enabled and user prefers it
+    if (this.serverStorage.isServerConfigEnabled() && prefersServerStorage(appId)) {
+      try {
+        await this._deleteGraphFromServer(appId, graphId);
+
+        // Invalidate cache - will be reloaded on next getGraphs call
+        if (serverGraphsCache[appId]) {
+          delete serverGraphsCache[appId][className];
+        }
+
+        return;
+      } catch (error) {
+        console.error('Failed to delete graph from server:', error);
+        // On error, fallback to local storage
+      }
+    }
+
+    // Use local storage (either by preference or as fallback)
+    return this._saveGraphsToLocal(appId, className, allGraphs);
+  }
+
+  /**
+   * Migrates graphs from local storage to server storage
+   * @param {string} appId - The application ID
+   * @param {string} className - The Parse class name
+   * @param {boolean} overwriteConflicts - If true, overwrite server graphs with same ID
+   * @returns {Promise<{success: boolean, graphCount: number, conflicts?: Array}>}
+   */
+  async migrateToServer(appId, className, overwriteConflicts = false) {
+    if (!this.serverStorage.isServerConfigEnabled()) {
+      throw new Error('Server configuration is not enabled for this app');
+    }
+
+    const localGraphs = this._getGraphsFromLocal(appId, className);
+    if (!localGraphs || localGraphs.length === 0) {
+      return { success: true, graphCount: 0 };
+    }
+
+    try {
+      // Get existing graphs from server to detect conflicts
+      const existingGraphConfigs = await this.serverStorage.getConfigsByPrefix(
+        'browser.graphs.graph.',
+        appId,
+        null,
+        { className }
+      );
+      const existingGraphIds = Object.keys(existingGraphConfigs).map(key =>
+        key.replace('browser.graphs.graph.', '')
+      );
+
+      // Check for conflicts
+      const localGraphIds = localGraphs.map(graph => graph.id).filter(Boolean);
+      const conflictingIds = localGraphIds.filter(id => existingGraphIds.includes(id));
+
+      if (conflictingIds.length > 0 && !overwriteConflicts) {
+        // Return conflicts for user decision
+        const conflicts = conflictingIds.map(id => {
+          const localGraph = localGraphs.find(g => g.id === id);
+          const serverGraphKey = `browser.graphs.graph.${id}`;
+          const serverGraph = existingGraphConfigs[serverGraphKey];
+          return {
+            id,
+            type: 'graph',
+            local: localGraph,
+            server: serverGraph
+          };
+        });
+
+        return {
+          success: false,
+          graphCount: 0,
+          conflicts
+        };
+      }
+
+      // Proceed with migration (merge mode)
+      await this._migrateGraphsToServer(appId, className, localGraphs, overwriteConflicts);
+
+      // Invalidate cache after migration
+      if (serverGraphsCache[appId]) {
+        delete serverGraphsCache[appId][className];
+      }
+
+      return { success: true, graphCount: localGraphs.length };
+    } catch (error) {
+      console.error('Failed to migrate graphs to server:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Deletes graphs from local storage
+   * @param {string} appId - The application ID
+   * @param {string} className - The Parse class name
+   * @returns {boolean} True if deletion was successful
+   */
+  deleteFromBrowser(appId, className) {
+    try {
+      localStorage.removeItem(this._getLocalPath(appId, className));
+      return true;
+    } catch (error) {
+      console.error('Failed to delete graphs from browser:', error);
+      return false;
+    }
+  }
+
+  /**
+   * Sets the storage preference for the app
+   * @param {string} appId - The application ID
+   * @param {string} preference - The storage preference ('local' or 'server')
+   */
+  setStoragePreference(appId, preference) {
+    setStoragePreference(appId, preference);
+  }
+
+  /**
+   * Gets the current storage preference for the app
+   * @param {string} appId - The application ID
+   * @returns {string} The storage preference ('local' or 'server')
+   */
+  getStoragePreference(appId) {
+    return prefersServerStorage(appId) ? 'server' : 'local';
+  }
+
+  /**
+   * Checks if server configuration is enabled for this app
+   * @returns {boolean} True if server config is enabled
+   */
+  isServerConfigEnabled() {
+    return this.serverStorage.isServerConfigEnabled();
+  }
+
+  /**
+   * Migrates graphs to server storage with merge/overwrite logic
+   * @private
+   */
+  async _migrateGraphsToServer(appId, className, localGraphs, overwriteConflicts) {
+    try {
+      // Get existing graphs from server
+      const existingGraphConfigs = await this.serverStorage.getConfigsByPrefix(
+        'browser.graphs.graph.',
+        appId,
+        null,
+        { className }
+      );
+      const existingGraphIds = Object.keys(existingGraphConfigs).map(key =>
+        key.replace('browser.graphs.graph.', '')
+      );
+
+      // Save local graphs to server
+      await Promise.all(
+        localGraphs.map(graph => {
+          const graphId = graph.id || this._generateGraphId();
+          const graphConfig = { ...graph };
+          delete graphConfig.id; // Don't store ID in the config itself
+
+          // Ensure className is included
+          if (!graphConfig.className) {
+            graphConfig.className = className;
+          }
+
+          // Remove null and undefined values to keep the storage clean
+          Object.keys(graphConfig).forEach(key => {
+            if (graphConfig[key] === null || graphConfig[key] === undefined) {
+              delete graphConfig[key];
+            }
+          });
+
+          // Only save if we're overwriting conflicts or if this graph doesn't exist on server
+          if (overwriteConflicts || !existingGraphIds.includes(graphId)) {
+            return this.serverStorage.setConfig(
+              `browser.graphs.graph.${graphId}`,
+              graphConfig,
+              appId
+            );
+          }
+          return Promise.resolve(); // Skip conflicting graphs when not overwriting
+        })
+      );
+
+      // Note: We don't delete server graphs that aren't in local storage
+      // This preserves server-side settings that don't conflict with local ones
+    } catch (error) {
+      console.error('Failed to migrate graphs to server:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Gets graphs from server storage
+   * @private
+   */
+  async _getGraphsFromServer(appId, className) {
+    try {
+      const graphConfigs = await this.serverStorage.getConfigsByPrefix(
+        'browser.graphs.graph.',
+        appId,
+        null,
+        { className }
+      );
+      const graphs = [];
+
+      Object.entries(graphConfigs).forEach(([key, config]) => {
+        if (config && typeof config === 'object') {
+          // Extract graph ID from key (browser.graphs.graph.{GRAPH_ID})
+          const graphId = key.replace('browser.graphs.graph.', '');
+
+          graphs.push({
+            id: graphId,
+            ...config
+          });
+        }
+      });
+
+      return graphs;
+    } catch (error) {
+      console.error('Failed to get graphs from server:', error);
+      return [];
+    }
+  }
+
+  /**
+   * Saves a single graph to server storage
+   * @private
+   */
+  async _saveGraphToServer(appId, className, graph) {
+    try {
+      const graphId = graph.id || this._generateGraphId();
+      const graphConfig = { ...graph };
+      delete graphConfig.id; // Don't store ID in the config itself
+
+      // Ensure className is included
+      if (!graphConfig.className) {
+        graphConfig.className = className;
+      }
+
+      // Remove null and undefined values to keep the storage clean
+      Object.keys(graphConfig).forEach(key => {
+        if (graphConfig[key] === null || graphConfig[key] === undefined) {
+          delete graphConfig[key];
+        }
+      });
+
+      await this.serverStorage.setConfig(
+        `browser.graphs.graph.${graphId}`,
+        graphConfig,
+        appId
+      );
+    } catch (error) {
+      console.error('Failed to save graph to server:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Deletes a single graph from server storage
+   * @private
+   */
+  async _deleteGraphFromServer(appId, graphId) {
+    try {
+      await this.serverStorage.deleteConfig(`browser.graphs.graph.${graphId}`, appId);
+    } catch (error) {
+      console.error('Failed to delete graph from server:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Gets graphs from local storage (original implementation)
+   * @private
+   */
+  _getGraphsFromLocal(appId, className) {
+    let entry;
+    try {
+      entry = localStorage.getItem(this._getLocalPath(appId, className)) || '[]';
+    } catch {
+      entry = '[]';
+    }
+    try {
+      return JSON.parse(entry);
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Saves graphs to local storage (original implementation)
+   * @private
+   */
+  _saveGraphsToLocal(appId, className, graphs) {
+    try {
+      localStorage.setItem(this._getLocalPath(appId, className), JSON.stringify(graphs));
+    } catch {
+      // ignore write errors
+    }
+  }
+
+  /**
+   * Gets the local storage path for graphs
+   * @private
+   */
+  _getLocalPath(appId, className) {
+    return `ParseDashboard:${VERSION}:${appId}:Graphs:${className}`;
+  }
+
+  /**
+   * Generates a unique ID for a new graph
+   * @returns {string} A UUID string
+   */
+  generateGraphId() {
+    return this._generateGraphId();
+  }
+
+  /**
+   * Generates a unique ID for a graph using UUID
+   * @private
+   */
+  _generateGraphId() {
+    return crypto.randomUUID();
+  }
+}

--- a/src/lib/GraphPreferencesManager.js
+++ b/src/lib/GraphPreferencesManager.js
@@ -76,22 +76,17 @@ export default class GraphPreferencesManager {
   async saveGraph(appId, className, graph, allGraphs) {
     // Check if server storage is enabled and user prefers it
     if (this.serverStorage.isServerConfigEnabled() && prefersServerStorage(appId)) {
-      try {
-        await this._saveGraphToServer(appId, className, graph);
+      await this._saveGraphToServer(appId, className, graph);
 
-        // Invalidate cache - will be reloaded on next getGraphs call
-        if (serverGraphsCache[appId]) {
-          delete serverGraphsCache[appId][className];
-        }
-
-        return;
-      } catch (error) {
-        console.error('Failed to save graph to server:', error);
-        // On error, fallback to local storage
+      // Invalidate cache - will be reloaded on next getGraphs call
+      if (serverGraphsCache[appId]) {
+        delete serverGraphsCache[appId][className];
       }
+
+      return;
     }
 
-    // Use local storage (either by preference or as fallback)
+    // Use local storage when server storage is not preferred
     return this._saveGraphsToLocal(appId, className, allGraphs);
   }
 
@@ -106,22 +101,17 @@ export default class GraphPreferencesManager {
   async deleteGraph(appId, className, graphId, allGraphs) {
     // Check if server storage is enabled and user prefers it
     if (this.serverStorage.isServerConfigEnabled() && prefersServerStorage(appId)) {
-      try {
-        await this._deleteGraphFromServer(appId, graphId);
+      await this._deleteGraphFromServer(appId, graphId);
 
-        // Invalidate cache - will be reloaded on next getGraphs call
-        if (serverGraphsCache[appId]) {
-          delete serverGraphsCache[appId][className];
-        }
-
-        return;
-      } catch (error) {
-        console.error('Failed to delete graph from server:', error);
-        // On error, fallback to local storage
+      // Invalidate cache - will be reloaded on next getGraphs call
+      if (serverGraphsCache[appId]) {
+        delete serverGraphsCache[appId][className];
       }
+
+      return;
     }
 
-    // Use local storage (either by preference or as fallback)
+    // Use local storage when server storage is not preferred
     return this._saveGraphsToLocal(appId, className, allGraphs);
   }
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Graph selection dropdown to browse/switch saved graphs, plus in-UI graph creation and deletion (with confirmation).
  * Server-backed graph persistence and sync across sessions; graph list and selection available in the Data Browser.

* **UI**
  * Toolbar simplified to always show "Show Graph Panel".
  * Header/title now reflects the active graph and shows helpful notices when no graph or data is available.

* **Style**
  * New styling for dropdown, items, and header controls.

* **Behavior**
  * Graph dialog now includes delete workflow and updated save/delete flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->