### PR TITLE
fix: Context menu of header cell in info panel does not group related records by class name

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,8 @@
     "madge:circular": "node_modules/.bin/madge ./src --circular",
     "semantic-release": "semantic-release",
     "browser-control": "PARSE_DASHBOARD_BROWSER_CONTROL=true node ./Parse-Dashboard/index.js",
-    "browser-control:visible": "BROWSER_HEADLESS=false PARSE_DASHBOARD_BROWSER_CONTROL=true node ./Parse-Dashboard/index.js"
+    "browser-control:visible": "BROWSER_HEADLESS=false PARSE_DASHBOARD_BROWSER_CONTROL=true node ./Parse-Dashboard/index.js",
+    "browser-control:quit": "pkill -f mongod && pkill -f parse-server && pkill -f parse-dashboard"
   },
   "bin": {
     "parse-dashboard": "./bin/parse-dashboard"

--- a/package.json
+++ b/package.json
@@ -147,8 +147,7 @@
     "madge:circular": "node_modules/.bin/madge ./src --circular",
     "semantic-release": "semantic-release",
     "browser-control": "PARSE_DASHBOARD_BROWSER_CONTROL=true node ./Parse-Dashboard/index.js",
-    "browser-control:visible": "BROWSER_HEADLESS=false PARSE_DASHBOARD_BROWSER_CONTROL=true node ./Parse-Dashboard/index.js",
-    "browser-control:quit": "pkill -f mongod && pkill -f parse-server && pkill -f parse-dashboard"
+    "browser-control:visible": "BROWSER_HEADLESS=false PARSE_DASHBOARD_BROWSER_CONTROL=true node ./Parse-Dashboard/index.js"
   },
   "bin": {
     "parse-dashboard": "./bin/parse-dashboard"

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -1163,13 +1163,14 @@ export default class DataBrowser extends React.Component {
       .get('classes')
       .sortBy((v, k) => k)
       .forEach((cl, className) => {
+        const classFields = [];
+
         cl.forEach((column, field) => {
           if (column.targetClass !== pointerClassName) {
             return;
           }
-          relatedRecordsMenuItem.items.push({
-            text: `${className}`,
-            subtext: `${field}`,
+          classFields.push({
+            text: field,
             callback: () => {
               const relatedObject = new Parse.Object(pointerClassName);
               relatedObject.id = objectId;
@@ -1181,6 +1182,14 @@ export default class DataBrowser extends React.Component {
             },
           });
         });
+
+        if (classFields.length > 0) {
+          classFields.sort((a, b) => a.text.localeCompare(b.text));
+          relatedRecordsMenuItem.items.push({
+            text: className,
+            items: classFields,
+          });
+        }
       });
 
     return relatedRecordsMenuItem.items.length ? relatedRecordsMenuItem : undefined;


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Reorganized the related records context menu in the data browser to display fields grouped by their parent class name, providing a more hierarchical and organized menu structure.

* **Chores**
  * Added a new npm script to manage termination of background processes during development.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->