### PR TITLE
feat: Add customizable Y-axis titles for data browser graphs

### DIFF
--- a/src/components/GraphPanel/GraphPanel.react.js
+++ b/src/components/GraphPanel/GraphPanel.react.js
@@ -171,6 +171,8 @@ const GraphPanel = ({
       showGrid,
       showAxisLabels,
       isStacked,
+      yAxisTitlePrimary,
+      yAxisTitleSecondary,
     } = graphConfig;
 
     const baseOptions = {
@@ -239,8 +241,13 @@ const GraphPanel = ({
           return [joined];
         };
 
-        const primaryAxisTitle = splitLabel(primaryAxisSeries, 'Primary Axis');
-        const secondaryAxisTitle = splitLabel(secondaryAxisSeries, 'Secondary Axis');
+        // Use custom titles if provided, otherwise fall back to auto-generated
+        const primaryAxisTitle = yAxisTitlePrimary
+          ? [yAxisTitlePrimary]
+          : splitLabel(primaryAxisSeries, 'Primary Axis');
+        const secondaryAxisTitle = yAxisTitleSecondary
+          ? [yAxisTitleSecondary]
+          : splitLabel(secondaryAxisSeries, 'Secondary Axis');
 
         const hasSecondaryAxis = secondaryAxisSeries.length > 0;
 
@@ -327,6 +334,17 @@ const GraphPanel = ({
               display: true,
               grid: {
                 display: showGrid,
+              },
+              title: {
+                display: showAxisLabels !== false && !!yAxisTitlePrimary,
+                text: yAxisTitlePrimary || '',
+                font: {
+                  size: 12,
+                },
+                padding: {
+                  top: 10,
+                  bottom: 10,
+                },
               },
             },
           },

--- a/src/dashboard/Data/Browser/GraphDialog.react.js
+++ b/src/dashboard/Data/Browser/GraphDialog.react.js
@@ -75,6 +75,8 @@ export default class GraphDialog extends React.Component {
       calculatedValues,
       aggregationType: initialConfig.aggregationType || 'count',
       title: initialConfig.title || '',
+      yAxisTitlePrimary: initialConfig.yAxisTitlePrimary || '',
+      yAxisTitleSecondary: initialConfig.yAxisTitleSecondary || '',
       showLegend: initialConfig.showLegend !== undefined ? initialConfig.showLegend : true,
       showGrid: initialConfig.showGrid !== undefined ? initialConfig.showGrid : true,
       showAxisLabels: initialConfig.showAxisLabels !== undefined ? initialConfig.showAxisLabels : true,
@@ -650,6 +652,36 @@ export default class GraphDialog extends React.Component {
               type={Toggle.Types.YES_NO}
               value={this.state.isStacked}
               onChange={isStacked => this.setState({ isStacked })}
+            />
+          } />
+        )}
+
+        {(this.state.chartType === 'bar' || this.state.chartType === 'line' || this.state.chartType === 'scatter' || this.state.chartType === 'radar') && (
+          <Field label={
+            <Label
+              text="Y-Axis Title (Primary)"
+              description="Optional label for left axis"
+            />
+          } input={
+            <TextInput
+              value={this.state.yAxisTitlePrimary}
+              onChange={yAxisTitlePrimary => this.setState({ yAxisTitlePrimary })}
+              placeholder="Primary Y-axis title"
+            />
+          } />
+        )}
+
+        {(this.state.chartType === 'bar' || this.state.chartType === 'line') && (
+          <Field label={
+            <Label
+              text="Y-Axis Title (Secondary)"
+              description="Optional label for right axis"
+            />
+          } input={
+            <TextInput
+              value={this.state.yAxisTitleSecondary}
+              onChange={yAxisTitleSecondary => this.setState({ yAxisTitleSecondary })}
+              placeholder="Secondary Y-axis title"
             />
           } />
         )}


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customizable Y-axis titles for charts. Users can now set primary and secondary Y-axis titles for bar, line, scatter, and radar charts. When custom titles are not provided, the system automatically generates appropriate labels.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->