### PR TITLE
fix: Setting a keyboard shortcut to its default value creates an unnecessary dashboard config storage entry

### DIFF
--- a/src/lib/KeyboardShortcutsPreferences.js
+++ b/src/lib/KeyboardShortcutsPreferences.js
@@ -89,11 +89,27 @@ export default class KeyboardShortcutsManager {
     }
 
     try {
-      // Save each shortcut as a separate config entry
+      // Save or delete each shortcut depending on whether it matches the default
       const promises = [];
       for (const [shortcutName, value] of Object.entries(shortcuts)) {
         const key = `settings.keyboard.binding.${shortcutName}`;
-        promises.push(this.serverStorage.setConfig(key, value, appId));
+        const defaultValue = DEFAULT_SHORTCUTS[shortcutName];
+
+        // Check if the value matches the default (compare key and modifiers)
+        const isDefault = defaultValue && value &&
+          value.key?.toLowerCase() === defaultValue.key?.toLowerCase() &&
+          !!value.ctrl === !!defaultValue.ctrl &&
+          !!value.shift === !!defaultValue.shift &&
+          !!value.alt === !!defaultValue.alt &&
+          !!value.meta === !!defaultValue.meta;
+
+        if (isDefault) {
+          // Delete the entry if it matches the default (no need to store it)
+          promises.push(this.serverStorage.deleteConfig(key, appId));
+        } else {
+          // Save the entry if it differs from the default
+          promises.push(this.serverStorage.setConfig(key, value, appId));
+        }
       }
 
       await Promise.all(promises);
@@ -104,12 +120,27 @@ export default class KeyboardShortcutsManager {
   }
 
   /**
-   * Resets keyboard shortcuts to defaults
+   * Resets keyboard shortcuts to defaults by deleting stored entries
    * @param {string} appId - The application ID
    * @returns {Promise}
    */
   async resetKeyboardShortcuts(appId) {
-    return this.saveKeyboardShortcuts(appId, DEFAULT_SHORTCUTS);
+    if (!this.serverStorage.isServerConfigEnabled()) {
+      return; // Nothing to delete if server config is not enabled
+    }
+
+    try {
+      // Delete all keyboard shortcut entries so defaults will be used
+      const promises = [];
+      for (const shortcutName of Object.keys(DEFAULT_SHORTCUTS)) {
+        const key = `settings.keyboard.binding.${shortcutName}`;
+        promises.push(this.serverStorage.deleteConfig(key, appId));
+      }
+      await Promise.all(promises);
+    } catch (error) {
+      console.error('Failed to reset keyboard shortcuts:', error);
+      throw error;
+    }
   }
 
   /**


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-dashboard/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-dashboard/blob/alpha/LICENSE).

## Issue

Setting a keyboard shortcut to its default value creates an unnecessary dashboard config storage entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard shortcuts reset functionality with safer validation checks.
  * Enhanced error handling and logging for keyboard shortcuts operations.

* **Improvements**
  * Optimized keyboard shortcuts storage to only save custom configurations, reducing unnecessary data storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->