### PR TITLE
feat: Add context menu in data browser to add cell content or selected text to Cloud Config parameter

### DIFF
--- a/src/components/AggregationPanel/AggregationPanel.js
+++ b/src/components/AggregationPanel/AggregationPanel.js
@@ -27,6 +27,7 @@ const AggregationPanel = ({
   cloudCodeFunction = null,
   panelTitle = null,
   style,
+  onContextMenu,
 }) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const [nestedData, setNestedData] = useState(null);
@@ -137,6 +138,7 @@ const AggregationPanel = ({
                     cloudCodeFunction={item.cloudCodeFunction}
                     panelTitle={item.title}
                     style={item.style}
+                    onContextMenu={onContextMenu}
                   />
                 </div>
               );
@@ -205,6 +207,7 @@ const AggregationPanel = ({
   return (
     <div
       onKeyDown={handleKeyDown}
+      onContextMenu={onContextMenu}
       tabIndex={0}
     >
       {isLoadingInfoPanel ? (

--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -631,7 +631,12 @@ export default class BrowserCell extends Component {
   }
 
   getAddToConfigContextMenuOption() {
-    const { arrayConfigParams, onAddToArrayConfig } = this.props;
+    const { arrayConfigParams, onAddToArrayConfig, hidden } = this.props;
+
+    // Don't show for hidden cells to prevent leaking sensitive values
+    if (hidden) {
+      return;
+    }
 
     // Only show if there are array config params and handler is available
     if (!arrayConfigParams || arrayConfigParams.length === 0 || !onAddToArrayConfig) {

--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -377,6 +377,13 @@ export default class BrowserCell extends Component {
         });
     }
 
+    // Add to Cloud Config parameter menu
+    const addToConfigOption = this.getAddToConfigContextMenuOption();
+    addToConfigOption && contextMenuOptions.push(addToConfigOption);
+
+    // Sort menu items alphabetically by text
+    contextMenuOptions.sort((a, b) => a.text.localeCompare(b.text));
+
     return contextMenuOptions;
   }
 
@@ -616,6 +623,33 @@ export default class BrowserCell extends Component {
       });
 
     return relatedRecordsMenuItem.items.length ? relatedRecordsMenuItem : undefined;
+  }
+
+  getAddToConfigContextMenuOption() {
+    const { arrayConfigParams, onAddToArrayConfig } = this.props;
+
+    // Only show if there are array config params and handler is available
+    if (!arrayConfigParams || arrayConfigParams.length === 0 || !onAddToArrayConfig) {
+      return;
+    }
+
+    // Get the cell's copyable value as string
+    const cellValue = this.copyableValue !== undefined ? String(this.copyableValue) : '';
+
+    // Don't show for empty or special values
+    if (!cellValue || cellValue === '(undefined)' || cellValue === '(null)' || cellValue === '(hidden)') {
+      return;
+    }
+
+    return {
+      text: 'Add to config parameter...',
+      items: arrayConfigParams.map(param => ({
+        text: param.name,
+        callback: () => {
+          onAddToArrayConfig(param.name, cellValue);
+        },
+      })),
+    };
   }
 
   pickFilter(constraint, addToExistingFilter) {

--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -377,12 +377,17 @@ export default class BrowserCell extends Component {
         });
     }
 
-    // Add to Cloud Config parameter menu
-    const addToConfigOption = this.getAddToConfigContextMenuOption();
-    addToConfigOption && contextMenuOptions.push(addToConfigOption);
-
     // Sort menu items alphabetically by text
     contextMenuOptions.sort((a, b) => a.text.localeCompare(b.text));
+
+    // Add separator and "Add to config parameter..." after the sorted items
+    const addToConfigOption = this.getAddToConfigContextMenuOption();
+    if (addToConfigOption && contextMenuOptions.length > 0) {
+      contextMenuOptions.push({ type: 'separator' });
+      contextMenuOptions.push(addToConfigOption);
+    } else if (addToConfigOption) {
+      contextMenuOptions.push(addToConfigOption);
+    }
 
     return contextMenuOptions;
   }

--- a/src/components/BrowserRow/BrowserRow.react.js
+++ b/src/components/BrowserRow/BrowserRow.react.js
@@ -191,6 +191,8 @@ export default class BrowserRow extends Component {
               setShowAggregatedData={this.props.setShowAggregatedData}
               setErrorAggregatedData={this.props.setErrorAggregatedData}
               firstSelectedCell={this.props.firstSelectedCell}
+              arrayConfigParams={this.props.arrayConfigParams}
+              onAddToArrayConfig={this.props.onAddToArrayConfig}
             />
           );
         })}

--- a/src/components/ContextMenu/ContextMenu.react.js
+++ b/src/components/ContextMenu/ContextMenu.react.js
@@ -37,7 +37,7 @@ const getPositionToFitVisibleScreen = (ref, offset = 0) => {
     const xLeft = prevElBox.left - elBox.left - elBox.width;
 
     // Align submenu vertically with the hovered item in the parent menu
-    // offset is the pixel position of the hovered item (index * 30px item height)
+    // offset is the actual pixel position of the hovered item (via offsetTop)
     // Subtract parent's scrollTop to account for scrolled position
     const adjustedOffset = offset - prevEl.scrollTop;
     let proposedTop = prevElBox.top + adjustedOffset;
@@ -59,14 +59,15 @@ const getPositionToFitVisibleScreen = (ref, offset = 0) => {
   };
 };
 
-const MenuSection = ({ level, items, path, setPath, hide }) => {
+const MenuSection = ({ level, items, path, setPath, hide, hoveredItemOffset }) => {
   const sectionRef = useRef(null);
   const [position, setPosition] = useState(null);
   const basePosition = useRef(null);
   const initialParentScrollTop = useRef(0);
 
   useEffect(() => {
-    const newPosition = getPositionToFitVisibleScreen(sectionRef, path[level] * 30);
+    // Use the actual pixel offset of the hovered item instead of index-based calculation
+    const newPosition = getPositionToFitVisibleScreen(sectionRef, hoveredItemOffset);
     if (newPosition) {
       setPosition(newPosition);
       basePosition.current = newPosition;
@@ -76,7 +77,7 @@ const MenuSection = ({ level, items, path, setPath, hide }) => {
         initialParentScrollTop.current = prevEl.scrollTop;
       }
     }
-  }, []);
+  }, [hoveredItemOffset]);
 
   // Listen for scroll events on the parent menu and adjust position
   useEffect(() => {
@@ -114,10 +115,13 @@ const MenuSection = ({ level, items, path, setPath, hide }) => {
   return (
     <ul ref={sectionRef} className={styles.category} style={style}>
       {items.map((item, index) => {
-        const handleHover = () => {
+        const handleHover = (event) => {
           const newPath = path.slice(0, level + 1);
           newPath.push(index);
-          setPath(newPath);
+          // Get the actual pixel offset of the hovered item relative to its parent
+          const itemElement = event.currentTarget;
+          const itemOffset = itemElement.offsetTop;
+          setPath(newPath, itemOffset);
         };
 
         // Handle separator items
@@ -154,6 +158,8 @@ const MenuSection = ({ level, items, path, setPath, hide }) => {
 
 const ContextMenu = ({ x, y, items }) => {
   const [path, setPath] = useState([0]);
+  // Track the pixel offset of the hovered item for each level
+  const [hoveredOffsets, setHoveredOffsets] = useState([0]);
   const [visible, setVisible] = useState(true);
   const menuRef = useRef(null);
 
@@ -164,6 +170,16 @@ const ContextMenu = ({ x, y, items }) => {
   const hide = () => {
     setVisible(false);
     setPath([0]);
+    setHoveredOffsets([0]);
+  };
+
+  // Combined setter that updates both path and offsets
+  const updatePath = (newPath, itemOffset) => {
+    setPath(newPath);
+    // Update offsets array to match the new path length
+    const newOffsets = hoveredOffsets.slice(0, newPath.length - 1);
+    newOffsets.push(itemOffset);
+    setHoveredOffsets(newOffsets);
   };
 
   useEffect(() => {
@@ -203,10 +219,11 @@ const ContextMenu = ({ x, y, items }) => {
           <MenuSection
             key={`section-${path[level]}-${level}`}
             path={path}
-            setPath={setPath}
+            setPath={updatePath}
             level={level}
             items={itemsForLevel}
             hide={hide}
+            hoveredItemOffset={hoveredOffsets[level] || 0}
           />
         );
       })}

--- a/src/components/ContextMenu/ContextMenu.react.js
+++ b/src/components/ContextMenu/ContextMenu.react.js
@@ -120,6 +120,16 @@ const MenuSection = ({ level, items, path, setPath, hide }) => {
           setPath(newPath);
         };
 
+        // Handle separator items
+        if (item.type === 'separator') {
+          return (
+            <li
+              key={`menu-section-${level}-${index}`}
+              className={styles.separator}
+            />
+          );
+        }
+
         return (
           <li
             key={`menu-section-${level}-${index}`}

--- a/src/components/ContextMenu/ContextMenu.scss
+++ b/src/components/ContextMenu/ContextMenu.scss
@@ -28,6 +28,19 @@
 		background: rgba(255, 255, 255, 0.1);
 	}
 
+	.separator {
+		height: 1px;
+		padding: 0;
+		margin: 5px 10px;
+		background: rgba(255, 255, 255, 0.2);
+		cursor: default;
+		pointer-events: none;
+
+		&:hover {
+			background: rgba(255, 255, 255, 0.2);
+		}
+	}
+
 	.category {
 		position: absolute;
 		// Keep above the toolbar (src/components/Toolbar/Toolbar.scss).

--- a/src/components/StringEditor/StringEditor.react.js
+++ b/src/components/StringEditor/StringEditor.react.js
@@ -18,6 +18,7 @@ export default class StringEditor extends React.Component {
 
     this.checkExternalClick = this.checkExternalClick.bind(this);
     this.handleKey = this.handleKey.bind(this);
+    this.handleContextMenu = this.handleContextMenu.bind(this);
     this.inputRef = React.createRef();
   }
 
@@ -61,6 +62,48 @@ export default class StringEditor extends React.Component {
     }
   }
 
+  handleContextMenu(e) {
+    const { setContextMenu, arrayConfigParams, onAddToArrayConfig } = this.props;
+
+    // Only show custom context menu when Alt key is held
+    if (!e.altKey) {
+      return;
+    }
+
+    // Check if there are array config params available
+    if (!arrayConfigParams || arrayConfigParams.length === 0 || !onAddToArrayConfig || !setContextMenu) {
+      return;
+    }
+
+    // Get selected text from the input/textarea
+    const input = this.inputRef.current;
+    const selectedText = input.value.substring(input.selectionStart, input.selectionEnd).trim();
+
+    // Only show if there's selected text
+    if (!selectedText) {
+      return;
+    }
+
+    // Prevent default context menu
+    e.preventDefault();
+    e.stopPropagation();
+
+    // Build context menu items
+    const menuItems = [
+      {
+        text: 'Add to config parameter...',
+        items: arrayConfigParams.map(param => ({
+          text: param.name,
+          callback: () => {
+            onAddToArrayConfig(param.name, selectedText);
+          },
+        })),
+      },
+    ];
+
+    setContextMenu(e.pageX, e.pageY, menuItems);
+  }
+
   render() {
     const classes = [styles.editor];
     const onChange = this.props.readonly ? () => {} : e => this.setState({ value: e.target.value });
@@ -79,6 +122,7 @@ export default class StringEditor extends React.Component {
             ref={this.inputRef}
             value={this.state.value}
             onChange={onChange}
+            onContextMenu={this.handleContextMenu}
             style={style}
           />
         </div>
@@ -90,6 +134,7 @@ export default class StringEditor extends React.Component {
           ref={this.inputRef}
           value={this.state.value}
           onChange={onChange}
+          onContextMenu={this.handleContextMenu}
           disabled={this.props.readonly}
         />
       </div>

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -2616,11 +2616,18 @@ class Browser extends DashboardView {
     if (paramData && paramData.value.length > 0) {
       lastType = this.getEntryType(paramData.value[paramData.value.length - 1]);
     }
+
+    // If the last item in the array is a string, wrap the prefilled text in quotes
+    let prefillValue = selectedText;
+    if (lastType === 'string') {
+      prefillValue = `"${selectedText}"`;
+    }
+
     this.setState({
       showAddToConfigDialog: true,
       addToConfigParam: param,
       addToConfigLastType: lastType,
-      addToConfigPrefillValue: selectedText,
+      addToConfigPrefillValue: prefillValue,
     });
   }
 

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -427,6 +427,11 @@ class Browser extends DashboardView {
     ) {
       this.loadAllClassFilters(nextProps);
     }
+
+    // Refresh Cloud Config array params when app changes
+    if (this.props.params.appId !== nextProps.params.appId) {
+      this.fetchArrayConfigParams();
+    }
   }
 
   setLoadingInfoPanel(bool) {

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -2579,6 +2579,10 @@ class Browser extends DashboardView {
     try {
       const configStore = getStore('Config');
       await configStore.dispatch(ConfigActionTypes.FETCH, {}, this.context);
+      // Check if component is still mounted before updating state
+      if (!this._isMounted) {
+        return;
+      }
       const configData = configStore.getData(this.context);
       if (configData) {
         const params = configData.get('params');

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -26,6 +26,7 @@ import ExportSelectedRowsDialog from 'dashboard/Data/Browser/ExportSelectedRowsD
 import Notification from 'dashboard/Data/Browser/Notification.react';
 import PointerKeyDialog from 'dashboard/Data/Browser/PointerKeyDialog.react';
 import RemoveColumnDialog from 'dashboard/Data/Browser/RemoveColumnDialog.react';
+import AddArrayEntryDialog from 'dashboard/Data/Config/AddArrayEntryDialog.react';
 import { List, Map } from 'immutable';
 import { get } from 'lib/AJAX';
 import * as ClassPreferences from 'lib/ClassPreferences';
@@ -35,6 +36,8 @@ import generatePath from 'lib/generatePath';
 import prettyNumber from 'lib/prettyNumber';
 import queryFromFilters from 'lib/queryFromFilters';
 import { ActionTypes } from 'lib/stores/SchemaStore';
+import { ActionTypes as ConfigActionTypes } from 'lib/stores/ConfigStore';
+import { getStore } from 'lib/stores/StoreManager';
 import stringCompare from 'lib/stringCompare';
 import subscribeTo from 'lib/subscribeTo';
 import { withRouter } from 'lib/withRouter';
@@ -195,6 +198,13 @@ class Browser extends DashboardView {
       classFilters: {}, // Map of className -> filters array
       selectedCellsCount: 0,
       selectedData: [],
+
+      // Cloud Config array params for context menu
+      arrayConfigParams: [],
+      showAddToConfigDialog: false,
+      addToConfigParam: '',
+      addToConfigLastType: null,
+      addToConfigPrefillValue: '',
     };
 
     this._isMounted = false;
@@ -275,6 +285,9 @@ class Browser extends DashboardView {
     this.fetchAggregationPanelData = this.fetchAggregationPanelData.bind(this);
     this.setAggregationPanelData = this.setAggregationPanelData.bind(this);
     this.handleCellSelectionChange = this.handleCellSelectionChange.bind(this);
+    this.fetchArrayConfigParams = this.fetchArrayConfigParams.bind(this);
+    this.handleAddToArrayConfig = this.handleAddToArrayConfig.bind(this);
+    this.handleConfirmAddToConfig = this.handleConfirmAddToConfig.bind(this);
 
     // Handle for the ongoing info panel cloud function request
     this.currentInfoPanelQuery = null;
@@ -310,6 +323,9 @@ class Browser extends DashboardView {
       this.setState({ configData: data });
       this.classAndCloudFuntionMap(this.state.configData);
     });
+
+    // Fetch Cloud Config array params for context menu
+    this.fetchArrayConfigParams();
 
     // Initialize FilterPreferencesManager
     if (this.context) {
@@ -2554,6 +2570,95 @@ class Browser extends DashboardView {
     }, 3500);
   }
 
+  async fetchArrayConfigParams() {
+    try {
+      const configStore = getStore('Config');
+      await configStore.dispatch(ConfigActionTypes.FETCH, {}, this.context);
+      const configData = configStore.getData(this.context);
+      if (configData) {
+        const params = configData.get('params');
+        const masterKeyOnly = configData.get('masterKeyOnly');
+        const arrayParams = [];
+        if (params) {
+          params.forEach((value, key) => {
+            if (Array.isArray(value)) {
+              arrayParams.push({
+                name: key,
+                value: value,
+                masterKeyOnly: masterKeyOnly?.get(key) || false,
+              });
+            }
+          });
+        }
+        // Sort alphabetically by name
+        arrayParams.sort((a, b) => a.name.localeCompare(b.name));
+        this.setState({ arrayConfigParams: arrayParams });
+      }
+    } catch (error) {
+      console.error('Failed to fetch config params:', error);
+    }
+  }
+
+  getEntryType(value) {
+    if (Array.isArray(value)) {
+      return 'array';
+    }
+    if (value === null) {
+      return 'null';
+    }
+    return typeof value;
+  }
+
+  handleAddToArrayConfig(param, selectedText) {
+    const { arrayConfigParams } = this.state;
+    const paramData = arrayConfigParams.find(p => p.name === param);
+    let lastType = null;
+    if (paramData && paramData.value.length > 0) {
+      lastType = this.getEntryType(paramData.value[paramData.value.length - 1]);
+    }
+    this.setState({
+      showAddToConfigDialog: true,
+      addToConfigParam: param,
+      addToConfigLastType: lastType,
+      addToConfigPrefillValue: selectedText,
+    });
+  }
+
+  async handleConfirmAddToConfig(value) {
+    try {
+      const param = this.state.addToConfigParam;
+      const configStore = getStore('Config');
+      const configData = configStore.getData(this.context);
+      const masterKeyOnlyMap = configData?.get('masterKeyOnly');
+      const masterKeyOnly = masterKeyOnlyMap?.get(param) || false;
+
+      await Parse._request(
+        'PUT',
+        'config',
+        {
+          params: {
+            [param]: { __op: 'AddUnique', objects: [Parse._encode(value)] },
+          },
+          masterKeyOnly: { [param]: masterKeyOnly },
+        },
+        { useMasterKey: true }
+      );
+
+      this.showNote(`Entry added to ${param}`, false);
+      // Refresh config params
+      await this.fetchArrayConfigParams();
+    } catch (error) {
+      this.showNote(`Failed to add entry: ${error.message}`, true);
+    } finally {
+      this.setState({
+        showAddToConfigDialog: false,
+        addToConfigParam: '',
+        addToConfigLastType: null,
+        addToConfigPrefillValue: '',
+      });
+    }
+  }
+
   showEditRowDialog(selectRow, objectId) {
     // objectId is optional param which is used for doubleClick event on objectId BrowserCell
     if (selectRow) {
@@ -2754,6 +2859,8 @@ class Browser extends DashboardView {
               limit={this.state.limit}
               skip={this.state.skip}
               onCellSelectionChange={this.handleCellSelectionChange}
+              arrayConfigParams={this.state.arrayConfigParams}
+              onAddToArrayConfig={this.handleAddToArrayConfig}
             />
             <BrowserFooter
               skip={this.state.skip}
@@ -2978,6 +3085,23 @@ class Browser extends DashboardView {
           onConfirm={(type, indentation) =>
             this.confirmExportSelectedRows(this.state.rowsToExport, type, indentation)
           }
+        />
+      );
+    } else if (this.state.showAddToConfigDialog) {
+      extras = (
+        <AddArrayEntryDialog
+          onCancel={() =>
+            this.setState({
+              showAddToConfigDialog: false,
+              addToConfigParam: '',
+              addToConfigLastType: null,
+              addToConfigPrefillValue: '',
+            })
+          }
+          onConfirm={this.handleConfirmAddToConfig}
+          lastType={this.state.addToConfigLastType}
+          param={this.state.addToConfigParam}
+          initialValue={this.state.addToConfigPrefillValue}
         />
       );
     }

--- a/src/dashboard/Data/Browser/BrowserTable.react.js
+++ b/src/dashboard/Data/Browser/BrowserTable.react.js
@@ -208,6 +208,8 @@ export default class BrowserTable extends React.Component {
                     setShowAggregatedData={this.props.setShowAggregatedData}
                     setErrorAggregatedData={this.props.setErrorAggregatedData}
                     firstSelectedCell={this.props.firstSelectedCell}
+                    arrayConfigParams={this.props.arrayConfigParams}
+                    onAddToArrayConfig={this.props.onAddToArrayConfig}
                   />
                   <Button
                     value="Clone"
@@ -294,6 +296,8 @@ export default class BrowserTable extends React.Component {
               setShowAggregatedData={this.props.setShowAggregatedData}
               setErrorAggregatedData={this.props.setErrorAggregatedData}
               firstSelectedCell={this.props.firstSelectedCell}
+              arrayConfigParams={this.props.arrayConfigParams}
+              onAddToArrayConfig={this.props.onAddToArrayConfig}
             />
             <Button
               value="Add"
@@ -389,6 +393,8 @@ export default class BrowserTable extends React.Component {
             setShowAggregatedData={this.props.setShowAggregatedData}
             setErrorAggregatedData={this.props.setErrorAggregatedData}
             firstSelectedCell={this.props.firstSelectedCell}
+            arrayConfigParams={this.props.arrayConfigParams}
+            onAddToArrayConfig={this.props.onAddToArrayConfig}
           />
         );
       }
@@ -484,6 +490,9 @@ export default class BrowserTable extends React.Component {
                   this.props.setEditing(false);
                 }}
                 onCancel={() => this.props.setEditing(false)}
+                setContextMenu={this.props.setContextMenu}
+                arrayConfigParams={this.props.arrayConfigParams}
+                onAddToArrayConfig={this.props.onAddToArrayConfig}
               />
             );
           }

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -1175,7 +1175,7 @@ export default class DataBrowser extends React.Component {
     // Build context menu items
     const menuItems = [
       {
-        text: 'Add to Cloud Config parameter...',
+        text: 'Add to config parameter...',
         items: arrayParams.map(param => ({
           text: param.name,
           callback: () => {

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -208,6 +208,7 @@ export default class DataBrowser extends React.Component {
     this.removePanel = this.removePanel.bind(this);
     this.handlePanelScroll = this.handlePanelScroll.bind(this);
     this.handlePanelHeaderContextMenu = this.handlePanelHeaderContextMenu.bind(this);
+    this.handleAggregationPanelTextContextMenu = this.handleAggregationPanelTextContextMenu.bind(this);
     this.handleWrapperWheel = this.handleWrapperWheel.bind(this);
     this.onMouseDownPanelCheckBox = this.onMouseDownPanelCheckBox.bind(this);
     this.onMouseUpPanelCheckBox = this.onMouseUpPanelCheckBox.bind(this);
@@ -1147,6 +1148,48 @@ export default class DataBrowser extends React.Component {
     }
   }
 
+  handleAggregationPanelTextContextMenu(event) {
+    // Only show custom menu when Alt/Option key is held
+    if (!event.altKey) {
+      return;
+    }
+
+    // Check if there's selected text
+    const selection = window.getSelection();
+    const selectedText = selection ? selection.toString().trim() : '';
+
+    if (!selectedText) {
+      return;
+    }
+
+    // Get array config params from props
+    const arrayParams = this.props.arrayConfigParams || [];
+
+    if (arrayParams.length === 0) {
+      return;
+    }
+
+    // Prevent default context menu
+    event.preventDefault();
+
+    // Build context menu items
+    const menuItems = [
+      {
+        text: 'Add to Cloud Config parameter...',
+        items: arrayParams.map(param => ({
+          text: param.name,
+          callback: () => {
+            if (this.props.onAddToArrayConfig) {
+              this.props.onAddToArrayConfig(param.name, selectedText);
+            }
+          },
+        })),
+      },
+    ];
+
+    this.setContextMenu(event.pageX, event.pageY, menuItems);
+  }
+
   getRelatedObjectsMenuItemForPanel(objectId, pointerClassName) {
     const { schema, onPointerCmdClick } = this.props;
 
@@ -2048,6 +2091,7 @@ export default class DataBrowser extends React.Component {
                             selectedObjectId={this.state.selectedObjectId}
                             appName={this.props.appName}
                             className={this.props.className}
+                            onContextMenu={this.handleAggregationPanelTextContextMenu}
                           />
                         );
                       }
@@ -2106,6 +2150,7 @@ export default class DataBrowser extends React.Component {
                                 selectedObjectId={objectId}
                                 appName={this.props.appName}
                                 className={this.props.className}
+                                onContextMenu={this.handleAggregationPanelTextContextMenu}
                               />
                             </div>
                             {index < this.state.displayedObjectIds.length - 1 && (
@@ -2128,6 +2173,7 @@ export default class DataBrowser extends React.Component {
                     selectedObjectId={this.state.selectedObjectId}
                     appName={this.props.appName}
                     className={this.props.className}
+                    onContextMenu={this.handleAggregationPanelTextContextMenu}
                   />
                 )}
               </div>

--- a/src/dashboard/Data/Browser/Editor.react.js
+++ b/src/dashboard/Data/Browser/Editor.react.js
@@ -16,7 +16,7 @@ import decode from 'parse/lib/browser/decode';
 import React from 'react';
 import StringEditor from 'components/StringEditor/StringEditor.react';
 
-const Editor = ({ top, left, type, targetClass, value, readonly, width, onCommit, onCancel }) => {
+const Editor = ({ top, left, type, targetClass, value, readonly, width, onCommit, onCancel, setContextMenu, arrayConfigParams, onAddToArrayConfig }) => {
   let content = null;
   if (type === 'String') {
     content = (
@@ -28,6 +28,9 @@ const Editor = ({ top, left, type, targetClass, value, readonly, width, onCommit
         onCommit={onCommit}
         onCancel={onCancel}
         resizable={true}
+        setContextMenu={setContextMenu}
+        arrayConfigParams={arrayConfigParams}
+        onAddToArrayConfig={onAddToArrayConfig}
       />
     );
   } else if (type === 'Array' || type === 'Object') {
@@ -47,6 +50,9 @@ const Editor = ({ top, left, type, targetClass, value, readonly, width, onCommit
         width={width}
         onCommit={encodeCommit}
         onCancel={onCancel}
+        setContextMenu={setContextMenu}
+        arrayConfigParams={arrayConfigParams}
+        onAddToArrayConfig={onAddToArrayConfig}
       />
     );
   } else if (type === 'Polygon') {
@@ -86,6 +92,9 @@ const Editor = ({ top, left, type, targetClass, value, readonly, width, onCommit
         width={width}
         onCommit={encodeCommit}
         onCancel={onCancel}
+        setContextMenu={setContextMenu}
+        arrayConfigParams={arrayConfigParams}
+        onAddToArrayConfig={onAddToArrayConfig}
       />
     );
   } else if (type === 'Date') {
@@ -97,6 +106,9 @@ const Editor = ({ top, left, type, targetClass, value, readonly, width, onCommit
           width={width}
           onCommit={() => onCommit(value)}
           onCancel={onCancel}
+          setContextMenu={setContextMenu}
+          arrayConfigParams={arrayConfigParams}
+          onAddToArrayConfig={onAddToArrayConfig}
         />
       );
     } else {
@@ -125,7 +137,7 @@ const Editor = ({ top, left, type, targetClass, value, readonly, width, onCommit
         );
       }
     };
-    content = <StringEditor value={value ? value.id : ''} width={width} onCommit={encodeCommit} onCancel={onCancel} />;
+    content = <StringEditor value={value ? value.id : ''} width={width} onCommit={encodeCommit} onCancel={onCancel} setContextMenu={setContextMenu} arrayConfigParams={arrayConfigParams} onAddToArrayConfig={onAddToArrayConfig} />;
   }
 
   return <div style={{ position: 'absolute', top: top, left: left }}>{content}</div>;

--- a/src/dashboard/Data/Config/AddArrayEntryDialog.react.js
+++ b/src/dashboard/Data/Config/AddArrayEntryDialog.react.js
@@ -14,10 +14,10 @@ import React from 'react';
 import TextInput from 'components/TextInput/TextInput.react';
 
 export default class AddArrayEntryDialog extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
-      value: '',
+      value: props.initialValue || '',
       showMismatchRow: false,
       mismatchConfirmed: false,
       parsedType: '',

--- a/src/dashboard/Data/Config/AddArrayEntryDialog.react.js
+++ b/src/dashboard/Data/Config/AddArrayEntryDialog.react.js
@@ -17,7 +17,7 @@ export default class AddArrayEntryDialog extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      value: props.initialValue || '',
+      value: String(props.initialValue ?? ''),
       showMismatchRow: false,
       mismatchConfirmed: false,
       parsedType: '',
@@ -28,6 +28,18 @@ export default class AddArrayEntryDialog extends React.Component {
   componentDidMount() {
     if (this.inputRef.current) {
       this.inputRef.current.focus();
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    // Sync state when initialValue prop changes
+    if (prevProps.initialValue !== this.props.initialValue) {
+      this.setState({
+        value: String(this.props.initialValue ?? ''),
+        showMismatchRow: false,
+        mismatchConfirmed: false,
+        parsedType: '',
+      });
     }
   }
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

# Feature

Adds "Add to config parameter..." context menu item to add cell content to Cloud Config array. When right-clicking on selected text inside the cell while in edit mode, or on selected text in the info panel, hold the `Alt` key while clicking to show the custom context menu.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Add to config parameter..." context menu across the app to add cell values or selected text to cloud config array parameters.
  * Enabled Alt+right-click context menus in text editors and aggregation panels to quickly invoke the add-to-config action.
  * Added a dialog UI for adding and managing entries in array configuration parameters.

* **Style**
  * Added non-interactive separators in context menus for clearer organization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->