### PR TITLE
fix: Name of calculated value in data browser graph allows leading and trailing spaces

### DIFF
--- a/src/dashboard/Data/Browser/GraphDialog.react.js
+++ b/src/dashboard/Data/Browser/GraphDialog.react.js
@@ -259,7 +259,13 @@ export default class GraphDialog extends React.Component {
       return null; // Empty names are allowed (will use default "Calculated Value N")
     }
 
-    const name = calc.name.trim();
+    const name = calc.name;
+    const trimmedName = name.trim();
+
+    // Check for leading or trailing whitespace
+    if (name !== trimmedName) {
+      return 'Name cannot start or end with spaces';
+    }
 
     // Check for valid characters (alphanumeric and underscore only)
     if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(name)) {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-dashboard/issues?q=is%3Aissue).

