### PR TITLE
feat: Add customizable styles for line and bar series in data browser graph

### DIFF
--- a/src/components/GraphPanel/GraphPanel.react.js
+++ b/src/components/GraphPanel/GraphPanel.react.js
@@ -169,9 +169,20 @@ const GraphPanel = ({
         });
       }
 
+      // Helper to compute the effective chart type for a dataset
+      // dataset.type overrides global defaults (set by secondary Y-axis type or other means)
+      const getEffectiveType = (dataset) => {
+        if (dataset.type) {
+          return dataset.type;
+        }
+        if (dataset.yAxisID === 'y1' && secondaryYAxisType) {
+          return secondaryYAxisType;
+        }
+        return chartType;
+      };
+
       // Apply line styles to datasets (convert lineStyle to Chart.js borderDash)
-      // Apply when chart type is line, or when dataset is on secondary axis with line type
-      if (result && result.datasets && (chartType === 'line' || secondaryYAxisType === 'line')) {
+      if (result && result.datasets) {
         const lineStyleToBorderDash = {
           solid: [],
           dashed: [8, 4],
@@ -179,11 +190,8 @@ const GraphPanel = ({
         };
 
         result.datasets = result.datasets.map(dataset => {
-          // Apply line style if:
-          // 1. Chart type is line (all datasets are lines), or
-          // 2. Dataset is on secondary axis and secondary axis type is line
-          const isLineDataset = chartType === 'line' || (dataset.yAxisID === 'y1' && secondaryYAxisType === 'line');
-          if (isLineDataset && dataset.lineStyle && lineStyleToBorderDash[dataset.lineStyle]) {
+          const effectiveType = getEffectiveType(dataset);
+          if (effectiveType === 'line' && dataset.lineStyle && lineStyleToBorderDash[dataset.lineStyle]) {
             return {
               ...dataset,
               borderDash: lineStyleToBorderDash[dataset.lineStyle],
@@ -194,14 +202,10 @@ const GraphPanel = ({
       }
 
       // Apply bar styles to datasets
-      // Apply when chart type is bar, or when dataset is on secondary axis with bar type
-      if (result && result.datasets && (chartType === 'bar' || secondaryYAxisType === 'bar')) {
+      if (result && result.datasets) {
         result.datasets = result.datasets.map(dataset => {
-          // Apply bar style if:
-          // 1. Chart type is bar (all datasets are bars), or
-          // 2. Dataset is on secondary axis and secondary axis type is bar
-          const isBarDataset = chartType === 'bar' || (dataset.yAxisID === 'y1' && secondaryYAxisType === 'bar');
-          if (isBarDataset && dataset.barStyle) {
+          const effectiveType = getEffectiveType(dataset);
+          if (effectiveType === 'bar' && dataset.barStyle) {
             switch (dataset.barStyle) {
               case 'outlined':
                 // Outlined: transparent fill with thick border

--- a/src/components/GraphPanel/GraphPanel.react.js
+++ b/src/components/GraphPanel/GraphPanel.react.js
@@ -133,6 +133,7 @@ const GraphPanel = ({
       aggregationType,
       maxDataPoints,
       calculatedValues,
+      secondaryYAxisType,
     } = graphConfig;
 
     // Limit data points for performance
@@ -154,6 +155,20 @@ const GraphPanel = ({
           result = processBarLineData(limitedData, xColumn, valueColumn, groupByColumn, aggregationType, calculatedValues);
           break;
       }
+
+      // Apply secondary Y-axis chart type to datasets on secondary axis
+      if (result && result.datasets && secondaryYAxisType && (chartType === 'bar' || chartType === 'line')) {
+        result.datasets = result.datasets.map(dataset => {
+          if (dataset.yAxisID === 'y1') {
+            return {
+              ...dataset,
+              type: secondaryYAxisType,
+            };
+          }
+          return dataset;
+        });
+      }
+
       return { processedData: result, validationError: null };
     } catch (err) {
       console.error('Error processing graph data:', err);

--- a/src/components/GraphPanel/GraphPanel.react.js
+++ b/src/components/GraphPanel/GraphPanel.react.js
@@ -193,6 +193,39 @@ const GraphPanel = ({
         });
       }
 
+      // Apply bar styles to datasets
+      // Apply when chart type is bar, or when dataset is on secondary axis with bar type
+      if (result && result.datasets && (chartType === 'bar' || secondaryYAxisType === 'bar')) {
+        result.datasets = result.datasets.map(dataset => {
+          // Apply bar style if:
+          // 1. Chart type is bar (all datasets are bars), or
+          // 2. Dataset is on secondary axis and secondary axis type is bar
+          const isBarDataset = chartType === 'bar' || (dataset.yAxisID === 'y1' && secondaryYAxisType === 'bar');
+          if (isBarDataset && dataset.barStyle) {
+            switch (dataset.barStyle) {
+              case 'outlined':
+                // Outlined: transparent fill with thick border
+                return {
+                  ...dataset,
+                  backgroundColor: 'transparent',
+                  borderWidth: 2,
+                };
+              case 'striped':
+                // Striped: lighter fill with dashed border to indicate pattern
+                return {
+                  ...dataset,
+                  backgroundColor: dataset.backgroundColor.replace('0.8', '0.3'),
+                  borderWidth: 2,
+                  borderDash: [4, 4],
+                };
+              default:
+                return dataset;
+            }
+          }
+          return dataset;
+        });
+      }
+
       return { processedData: result, validationError: null };
     } catch (err) {
       console.error('Error processing graph data:', err);

--- a/src/components/GraphPanel/GraphPanel.react.js
+++ b/src/components/GraphPanel/GraphPanel.react.js
@@ -169,6 +169,30 @@ const GraphPanel = ({
         });
       }
 
+      // Apply line styles to datasets (convert lineStyle to Chart.js borderDash)
+      // Apply when chart type is line, or when dataset is on secondary axis with line type
+      if (result && result.datasets && (chartType === 'line' || secondaryYAxisType === 'line')) {
+        const lineStyleToBorderDash = {
+          solid: [],
+          dashed: [8, 4],
+          dotted: [2, 2],
+        };
+
+        result.datasets = result.datasets.map(dataset => {
+          // Apply line style if:
+          // 1. Chart type is line (all datasets are lines), or
+          // 2. Dataset is on secondary axis and secondary axis type is line
+          const isLineDataset = chartType === 'line' || (dataset.yAxisID === 'y1' && secondaryYAxisType === 'line');
+          if (isLineDataset && dataset.lineStyle && lineStyleToBorderDash[dataset.lineStyle]) {
+            return {
+              ...dataset,
+              borderDash: lineStyleToBorderDash[dataset.lineStyle],
+            };
+          }
+          return dataset;
+        });
+      }
+
       return { processedData: result, validationError: null };
     } catch (err) {
       console.error('Error processing graph data:', err);

--- a/src/dashboard/Data/Browser/GraphDialog.react.js
+++ b/src/dashboard/Data/Browser/GraphDialog.react.js
@@ -77,6 +77,7 @@ export default class GraphDialog extends React.Component {
       title: initialConfig.title || '',
       yAxisTitlePrimary: initialConfig.yAxisTitlePrimary || '',
       yAxisTitleSecondary: initialConfig.yAxisTitleSecondary || '',
+      secondaryYAxisType: initialConfig.secondaryYAxisType || null,
       showLegend: initialConfig.showLegend !== undefined ? initialConfig.showLegend : true,
       showGrid: initialConfig.showGrid !== undefined ? initialConfig.showGrid : true,
       showAxisLabels: initialConfig.showAxisLabels !== undefined ? initialConfig.showAxisLabels : true,
@@ -683,6 +684,25 @@ export default class GraphDialog extends React.Component {
               onChange={yAxisTitleSecondary => this.setState({ yAxisTitleSecondary })}
               placeholder="Secondary Y-axis title"
             />
+          } />
+        )}
+
+        {(this.state.chartType === 'bar' || this.state.chartType === 'line') && (
+          <Field label={
+            <Label
+              text="Secondary Y-Axis Chart Type"
+              description="Chart type for secondary axis series"
+            />
+          } input={
+            <Dropdown
+              value={this.state.secondaryYAxisType || ''}
+              onChange={secondaryYAxisType => this.setState({ secondaryYAxisType: secondaryYAxisType || null })}
+              placeHolder="Same as chart type"
+            >
+              <Option value="">Same as chart type</Option>
+              <Option value="bar">Bar</Option>
+              <Option value="line">Line</Option>
+            </Dropdown>
           } />
         )}
 

--- a/src/dashboard/Data/Browser/GraphDialog.react.js
+++ b/src/dashboard/Data/Browser/GraphDialog.react.js
@@ -52,6 +52,12 @@ const LINE_STYLES = [
   { value: 'dotted', label: 'Dotted' },
 ];
 
+const BAR_STYLES = [
+  { value: 'solid', label: 'Solid' },
+  { value: 'outlined', label: 'Outlined' },
+  { value: 'striped', label: 'Striped' },
+];
+
 export default class GraphDialog extends React.Component {
   constructor(props) {
     super(props);
@@ -565,6 +571,25 @@ export default class GraphDialog extends React.Component {
                                 onChange={lineStyle => this.updateCalculatedValue(index, 'lineStyle', lineStyle)}
                               >
                                 {LINE_STYLES.map(style => (
+                                  <Option key={style.value} value={style.value}>
+                                    {style.label}
+                                  </Option>
+                                ))}
+                              </Dropdown>
+                            </div>
+                          </div>
+                        )}
+                        {(this.state.chartType === 'bar' || (calc.useSecondaryYAxis && this.state.secondaryYAxisType === 'bar')) && (
+                          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid #e3e3e3' }}>
+                            <div style={{ display: 'flex', alignItems: 'center' }}>
+                              <Label text="Bar Style" />
+                            </div>
+                            <div>
+                              <Dropdown
+                                value={calc.barStyle || 'solid'}
+                                onChange={barStyle => this.updateCalculatedValue(index, 'barStyle', barStyle)}
+                              >
+                                {BAR_STYLES.map(style => (
                                   <Option key={style.value} value={style.value}>
                                     {style.label}
                                   </Option>

--- a/src/dashboard/Data/Browser/GraphDialog.react.js
+++ b/src/dashboard/Data/Browser/GraphDialog.react.js
@@ -415,6 +415,10 @@ export default class GraphDialog extends React.Component {
               const hasCircular = this.hasCircularReference(index);
               // Check for formula errors
               const formulaError = this.getFormulaError(index);
+              // Compute effective chart type for this calculated value
+              const effectiveType = calc.useSecondaryYAxis && this.state.secondaryYAxisType
+                ? this.state.secondaryYAxisType
+                : this.state.chartType;
 
               return (
                 <div key={index} style={{ paddingTop: '10px', paddingLeft: '10px', paddingRight: '10px', paddingBottom: isExpanded ? '0' : '10px', borderTop: '1px solid #e3e3e3', borderLeft: '1px solid #e3e3e3', borderRight: '1px solid #e3e3e3', borderBottom: index === this.state.calculatedValues.length - 1 ? '1px solid #e3e3e3' : 'none' }}>
@@ -560,7 +564,7 @@ export default class GraphDialog extends React.Component {
                             </div>
                           </div>
                         )}
-                        {(this.state.chartType === 'line' || (calc.useSecondaryYAxis && this.state.secondaryYAxisType === 'line')) && (
+                        {effectiveType === 'line' && (
                           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid #e3e3e3' }}>
                             <div style={{ display: 'flex', alignItems: 'center' }}>
                               <Label text="Line Style" />
@@ -579,7 +583,7 @@ export default class GraphDialog extends React.Component {
                             </div>
                           </div>
                         )}
-                        {(this.state.chartType === 'bar' || (calc.useSecondaryYAxis && this.state.secondaryYAxisType === 'bar')) && (
+                        {effectiveType === 'bar' && (
                           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid #e3e3e3' }}>
                             <div style={{ display: 'flex', alignItems: 'center' }}>
                               <Label text="Bar Style" />

--- a/src/dashboard/Data/Browser/GraphDialog.react.js
+++ b/src/dashboard/Data/Browser/GraphDialog.react.js
@@ -46,6 +46,12 @@ const CALCULATED_VALUE_OPERATORS = [
   { value: 'formula', label: 'Formula' },
 ];
 
+const LINE_STYLES = [
+  { value: 'solid', label: 'Solid' },
+  { value: 'dashed', label: 'Dashed' },
+  { value: 'dotted', label: 'Dotted' },
+];
+
 export default class GraphDialog extends React.Component {
   constructor(props) {
     super(props);
@@ -545,6 +551,25 @@ export default class GraphDialog extends React.Component {
                                 value={calc.useSecondaryYAxis || false}
                                 onChange={useSecondaryYAxis => this.updateCalculatedValue(index, 'useSecondaryYAxis', useSecondaryYAxis)}
                               />
+                            </div>
+                          </div>
+                        )}
+                        {(this.state.chartType === 'line' || (calc.useSecondaryYAxis && this.state.secondaryYAxisType === 'line')) && (
+                          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid #e3e3e3' }}>
+                            <div style={{ display: 'flex', alignItems: 'center' }}>
+                              <Label text="Line Style" />
+                            </div>
+                            <div>
+                              <Dropdown
+                                value={calc.lineStyle || 'solid'}
+                                onChange={lineStyle => this.updateCalculatedValue(index, 'lineStyle', lineStyle)}
+                              >
+                                {LINE_STYLES.map(style => (
+                                  <Option key={style.value} value={style.value}>
+                                    {style.label}
+                                  </Option>
+                                ))}
+                              </Dropdown>
                             </div>
                           </div>
                         )}

--- a/src/lib/GraphDataUtils.js
+++ b/src/lib/GraphDataUtils.js
@@ -720,11 +720,12 @@ export function processBarLineData(data, xColumn, valueColumn, groupByColumn, ag
   const sortedXLabels = sortedXKeys.map(key => xValues.get(key));
   const groupKeys = Object.keys(groups);
 
-  // Create maps for calculated value properties (operator, secondary Y axis, line style)
+  // Create maps for calculated value properties (operator, secondary Y axis, line style, bar style)
   // This handles both simple calc names and grouped calc names like "CalcName (GroupValue)"
   const calcValueOperatorMap = new Map();
   const calcValueSecondaryYAxisMap = new Map();
   const calcValueLineStyleMap = new Map();
+  const calcValueBarStyleMap = new Map();
   if (calculatedValues && Array.isArray(calculatedValues)) {
     calculatedValues.forEach(calc => {
       if (calc.name && calc.operator) {
@@ -739,6 +740,9 @@ export function processBarLineData(data, xColumn, valueColumn, groupByColumn, ag
             }
             if (calc.lineStyle) {
               calcValueLineStyleMap.set(groupKey, calc.lineStyle);
+            }
+            if (calc.barStyle) {
+              calcValueBarStyleMap.set(groupKey, calc.barStyle);
             }
           }
         });
@@ -787,6 +791,12 @@ export function processBarLineData(data, xColumn, valueColumn, groupByColumn, ag
     const lineStyle = calcValueLineStyleMap.get(groupKey);
     if (lineStyle) {
       dataset.lineStyle = lineStyle;
+    }
+
+    // Add bar style if specified
+    const barStyle = calcValueBarStyleMap.get(groupKey);
+    if (barStyle) {
+      dataset.barStyle = barStyle;
     }
 
     return dataset;

--- a/src/lib/GraphDataUtils.js
+++ b/src/lib/GraphDataUtils.js
@@ -720,10 +720,11 @@ export function processBarLineData(data, xColumn, valueColumn, groupByColumn, ag
   const sortedXLabels = sortedXKeys.map(key => xValues.get(key));
   const groupKeys = Object.keys(groups);
 
-  // Create maps for calculated value properties (operator, secondary Y axis)
+  // Create maps for calculated value properties (operator, secondary Y axis, line style)
   // This handles both simple calc names and grouped calc names like "CalcName (GroupValue)"
   const calcValueOperatorMap = new Map();
   const calcValueSecondaryYAxisMap = new Map();
+  const calcValueLineStyleMap = new Map();
   if (calculatedValues && Array.isArray(calculatedValues)) {
     calculatedValues.forEach(calc => {
       if (calc.name && calc.operator) {
@@ -735,6 +736,9 @@ export function processBarLineData(data, xColumn, valueColumn, groupByColumn, ag
             calcValueOperatorMap.set(groupKey, calc.operator);
             if (calc.useSecondaryYAxis) {
               calcValueSecondaryYAxisMap.set(groupKey, true);
+            }
+            if (calc.lineStyle) {
+              calcValueLineStyleMap.set(groupKey, calc.lineStyle);
             }
           }
         });
@@ -770,7 +774,7 @@ export function processBarLineData(data, xColumn, valueColumn, groupByColumn, ag
       }
     });
 
-    return {
+    const dataset = {
       label: groupKey,
       data: values,
       backgroundColor: colors[index],
@@ -778,6 +782,14 @@ export function processBarLineData(data, xColumn, valueColumn, groupByColumn, ag
       borderWidth: 1,
       yAxisID: calcValueSecondaryYAxisMap.get(groupKey) ? 'y1' : 'y',
     };
+
+    // Add line style if specified
+    const lineStyle = calcValueLineStyleMap.get(groupKey);
+    if (lineStyle) {
+      dataset.lineStyle = lineStyle;
+    }
+
+    return dataset;
   });
 
   return {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Enhanced chart styling: apply custom line styles (solid, dashed, or dotted) and bar patterns (outlined or striped) to better differentiate and emphasize individual datasets in your charts
- Secondary Y-axis control: assign an independent chart type (bar or line) to secondary axis datasets, enabling mixed chart types within a single graph for better data comparison

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->