### PR TITLE
feat: Add context menu in data browser to get related records from String and Number fields

### DIFF
--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -329,6 +329,9 @@ export default class BrowserCell extends Component {
     const relatedTextFieldsContextMenuOption = this.getRelatedTextFieldsContextMenuOption();
     relatedTextFieldsContextMenuOption && contextMenuOptions.push(relatedTextFieldsContextMenuOption);
 
+    const relatedNumberFieldsContextMenuOption = this.getRelatedNumberFieldsContextMenuOption();
+    relatedNumberFieldsContextMenuOption && contextMenuOptions.push(relatedNumberFieldsContextMenuOption);
+
     !readonly &&
       onEditSelectedRow &&
       contextMenuOptions.push({
@@ -534,6 +537,60 @@ export default class BrowserCell extends Component {
             return;
           }
           if (field === 'sessionToken' && (className === '_User' || className === '_Session')) {
+            return;
+          }
+          classFields.push({
+            text: field,
+            callback: () => {
+              onPointerClick({
+                className,
+                id: value,
+                field,
+              });
+            },
+          });
+        });
+
+        if (classFields.length > 0) {
+          // Sort fields alphabetically
+          classFields.sort((a, b) => a.text.localeCompare(b.text));
+          relatedRecordsMenuItem.items.push({
+            text: className,
+            items: classFields,
+          });
+        }
+      });
+
+    return relatedRecordsMenuItem.items.length ? relatedRecordsMenuItem : undefined;
+  }
+
+  /**
+   * Returns "Get related records from..." context menu item if cell holds a Number value
+   * and there are classes with Number type fields to filter by.
+   * Groups fields by class name in a hierarchical submenu structure.
+   */
+  getRelatedNumberFieldsContextMenuOption() {
+    const { value, type, schema, onPointerClick } = this.props;
+
+    // Only show for Number type cells with a value
+    if (type !== 'Number' || value === undefined || value === null) {
+      return;
+    }
+
+    const relatedRecordsMenuItem = {
+      text: 'Get related records from...',
+      items: [],
+    };
+
+    // Group fields by class name for hierarchical navigation
+    schema.data
+      .get('classes')
+      .sortBy((v, k) => k)
+      .forEach((cl, className) => {
+        const classFields = [];
+
+        cl.forEach((column, field) => {
+          if (column.type !== 'Number') {
             return;
           }
           classFields.push({

--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -440,6 +440,7 @@ export default class BrowserCell extends Component {
   /**
    * Returns "Get related records from..." context menu item if cell holds a Pointer
    * or objectId and there's a class in relation.
+   * Groups fields by class name in a hierarchical submenu structure.
    */
   getRelatedObjectsContextMenuOption() {
     const { value, schema, onPointerClick } = this.props;
@@ -451,17 +452,20 @@ export default class BrowserCell extends Component {
         text: 'Get related records from...',
         items: [],
       };
+
+      // Group fields by class name for hierarchical navigation
       schema.data
         .get('classes')
         .sortBy((v, k) => k)
         .forEach((cl, className) => {
+          const classFields = [];
+
           cl.forEach((column, field) => {
             if (column.targetClass !== pointerClassName) {
               return;
             }
-            relatedRecordsMenuItem.items.push({
-              text: `${className}`,
-              subtext: `${field}`,
+            classFields.push({
+              text: field,
               callback: () => {
                 let relatedObject = value;
                 if (this.props.field === 'objectId') {
@@ -476,6 +480,15 @@ export default class BrowserCell extends Component {
               },
             });
           });
+
+          if (classFields.length > 0) {
+            // Sort fields alphabetically
+            classFields.sort((a, b) => a.text.localeCompare(b.text));
+            relatedRecordsMenuItem.items.push({
+              text: className,
+              items: classFields,
+            });
+          }
         });
 
       return relatedRecordsMenuItem.items.length ? relatedRecordsMenuItem : undefined;

--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -488,10 +488,11 @@ export default class BrowserCell extends Component {
    * Groups fields by class name in a hierarchical submenu structure.
    */
   getRelatedTextFieldsContextMenuOption() {
-    const { value, type, schema, onPointerClick } = this.props;
+    const { value, type, field, schema, onPointerClick } = this.props;
 
     // Only show for String type cells with a non-empty value
-    if (type !== 'String' || !value || typeof value !== 'string' || value.trim() === '') {
+    // Exclude objectId field - it uses getRelatedObjectsContextMenuOption() for pointer-based lookups
+    if (type !== 'String' || field === 'objectId' || !value || typeof value !== 'string' || value.trim() === '') {
       return;
     }
 
@@ -524,6 +525,8 @@ export default class BrowserCell extends Component {
         });
 
         if (classFields.length > 0) {
+          // Sort fields alphabetically
+          classFields.sort((a, b) => a.text.localeCompare(b.text));
           relatedRecordsMenuItem.items.push({
             text: className,
             items: classFields,

--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -326,6 +326,9 @@ export default class BrowserCell extends Component {
     const relatedObjectsContextMenuOption = this.getRelatedObjectsContextMenuOption();
     relatedObjectsContextMenuOption && contextMenuOptions.push(relatedObjectsContextMenuOption);
 
+    const relatedTextFieldsContextMenuOption = this.getRelatedTextFieldsContextMenuOption();
+    relatedTextFieldsContextMenuOption && contextMenuOptions.push(relatedTextFieldsContextMenuOption);
+
     !readonly &&
       onEditSelectedRow &&
       contextMenuOptions.push({
@@ -477,6 +480,58 @@ export default class BrowserCell extends Component {
 
       return relatedRecordsMenuItem.items.length ? relatedRecordsMenuItem : undefined;
     }
+  }
+
+  /**
+   * Returns "Get related records from..." context menu item if cell holds a String value
+   * and there are classes with String type fields to filter by.
+   * Groups fields by class name in a hierarchical submenu structure.
+   */
+  getRelatedTextFieldsContextMenuOption() {
+    const { value, type, schema, onPointerClick } = this.props;
+
+    // Only show for String type cells with a non-empty value
+    if (type !== 'String' || !value || typeof value !== 'string' || value.trim() === '') {
+      return;
+    }
+
+    const relatedRecordsMenuItem = {
+      text: 'Get related records from...',
+      items: [],
+    };
+
+    // Group fields by class name for hierarchical navigation
+    schema.data
+      .get('classes')
+      .sortBy((v, k) => k)
+      .forEach((cl, className) => {
+        const classFields = [];
+
+        cl.forEach((column, field) => {
+          if (column.type !== 'String') {
+            return;
+          }
+          classFields.push({
+            text: field,
+            callback: () => {
+              onPointerClick({
+                className,
+                id: value,
+                field,
+              });
+            },
+          });
+        });
+
+        if (classFields.length > 0) {
+          relatedRecordsMenuItem.items.push({
+            text: className,
+            items: classFields,
+          });
+        }
+      });
+
+    return relatedRecordsMenuItem.items.length ? relatedRecordsMenuItem : undefined;
   }
 
   pickFilter(constraint, addToExistingFilter) {

--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -525,6 +525,17 @@ export default class BrowserCell extends Component {
           if (column.type !== 'String') {
             return;
           }
+          // Exclude objectId - it's a special field referenced by pointers, not strings
+          if (field === 'objectId') {
+            return;
+          }
+          // Exclude hidden/sensitive fields
+          if (field === 'password' && className === '_User') {
+            return;
+          }
+          if (field === 'sessionToken' && (className === '_User' || className === '_Session')) {
+            return;
+          }
           classFields.push({
             text: field,
             callback: () => {

--- a/src/components/ContextMenu/ContextMenu.react.js
+++ b/src/components/ContextMenu/ContextMenu.react.js
@@ -31,16 +31,23 @@ const getPositionToFitVisibleScreen = (
 
   if (prevEl) {
     const prevElBox = prevEl.getBoundingClientRect();
-    const showOnRight = prevElBox.x + prevElBox.width + elBox.width < window.innerWidth;
 
-    let proposedTop = shouldApplyOffset
-      ? prevElBox.top + offset
-      : prevElBox.top;
+    // Position relative to the immediate previous sibling (parent submenu)
+    // Check if there's space to the right of the previous menu
+    const spaceOnRight = window.innerWidth - prevElBox.right;
+    const showOnRight = spaceOnRight >= elBox.width;
+
+    // Calculate x offset relative to current element's position
+    // to place it adjacent to the previous sibling
+    const xRight = prevElBox.right - elBox.left;
+    const xLeft = prevElBox.left - elBox.left - elBox.width;
+
+    let proposedTop = shouldApplyOffset ? prevElBox.top + offset : prevElBox.top;
 
     proposedTop = Math.max(upperLimit, Math.min(proposedTop, lowerLimit - menuHeight));
 
     return {
-      x: showOnRight ? prevElBox.width : -elBox.width,
+      x: showOnRight ? xRight : xLeft,
       y: proposedTop - elBox.top,
     };
   }

--- a/src/components/ContextMenu/ContextMenu.react.js
+++ b/src/components/ContextMenu/ContextMenu.react.js
@@ -26,7 +26,6 @@ const getPositionToFitVisibleScreen = (
   const lowerLimit = window.innerHeight - footerHeight;
   const upperLimit = 0;
 
-  const shouldApplyOffset = mainItemCount === 0 || subItemCount > mainItemCount;
   const prevEl = ref.current.previousSibling;
 
   if (prevEl) {
@@ -42,8 +41,11 @@ const getPositionToFitVisibleScreen = (
     const xRight = prevElBox.right - elBox.left;
     const xLeft = prevElBox.left - elBox.left - elBox.width;
 
-    let proposedTop = shouldApplyOffset ? prevElBox.top + offset : prevElBox.top;
+    // Align submenu vertically with the hovered item in the parent menu
+    // offset is the pixel position of the hovered item (index * 30px item height)
+    let proposedTop = prevElBox.top + offset;
 
+    // Clamp to screen bounds
     proposedTop = Math.max(upperLimit, Math.min(proposedTop, lowerLimit - menuHeight));
 
     return {

--- a/src/components/ContextMenu/ContextMenu.react.js
+++ b/src/components/ContextMenu/ContextMenu.react.js
@@ -10,12 +10,7 @@ import PropTypes from 'lib/PropTypes';
 import React, { useState, useEffect, useRef } from 'react';
 import styles from 'components/ContextMenu/ContextMenu.scss';
 
-const getPositionToFitVisibleScreen = (
-  ref,
-  offset = 0,
-  mainItemCount = 0,
-  subItemCount = 0
-) => {
+const getPositionToFitVisibleScreen = (ref, offset = 0) => {
   if (!ref.current) {
     return;
   }
@@ -62,19 +57,14 @@ const getPositionToFitVisibleScreen = (
   };
 };
 
-const MenuSection = ({ level, items, path, setPath, hide, parentItemCount = 0 }) => {
+const MenuSection = ({ level, items, path, setPath, hide }) => {
   const sectionRef = useRef(null);
   const [position, setPosition] = useState(null);
   const hasPositioned = useRef(false);
 
   useEffect(() => {
     if (!hasPositioned.current) {
-      const newPosition = getPositionToFitVisibleScreen(
-        sectionRef,
-        path[level] * 30,
-        parentItemCount,
-        items.length
-      );
+      const newPosition = getPositionToFitVisibleScreen(sectionRef, path[level] * 30);
       if (newPosition) {
         setPosition(newPosition);
         hasPositioned.current = true;
@@ -169,8 +159,6 @@ const ContextMenu = ({ x, y, items }) => {
     >
       {path.map((_, level) => {
         const itemsForLevel = getItemsFromLevel(level);
-        const parentItemCount =
-          level === 0 ? items.length : getItemsFromLevel(level - 1).length;
 
         return (
           <MenuSection
@@ -180,7 +168,6 @@ const ContextMenu = ({ x, y, items }) => {
             level={level}
             items={itemsForLevel}
             hide={hide}
-            parentItemCount={parentItemCount}
           />
         );
       })}


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added context menu options to access related text and number fields from cell values, auto-organized by class name
  * Related objects menu now groups fields under class-name submenus for easier navigation

* **Bug Fixes**
  * Improved submenu placement with dynamic right-side space detection and clamped vertical positioning for more accurate menus

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->