### PR TITLE
feat: Add keyboard shortcut for executing script on selected rows in data browser

### DIFF
--- a/src/dashboard/Data/Browser/BrowserToolbar.react.js
+++ b/src/dashboard/Data/Browser/BrowserToolbar.react.js
@@ -104,6 +104,7 @@ const BrowserToolbar = ({
   stopAutoScroll,
   toggleGraphPanel,
   isGraphPanelVisible,
+  runScriptShortcut,
 }) => {
   const selectionLength = Object.keys(selection).length;
   const isPendingEditCloneRows = editCloneRows && editCloneRows.length > 0;
@@ -623,6 +624,7 @@ const BrowserToolbar = ({
               : `Run script on ${selectionLength} selected rows...`
           }
           onClick={() => onExecuteScriptRows(selection)}
+          shortcut={runScriptShortcut}
         />
       </BrowserMenu>
       <div className={styles.toolbarSeparator} />

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -808,6 +808,19 @@ export default class DataBrowser extends React.Component {
       return;
     }
 
+    // Handle "Run script on selected rows" shortcut before input element check
+    // This allows the shortcut to work even when a checkbox is focused
+    const shortcuts = this.state.keyboardShortcuts;
+    if (shortcuts && matchesShortcut(e, shortcuts.dataBrowserRunScriptOnSelectedRows)) {
+      const selection = this.props.selection || {};
+      const selectionLength = Object.keys(selection).length;
+      if (selectionLength > 0 && this.props.onExecuteScriptRows) {
+        this.props.onExecuteScriptRows(selection);
+        e.preventDefault();
+        return;
+      }
+    }
+
     // Check if the event target is an input, textarea, or select element
     const target = e.target;
     const isInputElement = target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.tagName === 'SELECT');
@@ -898,19 +911,6 @@ export default class DataBrowser extends React.Component {
       if (e.keyCode === 27) {
         this.props.onAbortAddRow();
         e.preventDefault();
-      }
-    }
-
-    // Handle "Run script on selected rows" shortcut early, before cell selection check
-    // This allows the shortcut to work when rows are selected via checkbox without a cell being focused
-    const shortcuts = this.state.keyboardShortcuts;
-    if (shortcuts && matchesShortcut(e, shortcuts.dataBrowserRunScriptOnSelectedRows)) {
-      const selection = this.props.selection || {};
-      const selectionLength = Object.keys(selection).length;
-      if (selectionLength > 0 && this.props.onExecuteScriptRows) {
-        this.props.onExecuteScriptRows(selection);
-        e.preventDefault();
-        return;
       }
     }
 

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -2849,6 +2849,7 @@ export default class DataBrowser extends React.Component {
           stopAutoScroll={this.stopAutoScroll}
           toggleGraphPanel={this.toggleGraphPanelVisibility}
           isGraphPanelVisible={this.state.isGraphPanelVisible}
+          runScriptShortcut={this.state.keyboardShortcuts?.dataBrowserRunScriptOnSelectedRows?.key?.toUpperCase()}
           {...other}
           onRefresh={this.handleRefresh}
         />

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -900,6 +900,20 @@ export default class DataBrowser extends React.Component {
         e.preventDefault();
       }
     }
+
+    // Handle "Run script on selected rows" shortcut early, before cell selection check
+    // This allows the shortcut to work when rows are selected via checkbox without a cell being focused
+    const shortcuts = this.state.keyboardShortcuts;
+    if (shortcuts && matchesShortcut(e, shortcuts.dataBrowserRunScriptOnSelectedRows)) {
+      const selection = this.props.selection || {};
+      const selectionLength = Object.keys(selection).length;
+      if (selectionLength > 0 && this.props.onExecuteScriptRows) {
+        this.props.onExecuteScriptRows(selection);
+        e.preventDefault();
+        return;
+      }
+    }
+
     if (this.state.editing) {
       switch (e.keyCode) {
         case 27: // ESC

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -808,27 +808,38 @@ export default class DataBrowser extends React.Component {
       return;
     }
 
-    // Handle "Run script on selected rows" shortcut before input element check
-    // This allows the shortcut to work even when a checkbox is focused
+    // Ignore keyboard events when a modal is open
+    // Modals handle their own keyboard navigation and should not affect the data browser
+    if (document.querySelector('[data-modal="true"]')) {
+      return;
+    }
+
+    // Check if the event target is an input, textarea, or select element
+    // Allow checkboxes since they don't accept text input
+    const target = e.target;
+    const isTextInputElement = target && (
+      target.tagName === 'TEXTAREA' ||
+      target.tagName === 'SELECT' ||
+      (target.tagName === 'INPUT' && target.type !== 'checkbox')
+    );
+
+    // Ignore most keyboard events when focus is on text input elements
+    // This allows normal text editing behavior in filter inputs and dropdown navigation
+    if (isTextInputElement) {
+      return;
+    }
+
+    // Handle "Run script on selected rows" shortcut
+    // Only works when in editable mode (onEditSelectedRow exists) and rows are selected
     const shortcuts = this.state.keyboardShortcuts;
     if (shortcuts && matchesShortcut(e, shortcuts.dataBrowserRunScriptOnSelectedRows)) {
       const selection = this.props.selection || {};
       const selectionLength = Object.keys(selection).length;
-      if (selectionLength > 0 && this.props.onExecuteScriptRows) {
+      if (selectionLength > 0 && this.props.onExecuteScriptRows && this.props.onEditSelectedRow) {
         this.props.onExecuteScriptRows(selection);
         e.preventDefault();
         return;
       }
-    }
-
-    // Check if the event target is an input, textarea, or select element
-    const target = e.target;
-    const isInputElement = target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.tagName === 'SELECT');
-
-    // Ignore all keyboard events when focus is on input/textarea/select elements
-    // This allows normal text editing behavior in filter inputs and dropdown navigation
-    if (isInputElement) {
-      return;
     }
 
     // Escape key stops auto-scrolling

--- a/src/dashboard/Settings/KeyboardShortcutsSettings.react.js
+++ b/src/dashboard/Settings/KeyboardShortcutsSettings.react.js
@@ -26,6 +26,7 @@ export default class KeyboardShortcutsSettings extends DashboardView {
     this.state = {
       dataBrowserReloadData: '',
       dataBrowserToggleInfoPanels: '',
+      dataBrowserRunScriptOnSelectedRows: '',
       hasChanges: false,
       message: undefined,
       loading: true,
@@ -55,6 +56,7 @@ export default class KeyboardShortcutsSettings extends DashboardView {
       this.setState({
         dataBrowserReloadData: shortcuts.dataBrowserReloadData?.key || '',
         dataBrowserToggleInfoPanels: shortcuts.dataBrowserToggleInfoPanels?.key || '',
+        dataBrowserRunScriptOnSelectedRows: shortcuts.dataBrowserRunScriptOnSelectedRows?.key || '',
         hasChanges: false,
         loading: false,
       });
@@ -88,6 +90,7 @@ export default class KeyboardShortcutsSettings extends DashboardView {
     const shortcuts = {
       dataBrowserReloadData: this.state.dataBrowserReloadData ? createShortcut(this.state.dataBrowserReloadData) : null,
       dataBrowserToggleInfoPanels: this.state.dataBrowserToggleInfoPanels ? createShortcut(this.state.dataBrowserToggleInfoPanels) : null,
+      dataBrowserRunScriptOnSelectedRows: this.state.dataBrowserRunScriptOnSelectedRows ? createShortcut(this.state.dataBrowserRunScriptOnSelectedRows) : null,
     };
 
     // Validate shortcuts (only if they are set)
@@ -101,7 +104,12 @@ export default class KeyboardShortcutsSettings extends DashboardView {
       return;
     }
 
-    // Check for duplicates (only if both are set)
+    if (shortcuts.dataBrowserRunScriptOnSelectedRows && !isValidShortcut(shortcuts.dataBrowserRunScriptOnSelectedRows)) {
+      this.showNote('Invalid key for "Run Script on Selected Rows". Please enter a valid key.', true);
+      return;
+    }
+
+    // Check for duplicates among shortcuts without meta modifier (only if set)
     if (shortcuts.dataBrowserReloadData && shortcuts.dataBrowserToggleInfoPanels &&
         shortcuts.dataBrowserReloadData.key.toLowerCase() === shortcuts.dataBrowserToggleInfoPanels.key.toLowerCase()) {
       this.showNote('Keyboard shortcuts must be unique. Please use different keys.', true);
@@ -199,6 +207,25 @@ export default class KeyboardShortcutsSettings extends DashboardView {
                   value={this.state.dataBrowserToggleInfoPanels}
                   disabled={this.state.loading}
                   onChange={this.handleFieldChange.bind(this, 'dataBrowserToggleInfoPanels')}
+                  onFocus={this.handleInputFocus.bind(this)}
+                  maxLength={1}
+                />
+              }
+            />
+            <Field
+              labelWidth={62}
+              label={
+                <Label
+                  text="Run Script on Selected Rows"
+                  description={'Opens the script dialog for selected rows.'}
+                />
+              }
+              input={
+                <TextInput
+                  placeholder={this.state.loading ? 'Loading...' : DEFAULT_SHORTCUTS.dataBrowserRunScriptOnSelectedRows.key}
+                  value={this.state.dataBrowserRunScriptOnSelectedRows}
+                  disabled={this.state.loading}
+                  onChange={this.handleFieldChange.bind(this, 'dataBrowserRunScriptOnSelectedRows')}
                   onFocus={this.handleInputFocus.bind(this)}
                   maxLength={1}
                 />

--- a/src/lib/KeyboardShortcutsPreferences.js
+++ b/src/lib/KeyboardShortcutsPreferences.js
@@ -12,8 +12,9 @@ import ServerConfigStorage from './ServerConfigStorage';
  * Default keyboard shortcuts
  */
 export const DEFAULT_SHORTCUTS = {
-  dataBrowserReloadData: { key: 'r', ctrl: false, shift: false, alt: false },
-  dataBrowserToggleInfoPanels: { key: 'p', ctrl: false, shift: false, alt: false },
+  dataBrowserReloadData: { key: 'r', ctrl: false, shift: false, alt: false, meta: false },
+  dataBrowserToggleInfoPanels: { key: 'p', ctrl: false, shift: false, alt: false, meta: false },
+  dataBrowserRunScriptOnSelectedRows: { key: 's', ctrl: false, shift: false, alt: false, meta: false },
 };
 
 /**
@@ -142,7 +143,6 @@ export function isValidShortcut(shortcut) {
   }
 
   // Modifier keys are optional booleans
-  // Note: Meta/Cmd key support could be added in the future
   if (shortcut.ctrl !== undefined && typeof shortcut.ctrl !== 'boolean') {
     return false;
   }
@@ -152,6 +152,9 @@ export function isValidShortcut(shortcut) {
   if (shortcut.alt !== undefined && typeof shortcut.alt !== 'boolean') {
     return false;
   }
+  if (shortcut.meta !== undefined && typeof shortcut.meta !== 'boolean') {
+    return false;
+  }
 
   return true;
 }
@@ -159,13 +162,14 @@ export function isValidShortcut(shortcut) {
 /**
  * Creates a shortcut object from a key string
  * @param {string} key - The key character
+ * @param {boolean} meta - Whether to include meta/cmd modifier
  * @returns {Object} Shortcut object
  */
-export function createShortcut(key) {
+export function createShortcut(key, meta = false) {
   if (!key || key.length !== 1) {
     return null;
   }
-  return { key, ctrl: false, shift: false, alt: false };
+  return { key, ctrl: false, shift: false, alt: false, meta };
 }
 
 /**
@@ -185,6 +189,7 @@ export function matchesShortcut(event, shortcut) {
   const ctrlMatches = !!event.ctrlKey === !!shortcut.ctrl;
   const shiftMatches = !!event.shiftKey === !!shortcut.shift;
   const altMatches = !!event.altKey === !!shortcut.alt;
+  const metaMatches = !!event.metaKey === !!shortcut.meta;
 
-  return keyMatches && ctrlMatches && shiftMatches && altMatches;
+  return keyMatches && ctrlMatches && shiftMatches && altMatches && metaMatches;
 }


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-dashboard/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-dashboard/blob/alpha/LICENSE).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable keyboard shortcut to run scripts on selected rows in the Data Browser.
  * Keyboard shortcut support extended to include the meta (Command/Windows) modifier.
  * Settings UI updated to let users view and customize the Run Script on Selected Rows shortcut.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->