### PR TITLE
fix: Canvas is not expandable or scrollable beyond current view size

### DIFF
--- a/src/dashboard/Data/CustomDashboard/CanvasElement.react.js
+++ b/src/dashboard/Data/CustomDashboard/CanvasElement.react.js
@@ -54,8 +54,8 @@ const CanvasElement = ({
     <Rnd
       position={{ x: element.x, y: element.y }}
       size={{ width: element.width, height: element.height }}
-      dragGrid={[16, 16]}
-      resizeGrid={[16, 16]}
+      dragGrid={[50, 50]}
+      resizeGrid={[50, 50]}
       minWidth={100}
       minHeight={50}
       dragHandleClassName={styles.dragHandle}

--- a/src/dashboard/Data/CustomDashboard/CanvasElement.react.js
+++ b/src/dashboard/Data/CustomDashboard/CanvasElement.react.js
@@ -15,10 +15,24 @@ const CanvasElement = ({
   onSelect,
   onPositionChange,
   onSizeChange,
+  onDrag,
+  onResize,
   children,
 }) => {
+  const handleDrag = (e, d) => {
+    if (onDrag) {
+      onDrag(element.id, d.x, d.y, element.width, element.height);
+    }
+  };
+
   const handleDragStop = (e, d) => {
     onPositionChange(element.id, d.x, d.y);
+  };
+
+  const handleResize = (e, direction, ref, delta, position) => {
+    if (onResize) {
+      onResize(element.id, ref.offsetWidth, ref.offsetHeight, position.x, position.y);
+    }
   };
 
   const handleResizeStop = (e, direction, ref, delta, position) => {
@@ -44,9 +58,10 @@ const CanvasElement = ({
       resizeGrid={[16, 16]}
       minWidth={100}
       minHeight={50}
-      bounds="parent"
       dragHandleClassName={styles.dragHandle}
+      onDrag={handleDrag}
       onDragStop={handleDragStop}
+      onResize={handleResize}
       onResizeStop={handleResizeStop}
       className={`${styles.canvasElement} ${isSelected ? styles.selected : ''}`}
       enableResizing={{

--- a/src/dashboard/Data/CustomDashboard/CanvasElement.scss
+++ b/src/dashboard/Data/CustomDashboard/CanvasElement.scss
@@ -41,8 +41,4 @@
 
 .resizeHandle {
   background: transparent !important;
-
-  &:hover {
-    background: rgba(22, 156, 238, 0.3) !important;
-  }
 }

--- a/src/dashboard/Data/CustomDashboard/CustomDashboard.react.js
+++ b/src/dashboard/Data/CustomDashboard/CustomDashboard.react.js
@@ -675,7 +675,7 @@ class CustomDashboard extends DashboardView {
   // Returns dimensions only when content extends beyond the default CSS size
   getCanvasSize() {
     const { elements, dragPosition } = this.state;
-    const padding = 100; // Extra padding to allow easy placement at edges
+    const padding = 50; // Extra padding to allow easy placement at edges
 
     let maxRight = 0;
     let maxBottom = 0;

--- a/src/dashboard/Data/CustomDashboard/CustomDashboard.react.js
+++ b/src/dashboard/Data/CustomDashboard/CustomDashboard.react.js
@@ -625,10 +625,15 @@ class CustomDashboard extends DashboardView {
     }
   };
 
+  // Snap value to grid
+  snapToGrid(value, gridSize = 50) {
+    return Math.round(value / gridSize) * gridSize;
+  }
+
   handlePositionChange = (id, x, y) => {
-    // Ensure position is not negative
-    const safeX = Math.max(0, x);
-    const safeY = Math.max(0, y);
+    // Snap to grid and ensure position is not negative
+    const safeX = Math.max(0, this.snapToGrid(x));
+    const safeY = Math.max(0, this.snapToGrid(y));
     this.setState(state => ({
       elements: state.elements.map(el =>
         el.id === id ? { ...el, x: safeX, y: safeY } : el
@@ -637,12 +642,14 @@ class CustomDashboard extends DashboardView {
   };
 
   handleSizeChange = (id, width, height, x, y) => {
-    // Ensure position is not negative when resizing from left/top edges
-    const safeX = Math.max(0, x);
-    const safeY = Math.max(0, y);
+    // Snap to grid and ensure position is not negative when resizing from left/top edges
+    const safeX = Math.max(0, this.snapToGrid(x));
+    const safeY = Math.max(0, this.snapToGrid(y));
+    const snappedWidth = this.snapToGrid(width);
+    const snappedHeight = this.snapToGrid(height);
     this.setState(state => ({
       elements: state.elements.map(el =>
-        el.id === id ? { ...el, width, height, x: safeX, y: safeY } : el
+        el.id === id ? { ...el, width: snappedWidth, height: snappedHeight, x: safeX, y: safeY } : el
       ),
     }), this.markUnsavedChanges);
   };

--- a/src/dashboard/Data/CustomDashboard/CustomDashboard.react.js
+++ b/src/dashboard/Data/CustomDashboard/CustomDashboard.react.js
@@ -76,6 +76,8 @@ class CustomDashboard extends DashboardView {
       currentCanvasFavorite: false,
       hasUnsavedChanges: false,
       isFullscreen: false,
+      // Track dragging element position for canvas auto-extend
+      dragPosition: null,
     };
     this.autoReloadTimer = null;
     this.autoReloadProgressTimer = null;
@@ -83,6 +85,7 @@ class CustomDashboard extends DashboardView {
     this.canvasPreferencesManager = null;
     this._isMounted = false;
     this._elementSeq = {};
+    this.canvasRef = React.createRef();
   }
 
   componentDidMount() {
@@ -623,20 +626,94 @@ class CustomDashboard extends DashboardView {
   };
 
   handlePositionChange = (id, x, y) => {
+    // Ensure position is not negative
+    const safeX = Math.max(0, x);
+    const safeY = Math.max(0, y);
     this.setState(state => ({
       elements: state.elements.map(el =>
-        el.id === id ? { ...el, x, y } : el
+        el.id === id ? { ...el, x: safeX, y: safeY } : el
       ),
     }), this.markUnsavedChanges);
   };
 
   handleSizeChange = (id, width, height, x, y) => {
+    // Ensure position is not negative when resizing from left/top edges
+    const safeX = Math.max(0, x);
+    const safeY = Math.max(0, y);
     this.setState(state => ({
       elements: state.elements.map(el =>
-        el.id === id ? { ...el, width, height, x, y } : el
+        el.id === id ? { ...el, width, height, x: safeX, y: safeY } : el
       ),
     }), this.markUnsavedChanges);
   };
+
+  handleDrag = (id, x, y, width, height) => {
+    // Update drag position to trigger canvas auto-extend during drag
+    this.setState({
+      dragPosition: { id, x, y, width, height },
+    });
+  };
+
+  handleDragEnd = () => {
+    // Clear drag position when drag ends
+    this.setState({ dragPosition: null });
+  };
+
+  handleResize = (id, width, height, x, y) => {
+    // Update drag position to trigger canvas auto-extend during resize
+    this.setState({
+      dragPosition: { id, x, y, width, height },
+    });
+  };
+
+  handleResizeEnd = () => {
+    // Clear drag position when resize ends
+    this.setState({ dragPosition: null });
+  };
+
+  // Calculate the required canvas size based on all elements and current drag position
+  // Returns dimensions only when content extends beyond the default CSS size
+  getCanvasSize() {
+    const { elements, dragPosition } = this.state;
+    const padding = 100; // Extra padding to allow easy placement at edges
+
+    let maxRight = 0;
+    let maxBottom = 0;
+
+    // Calculate bounds from all elements
+    elements.forEach(el => {
+      const right = el.x + el.width;
+      const bottom = el.y + el.height;
+      if (right > maxRight) {
+        maxRight = right;
+      }
+      if (bottom > maxBottom) {
+        maxBottom = bottom;
+      }
+    });
+
+    // Include current drag position if dragging
+    if (dragPosition) {
+      const dragRight = dragPosition.x + dragPosition.width;
+      const dragBottom = dragPosition.y + dragPosition.height;
+      if (dragRight > maxRight) {
+        maxRight = dragRight;
+      }
+      if (dragBottom > maxBottom) {
+        maxBottom = dragBottom;
+      }
+    }
+
+    // Add padding to content bounds
+    const contentWidth = maxRight + padding;
+    const contentHeight = maxBottom + padding;
+
+    // Return the content-based dimensions (CSS handles minimum via width:100% and min-height)
+    return {
+      minWidth: contentWidth,
+      minHeight: contentHeight,
+    };
+  }
 
   handleDeleteElement = (id) => {
     this.setState(state => ({
@@ -1065,13 +1142,30 @@ class CustomDashboard extends DashboardView {
       wrapperClasses.push(styles.fullscreen);
     }
 
+    // Calculate dynamic canvas size based on element positions
+    const canvasSize = this.getCanvasSize();
+
     return (
       <div className={wrapperClasses.join(' ')}>
         <div
+          ref={this.canvasRef}
           className={styles.canvas}
           onClick={this.handleDeselectElement}
           tabIndex={0}
         >
+          {/* Invisible sizing element that expands the canvas when elements extend beyond */}
+          {(canvasSize.minWidth > 0 || canvasSize.minHeight > 0) && (
+            <div
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: canvasSize.minWidth,
+                height: canvasSize.minHeight,
+                pointerEvents: 'none',
+              }}
+            />
+          )}
           {elements.length === 0 && !isFullscreen ? (
             <EmptyState
               icon="canvas-outline"
@@ -1087,8 +1181,16 @@ class CustomDashboard extends DashboardView {
                 element={element}
                 isSelected={element.id === selectedElement}
                 onSelect={this.handleSelectElement}
-                onPositionChange={this.handlePositionChange}
-                onSizeChange={this.handleSizeChange}
+                onPositionChange={(id, x, y) => {
+                  this.handleDragEnd();
+                  this.handlePositionChange(id, x, y);
+                }}
+                onSizeChange={(id, width, height, x, y) => {
+                  this.handleResizeEnd();
+                  this.handleSizeChange(id, width, height, x, y);
+                }}
+                onDrag={this.handleDrag}
+                onResize={this.handleResize}
               >
                 {this.renderElementContent(element)}
               </CanvasElement>

--- a/src/dashboard/Data/CustomDashboard/CustomDashboard.scss
+++ b/src/dashboard/Data/CustomDashboard/CustomDashboard.scss
@@ -11,7 +11,7 @@
   position: relative;
   width: 100%;
   min-height: calc(100vh - 96px);
-  background-color: #f4f5f7;
+  background-color: #ffffff;
   overflow: auto;
   outline: none;
 }


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-dashboard/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-dashboard/blob/alpha/LICENSE).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time drag and resize callbacks for canvas elements (external handlers can react during interactions).
  * Dynamic canvas sizing that expands based on element positions.

* **Behavior Changes**
  * Increased grid/snap spacing for coarser movement and relaxed bounds for freer dragging.
  * Grid-snapping and position clamping to prevent negative coordinates; existing save/update flows preserved.

* **Style**
  * Canvas background changed to white; resize handle hover no longer shows a colored background.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->