### PR TITLE
feat: Allow to use ESC key to cancel, Cmd + Enter key to submit, Tab key to navigate a modal dialog

### DIFF
--- a/src/components/Dropdown/Dropdown.react.js
+++ b/src/components/Dropdown/Dropdown.react.js
@@ -19,56 +19,140 @@ export default class Dropdown extends React.Component {
     this.state = {
       open: false,
       position: null,
+      highlightedIndex: -1,
     };
 
     this.dropdownRef = React.createRef();
     this.menuRef = React.createRef();
+    this.triggerRef = React.createRef();
+    this.handleKeyDown = this.handleKeyDown.bind(this);
+  }
+
+  getOptions() {
+    const options = [];
+    React.Children.forEach(this.props.children, c => {
+      if (c) {
+        options.push(c.props.value);
+      }
+    });
+    return options;
   }
 
   componentDidUpdate(prevProps, prevState) {
-    // When dropdown opens, scroll to the selected item
-    if (this.state.open && !prevState.open && this.menuRef.current) {
-      const menu = this.menuRef.current;
-      const selectedButton = menu.querySelector('button[data-selected="true"]');
-      if (selectedButton) {
-        // Scroll so the selected item is at the top of the visible list
-        menu.scrollTop = selectedButton.offsetTop;
+    // When dropdown opens, scroll to the selected item and set highlight
+    if (this.state.open && !prevState.open) {
+      const options = this.getOptions();
+      const selectedIndex = options.indexOf(this.props.value);
+      this.setState({ highlightedIndex: selectedIndex >= 0 ? selectedIndex : 0 });
+
+      if (this.menuRef.current) {
+        const menu = this.menuRef.current;
+        const selectedButton = menu.querySelector('button[data-selected="true"]');
+        if (selectedButton) {
+          menu.scrollTop = selectedButton.offsetTop;
+        }
+      }
+    }
+
+    // Scroll highlighted item into view
+    if (this.state.open && this.state.highlightedIndex !== prevState.highlightedIndex && this.menuRef.current) {
+      const buttons = this.menuRef.current.querySelectorAll('button');
+      const highlightedButton = buttons[this.state.highlightedIndex];
+      if (highlightedButton) {
+        highlightedButton.scrollIntoView({ block: 'nearest' });
       }
     }
   }
 
-  toggle() {
-    this.setState(() => {
-      if (this.state.open) {
-        return { open: false };
+  handleKeyDown(e) {
+    const options = this.getOptions();
+
+    // Don't handle Enter with Command key - let it bubble up for modal submit
+    const isEnterWithMeta = e.key === 'Enter' && e.metaKey;
+
+    if (!this.state.open) {
+      // Dropdown is closed
+      if (e.key === 'ArrowDown' || e.key === 'ArrowUp' || ((e.key === 'Enter' || e.key === ' ') && !isEnterWithMeta)) {
+        e.preventDefault();
+        e.stopPropagation(); // Prevent event from reaching other handlers
+        this.open();
       }
-      let pos = Position.inDocument(this.dropdownRef.current);
-      if (this.props.fixed) {
-        pos = Position.inWindow(this.dropdownRef.current);
+    } else {
+      // Dropdown is open
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        e.stopPropagation(); // Prevent event from reaching other handlers
+        this.setState(state => ({
+          highlightedIndex: Math.min(state.highlightedIndex + 1, options.length - 1)
+        }));
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        e.stopPropagation(); // Prevent event from reaching other handlers
+        this.setState(state => ({
+          highlightedIndex: Math.max(state.highlightedIndex - 1, 0)
+        }));
+      } else if ((e.key === 'Enter' || e.key === ' ') && !isEnterWithMeta) {
+        e.preventDefault();
+        e.stopPropagation(); // Prevent event from reaching other handlers
+        if (this.state.highlightedIndex >= 0 && this.state.highlightedIndex < options.length) {
+          this.select(options[this.state.highlightedIndex]);
+        }
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        e.stopPropagation(); // Prevent modal from closing
+        this.close();
+        // Return focus to trigger
+        if (this.triggerRef.current) {
+          this.triggerRef.current.focus();
+        }
       }
-      return {
-        open: true,
-        position: pos,
-      };
+    }
+  }
+
+  open() {
+    if (this.state.open || this.props.disabled) {
+      return;
+    }
+    let pos = Position.inDocument(this.dropdownRef.current);
+    if (this.props.fixed) {
+      pos = Position.inWindow(this.dropdownRef.current);
+    }
+    this.setState({
+      open: true,
+      position: pos,
     });
+  }
+
+  toggle() {
+    if (this.state.open) {
+      this.close();
+    } else {
+      this.open();
+    }
   }
 
   close() {
     this.setState({
       open: false,
+      highlightedIndex: -1,
     });
   }
 
   select(value) {
     if (value === this.props.value) {
-      return this.setState({ open: false });
+      return this.setState({ open: false, highlightedIndex: -1 });
     }
     this.setState(
       {
         open: false,
+        highlightedIndex: -1,
       },
       () => {
         this.props.onChange(value);
+        // Return focus to trigger after selection
+        if (this.triggerRef.current) {
+          this.triggerRef.current.focus();
+        }
       }
     );
   }
@@ -77,18 +161,32 @@ export default class Dropdown extends React.Component {
     let popover = null;
     if (this.state.open && !this.props.disabled) {
       const width = this.dropdownRef.current.clientWidth;
+      let optionIndex = 0;
       const popoverChildren = (
         <SliderWrap direction={Directions.DOWN} expanded={true}>
-          <div style={{ width }} className={styles.menu} ref={this.menuRef}>
-            {React.Children.map(this.props.children, c => c && (
-              <button
-                type="button"
-                onClick={this.select.bind(this, c.props.value)}
-                data-selected={c.props.value === this.props.value ? 'true' : undefined}
-              >
-                {c}
-              </button>
-            ))}
+          <div style={{ width }} className={styles.menu} ref={this.menuRef} role="listbox">
+            {React.Children.map(this.props.children, c => {
+              if (!c) {
+                return null;
+              }
+              const index = optionIndex++;
+              const isHighlighted = index === this.state.highlightedIndex;
+              const isSelected = c.props.value === this.props.value;
+              return (
+                <button
+                  type="button"
+                  onClick={this.select.bind(this, c.props.value)}
+                  onMouseEnter={() => this.setState({ highlightedIndex: index })}
+                  data-selected={isSelected ? 'true' : undefined}
+                  data-highlighted={isHighlighted ? 'true' : undefined}
+                  role="option"
+                  aria-selected={isSelected}
+                  style={isHighlighted ? { backgroundColor: 'rgba(0, 0, 0, 0.1)' } : undefined}
+                >
+                  {c}
+                </button>
+              );
+            })}
           </div>
         </SliderWrap>
       );
@@ -125,8 +223,14 @@ export default class Dropdown extends React.Component {
     return (
       <div style={dropdownStyle} className={dropdownClasses.join(' ')} ref={this.dropdownRef}>
         <div
+          ref={this.triggerRef}
           className={[styles.current, this.props.hideArrow ? styles.hideArrow : ''].join(' ')}
           onClick={this.toggle.bind(this)}
+          onKeyDown={this.handleKeyDown}
+          tabIndex={this.props.disabled ? -1 : 0}
+          role="combobox"
+          aria-expanded={this.state.open}
+          aria-haspopup="listbox"
         >
           {content}
         </div>

--- a/src/components/Modal/Modal.react.js
+++ b/src/components/Modal/Modal.react.js
@@ -44,6 +44,107 @@ const Modal = ({
   showContinue,
   buttonsInCenter = React.Children.count(children) === 0,
 }) => {
+  const modalRef = React.useRef(null);
+
+  // Focus trap and keyboard handling
+  React.useEffect(() => {
+    const modal = modalRef.current;
+    if (!modal) {
+      return;
+    }
+
+    // Selector for all focusable elements (excluding buttons - they're handled via Enter key)
+    const focusableSelector = [
+      'input:not([disabled])',
+      'select:not([disabled])',
+      'textarea:not([disabled])',
+      'a[href]',
+      '[tabindex]:not([tabindex="-1"])',
+    ].join(', ');
+
+    const getFocusableElements = () => {
+      return Array.from(modal.querySelectorAll(focusableSelector)).filter(el => {
+        // Filter out elements that are hidden or not visible
+        // offsetParent is null for hidden elements (display:none or in hidden ancestors)
+        // Also check for zero dimensions (collapsed elements)
+        if (el.offsetParent === null && el.tagName !== 'BODY') {
+          return false;
+        }
+        const rect = el.getBoundingClientRect();
+        if (rect.width === 0 || rect.height === 0) {
+          return false;
+        }
+        return true;
+      });
+    };
+
+    // Focus the first focusable element when modal opens
+    const focusableElements = getFocusableElements();
+    if (focusableElements.length > 0) {
+      focusableElements[0].focus();
+    }
+
+    const handleKeyDown = (e) => {
+      // Handle Escape to close modal
+      if (e.key === 'Escape') {
+        e.stopImmediatePropagation();
+        if (canCancel && onCancel && !progress) {
+          e.preventDefault();
+          onCancel();
+        }
+        return;
+      }
+
+      // Handle Tab for focus trapping
+      if (e.key === 'Tab') {
+        e.stopImmediatePropagation();
+        const focusable = getFocusableElements();
+        if (focusable.length === 0) {
+          return;
+        }
+
+        const firstElement = focusable[0];
+        const lastElement = focusable[focusable.length - 1];
+
+        if (e.shiftKey) {
+          // Shift+Tab: if on first element, wrap to last
+          if (document.activeElement === firstElement) {
+            e.preventDefault();
+            lastElement.focus();
+          }
+        } else {
+          // Tab: if on last element, wrap to first
+          if (document.activeElement === lastElement) {
+            e.preventDefault();
+            firstElement.focus();
+          }
+        }
+        return;
+      }
+
+      // Other keys (like arrow keys) are allowed to propagate normally
+      // The DataBrowser checks for open modals and ignores keyboard events when one is present
+    };
+
+    // Handle Command+Enter to trigger primary button (runs in bubble phase after component handlers)
+    const handleEnterKey = (e) => {
+      if (e.key === 'Enter' && e.metaKey && !e.defaultPrevented && !disabled && !progress && onConfirm) {
+        e.preventDefault();
+        onConfirm();
+      }
+    };
+
+    // Use capture phase on window for Escape and Tab (need to intercept early)
+    window.addEventListener('keydown', handleKeyDown, true);
+    // Use bubble phase on document for Enter (need to run after component handlers)
+    document.addEventListener('keydown', handleEnterKey);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown, true);
+      document.removeEventListener('keydown', handleEnterKey);
+    };
+  }, [canCancel, onCancel, progress, disabled, onConfirm]);
+
   if (children) {
     children = React.Children.map(children, c => {
       if (c && c.type === Field && c.props.label) {
@@ -81,7 +182,7 @@ const Modal = ({
 
   return (
     <Popover fadeIn={true} fixed={true} position={origin} modal={true} color="rgba(17,13,17,0.8)">
-      <div className={[styles.modal, styles[type]].join(' ')} style={{ width }}>
+      <div ref={modalRef} className={[styles.modal, styles[type]].join(' ')} style={{ width }}>
         <div className={styles.header}>
           <div
             style={{

--- a/src/components/Popover/Popover.react.js
+++ b/src/components/Popover/Popover.react.js
@@ -45,6 +45,7 @@ export default class Popover extends React.Component {
     if (this.props.modal) {
       this._popoverLayer.style.right = 0;
       this._popoverLayer.style.bottom = 0;
+      this._popoverLayer.dataset.modal = 'true';
     }
     if (this.props.color) {
       this._popoverLayer.style.background = this.props.color;

--- a/src/components/SliderWrap/SliderWrap.react.js
+++ b/src/components/SliderWrap/SliderWrap.react.js
@@ -59,11 +59,12 @@ export default class SliderWrap extends React.Component {
       style.margin = '0 0 0 auto';
     }
     return (
-      <div className={styles.slider} style={style}>
+      <div className={styles.slider} style={style} tabIndex={-1}>
         <div
           className={styles.metrics}
           style={this.props.block ? { display: 'block' } : {}}
           ref={this.metricsRef}
+          tabIndex={-1}
         >
           {this.props.children}
         </div>

--- a/src/dashboard/DashboardView.react.js
+++ b/src/dashboard/DashboardView.react.js
@@ -227,12 +227,12 @@ export default class DashboardView extends React.Component {
         link: '/settings/dashboard',
       },
       {
-        name: 'Keyboard Shortcuts',
-        link: '/settings/keyboard-shortcuts',
-      },
-      {
         name: 'Cloud Config',
         link: '/settings/cloud-config',
+      },
+      {
+        name: 'Keyboard Shortcuts',
+        link: '/settings/keyboard-shortcuts',
       },
     ];
 


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-dashboard/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-dashboard/blob/alpha/LICENSE).

## Feature

Allow to use ESC key to cancel, Cmd + Enter key to submit, Tab key to navigate a modal dialog. Footer buttons are deliberately excluded from Tab navigation and are not focusable, to prevent accidentally trigger them; instead they can be triggered via ESC key (cancel button) or Cmd+Enter (primary button).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added keyboard navigation to dropdowns (arrow keys to navigate, enter/space to select, escape to close)
  * Enhanced modal interactions with focus trapping and keyboard shortcuts (escape to close, tab to cycle focus, enter to confirm)

* **Improvements**
  * Improved accessibility across components with better focus management and keyboard support
  * Reorganized settings menu for improved navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->