### PR TITLE
feat: Add syntax highlighting, formatting, auto-indentation for Cloud Config parameter values of type Object and Array

### DIFF
--- a/src/components/JsonEditor/JsonEditor.react.js
+++ b/src/components/JsonEditor/JsonEditor.react.js
@@ -112,6 +112,36 @@ export default class JsonEditor extends React.Component {
     }
   }
 
+  getSyntaxColorStyles() {
+    const { syntaxColors } = this.props;
+    if (!syntaxColors) {
+      return null;
+    }
+
+    // Generate CSS custom properties for syntax colors
+    const colorVars = Object.entries(syntaxColors)
+      .filter(([, color]) => color)
+      .map(([token, color]) => `--syntax-${token}: ${color};`)
+      .join(' ');
+
+    if (!colorVars) {
+      return null;
+    }
+
+    // Return a style tag with scoped CSS overrides
+    return (
+      <style>{`
+        .${styles.highlightLayer} .token.property { color: ${syntaxColors.property || '#005cc5'} !important; }
+        .${styles.highlightLayer} .token.string { color: ${syntaxColors.string || '#000000'} !important; }
+        .${styles.highlightLayer} .token.number { color: ${syntaxColors.number || '#098658'} !important; }
+        .${styles.highlightLayer} .token.boolean { color: ${syntaxColors.boolean || '#d73a49'} !important; }
+        .${styles.highlightLayer} .token.null { color: ${syntaxColors.null || '#d73a49'} !important; }
+        .${styles.highlightLayer} .token.punctuation { color: ${syntaxColors.punctuation || '#24292e'} !important; }
+        .${styles.highlightLayer} .token.operator { color: ${syntaxColors.operator || '#24292e'} !important; }
+      `}</style>
+    );
+  }
+
   render() {
     const { value, placeholder, wordWrap = false } = this.props;
 
@@ -121,6 +151,7 @@ export default class JsonEditor extends React.Component {
 
     return (
       <div className={styles.container}>
+        {this.getSyntaxColorStyles()}
         <pre
           ref={this.preRef}
           className={styles.highlightLayer}

--- a/src/components/JsonEditor/JsonEditor.react.js
+++ b/src/components/JsonEditor/JsonEditor.react.js
@@ -118,26 +118,50 @@ export default class JsonEditor extends React.Component {
       return null;
     }
 
-    // Generate CSS custom properties for syntax colors
-    const colorVars = Object.entries(syntaxColors)
-      .filter(([, color]) => color)
-      .map(([token, color]) => `--syntax-${token}: ${color};`)
-      .join(' ');
+    // Safe default colors for each token type
+    const defaults = {
+      property: '#005cc5',
+      string: '#000000',
+      number: '#098658',
+      boolean: '#d73a49',
+      null: '#d73a49',
+      punctuation: '#24292e',
+      operator: '#24292e',
+    };
 
-    if (!colorVars) {
+    // Validate hex color: only accept #RGB or #RRGGBB (case-insensitive)
+    const isValidHexColor = (color) => {
+      if (typeof color !== 'string') {
+        return false;
+      }
+      return /^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/.test(color);
+    };
+
+    // Get sanitized color for a token, falling back to default if invalid
+    const getSafeColor = (token) => {
+      const color = syntaxColors[token];
+      return isValidHexColor(color) ? color : defaults[token];
+    };
+
+    // Check if any custom colors are provided and valid
+    const hasCustomColors = Object.keys(defaults).some(
+      token => syntaxColors[token] && isValidHexColor(syntaxColors[token])
+    );
+
+    if (!hasCustomColors) {
       return null;
     }
 
-    // Return a style tag with scoped CSS overrides
+    // Return a style tag with sanitized CSS overrides
     return (
       <style>{`
-        .${styles.highlightLayer} .token.property { color: ${syntaxColors.property || '#005cc5'} !important; }
-        .${styles.highlightLayer} .token.string { color: ${syntaxColors.string || '#000000'} !important; }
-        .${styles.highlightLayer} .token.number { color: ${syntaxColors.number || '#098658'} !important; }
-        .${styles.highlightLayer} .token.boolean { color: ${syntaxColors.boolean || '#d73a49'} !important; }
-        .${styles.highlightLayer} .token.null { color: ${syntaxColors.null || '#d73a49'} !important; }
-        .${styles.highlightLayer} .token.punctuation { color: ${syntaxColors.punctuation || '#24292e'} !important; }
-        .${styles.highlightLayer} .token.operator { color: ${syntaxColors.operator || '#24292e'} !important; }
+        .${styles.highlightLayer} .token.property { color: ${getSafeColor('property')} !important; }
+        .${styles.highlightLayer} .token.string { color: ${getSafeColor('string')} !important; }
+        .${styles.highlightLayer} .token.number { color: ${getSafeColor('number')} !important; }
+        .${styles.highlightLayer} .token.boolean { color: ${getSafeColor('boolean')} !important; }
+        .${styles.highlightLayer} .token.null { color: ${getSafeColor('null')} !important; }
+        .${styles.highlightLayer} .token.punctuation { color: ${getSafeColor('punctuation')} !important; }
+        .${styles.highlightLayer} .token.operator { color: ${getSafeColor('operator')} !important; }
       `}</style>
     );
   }

--- a/src/components/JsonEditor/JsonEditor.react.js
+++ b/src/components/JsonEditor/JsonEditor.react.js
@@ -21,14 +21,31 @@ export default class JsonEditor extends React.Component {
     super(props);
     this.textareaRef = React.createRef();
     this.preRef = React.createRef();
+    this.pendingCursorPosition = null;
   }
 
   componentDidMount() {
     this.syncScroll();
+    // Use native event listener for keydown to handle Enter auto-indent
+    if (this.textareaRef.current) {
+      this.textareaRef.current.addEventListener('keydown', this.handleKeyDown);
+    }
   }
 
   componentDidUpdate() {
     this.syncScroll();
+    // Restore cursor position after key insertion
+    if (this.pendingCursorPosition !== null && this.textareaRef.current) {
+      this.textareaRef.current.selectionStart = this.pendingCursorPosition;
+      this.textareaRef.current.selectionEnd = this.pendingCursorPosition;
+      this.pendingCursorPosition = null;
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.textareaRef.current) {
+      this.textareaRef.current.removeEventListener('keydown', this.handleKeyDown);
+    }
   }
 
   syncScroll = () => {
@@ -49,6 +66,32 @@ export default class JsonEditor extends React.Component {
     const { onChange } = this.props;
     if (onChange) {
       onChange(e.target.value);
+    }
+  };
+
+  handleKeyDown = (e) => {
+    // Enter key - auto-indent to match current line
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      e.stopPropagation();
+
+      const textarea = this.textareaRef.current;
+      const start = textarea.selectionStart;
+      const end = textarea.selectionEnd;
+      const value = this.props.value || '';
+
+      // Find the start of the current line
+      const lineStart = value.lastIndexOf('\n', start - 1) + 1;
+      const line = value.substring(lineStart, start);
+      // Get leading whitespace from current line
+      const indent = line.match(/^[\t ]*/)[0];
+
+      const newValue = value.substring(0, start) + '\n' + indent + value.substring(end);
+      this.pendingCursorPosition = start + 1 + indent.length;
+
+      if (this.props.onChange) {
+        this.props.onChange(newValue);
+      }
     }
   };
 

--- a/src/components/JsonEditor/JsonEditor.react.js
+++ b/src/components/JsonEditor/JsonEditor.react.js
@@ -115,7 +115,7 @@ export default class JsonEditor extends React.Component {
     const { value, placeholder, wordWrap = false } = this.props;
 
     const wrapStyle = wordWrap
-      ? { whiteSpace: 'pre-wrap', wordWrap: 'break-word' }
+      ? { whiteSpace: 'pre-wrap', wordWrap: 'break-word', overflowWrap: 'break-word' }
       : { whiteSpace: 'pre' };
 
     return (

--- a/src/components/JsonEditor/JsonEditor.react.js
+++ b/src/components/JsonEditor/JsonEditor.react.js
@@ -71,7 +71,8 @@ export default class JsonEditor extends React.Component {
 
   handleKeyDown = (e) => {
     // Enter key - auto-indent to match current line
-    if (e.key === 'Enter') {
+    // Skip if Cmd/Ctrl is pressed (let it bubble up for modal confirm)
+    if (e.key === 'Enter' && !e.metaKey && !e.ctrlKey) {
       e.preventDefault();
       e.stopPropagation();
 

--- a/src/components/JsonEditor/JsonEditor.react.js
+++ b/src/components/JsonEditor/JsonEditor.react.js
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2016-present, Parse, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+import React from 'react';
+import Prism from 'prismjs';
+import 'prismjs/components/prism-json';
+import styles from './JsonEditor.scss';
+
+/**
+ * JsonEditor - An editable JSON editor with syntax highlighting using Prism.js
+ *
+ * Uses overlay technique: a transparent textarea for input layered over
+ * a syntax-highlighted code display.
+ */
+export default class JsonEditor extends React.Component {
+  constructor(props) {
+    super(props);
+    this.textareaRef = React.createRef();
+    this.preRef = React.createRef();
+  }
+
+  componentDidMount() {
+    this.syncScroll();
+  }
+
+  componentDidUpdate() {
+    this.syncScroll();
+  }
+
+  syncScroll = () => {
+    // Sync scroll position between textarea and highlighted code
+    if (this.textareaRef.current && this.preRef.current) {
+      const textarea = this.textareaRef.current;
+      const pre = this.preRef.current;
+      pre.scrollTop = textarea.scrollTop;
+      pre.scrollLeft = textarea.scrollLeft;
+    }
+  };
+
+  handleScroll = () => {
+    this.syncScroll();
+  };
+
+  handleChange = (e) => {
+    const { onChange } = this.props;
+    if (onChange) {
+      onChange(e.target.value);
+    }
+  };
+
+  getHighlightedCode() {
+    const { value } = this.props;
+    if (!value) {
+      return '';
+    }
+    try {
+      return Prism.highlight(value, Prism.languages.json, 'json');
+    } catch {
+      // If highlighting fails, return escaped HTML
+      return value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+    }
+  }
+
+  render() {
+    const { value, placeholder, wordWrap = false } = this.props;
+
+    const wrapStyle = wordWrap
+      ? { whiteSpace: 'pre-wrap', wordWrap: 'break-word' }
+      : { whiteSpace: 'pre' };
+
+    return (
+      <div className={styles.container}>
+        <pre
+          ref={this.preRef}
+          className={styles.highlightLayer}
+          style={wrapStyle}
+          aria-hidden="true"
+        >
+          <code
+            className="language-json"
+            dangerouslySetInnerHTML={{ __html: this.getHighlightedCode() + '\n' }}
+          />
+        </pre>
+        <textarea
+          ref={this.textareaRef}
+          className={styles.inputLayer}
+          style={wrapStyle}
+          value={value || ''}
+          onChange={this.handleChange}
+          onScroll={this.handleScroll}
+          placeholder={placeholder}
+          spellCheck={false}
+          autoCapitalize="off"
+          autoComplete="off"
+          autoCorrect="off"
+        />
+      </div>
+    );
+  }
+}

--- a/src/components/JsonEditor/JsonEditor.scss
+++ b/src/components/JsonEditor/JsonEditor.scss
@@ -29,6 +29,7 @@
   box-sizing: border-box;
   text-align: left;
   direction: ltr;
+  overscroll-behavior: none; // Disable rubber band / bounce effect in Safari
 }
 
 // The syntax-highlighted layer (behind, absolutely positioned)

--- a/src/components/JsonEditor/JsonEditor.scss
+++ b/src/components/JsonEditor/JsonEditor.scss
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2016-present, Parse, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+@import 'stylesheets/globals.scss';
+
+.container {
+  position: relative;
+  display: inline-block;
+  width: 100%;
+  font-family: 'Source Code Pro', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+  font-size: 14px;
+  line-height: 1.5;
+  background: $inputBackgroundColor;
+}
+
+// Shared text styles
+.highlightLayer,
+.inputLayer {
+  padding: 10px;
+  margin: 0;
+  border: none;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  box-sizing: border-box;
+  text-align: left;
+  direction: ltr;
+}
+
+// The syntax-highlighted layer (behind, absolutely positioned)
+.highlightLayer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  pointer-events: none;
+  background: transparent;
+  color: #555572;
+  overflow: auto;
+
+  code {
+    font-family: inherit;
+    font-size: inherit;
+    line-height: inherit;
+  }
+
+  // Prism token colors (matching CodeSnippet.css)
+  :global {
+    .token.property {
+      color: #FF395E;
+    }
+
+    .token.string {
+      color: #00D275;
+    }
+
+    .token.number {
+      color: #FF395E;
+    }
+
+    .token.boolean {
+      color: #169CEE;
+    }
+
+    .token.null {
+      color: #169CEE;
+    }
+
+    .token.punctuation {
+      color: #555572;
+    }
+
+    .token.operator {
+      color: #555572;
+    }
+  }
+}
+
+// The editable textarea layer (in normal flow, controls container size)
+.inputLayer {
+  display: block;
+  width: 100%;
+  min-width: calc(var(--modal-min-width) * (1 - var(--modal-label-ratio)));
+  background: transparent;
+  color: transparent;
+  caret-color: #333;
+  resize: both;
+  outline: none;
+  min-height: 80px;
+  height: 200px;
+  overflow: auto;
+
+  &::placeholder {
+    color: #bbb;
+  }
+}

--- a/src/components/JsonEditor/JsonEditor.scss
+++ b/src/components/JsonEditor/JsonEditor.scss
@@ -45,9 +45,13 @@
   overflow: auto;
 
   code {
+    display: block;
     font-family: inherit;
     font-size: inherit;
     line-height: inherit;
+    white-space: inherit;
+    word-wrap: inherit;
+    overflow-wrap: inherit;
   }
 
   // Prism token colors (GitHub light theme)

--- a/src/components/JsonEditor/JsonEditor.scss
+++ b/src/components/JsonEditor/JsonEditor.scss
@@ -12,7 +12,7 @@
   display: inline-block;
   width: 100%;
   font-family: 'Source Code Pro', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
-  font-size: 14px;
+  font-size: 15px;
   line-height: 1.5;
   background: $inputBackgroundColor;
 }
@@ -50,34 +50,34 @@
     line-height: inherit;
   }
 
-  // Prism token colors (matching CodeSnippet.css)
+  // Prism token colors (GitHub light theme)
   :global {
     .token.property {
-      color: #FF395E;
+      color: #005cc5; // Blue - JSON keys
     }
 
     .token.string {
-      color: #00D275;
+      color: #000000; // Black - string values
     }
 
     .token.number {
-      color: #FF395E;
+      color: #098658; // Dark green - numbers
     }
 
     .token.boolean {
-      color: #169CEE;
+      color: #d73a49; // Red - true/false
     }
 
     .token.null {
-      color: #169CEE;
+      color: #d73a49; // Red - null
     }
 
     .token.punctuation {
-      color: #555572;
+      color: #24292e; // Dark gray - brackets, commas
     }
 
     .token.operator {
-      color: #555572;
+      color: #24292e; // Dark gray - colons
     }
   }
 }

--- a/src/components/Toggle/Toggle.react.js
+++ b/src/components/Toggle/Toggle.react.js
@@ -96,7 +96,8 @@ export default class Toggle extends React.Component {
     }
 
     const switchClasses = [styles.switch];
-    if (colored) {
+    // Only use default colored class if no custom colors provided
+    if (colored && !this.props.colorLeft && !this.props.colorRight) {
       switchClasses.push(styles.colored);
     }
     if (this.props.switchNoMargin) {
@@ -109,6 +110,20 @@ export default class Toggle extends React.Component {
     if (this.props.darkBg) {
       toggleClasses.push(styles.darkBg);
     }
+
+    // Custom colors for the switch
+    let switchStyle = {};
+    if (this.props.colorLeft || this.props.colorRight) {
+      const colorLeft = this.props.colorLeft || '#999';
+      const colorRight = this.props.colorRight || '#00db7c';
+      switchStyle = {
+        background: `linear-gradient(90deg, ${colorRight}, ${colorRight} 50%, ${colorLeft} 50%, ${colorLeft})`,
+        backgroundSize: '200%',
+        backgroundPosition: left ? '100%' : '0',
+        transition: 'background-position 0.15s ease-out',
+      };
+    }
+
     return (
       <div className={toggleClasses.join(' ')} style={this.props.additionalStyles || {}}>
         {labelLeft && (
@@ -116,7 +131,7 @@ export default class Toggle extends React.Component {
             {labelLeft}
           </span>
         )}
-        <span className={switchClasses.join(' ')} onClick={this.toggle.bind(this)}></span>
+        <span className={switchClasses.join(' ')} style={switchStyle} onClick={this.toggle.bind(this)}></span>
         {labelRight && (
           <span className={styles.label} onClick={this.toRight.bind(this)}>
             {labelRight}
@@ -144,6 +159,8 @@ Toggle.propTypes = {
   colored: PropTypes.bool.describe(
     'Flag describing is toggle is colored. [For Toggle.Type.CUSTOM]'
   ),
+  colorLeft: PropTypes.string.describe('Custom color for the left (off) state of the toggle.'),
+  colorRight: PropTypes.string.describe('Custom color for the right (on) state of the toggle.'),
   darkBg: PropTypes.bool,
   additionalStyles: PropTypes.object.describe('Additional styles for Toggle component.'),
 };

--- a/src/dashboard/Data/Config/ConfigDialog.react.js
+++ b/src/dashboard/Data/Config/ConfigDialog.react.js
@@ -106,6 +106,7 @@ export default class ConfigDialog extends React.Component {
       masterKeyOnly: false,
       selectedIndex: null,
       wordWrap: false,
+      error: null,
     };
     if (props.param.length > 0) {
       // Auto-format JSON values on initial open
@@ -125,6 +126,7 @@ export default class ConfigDialog extends React.Component {
         masterKeyOnly: props.masterKeyOnly,
         selectedIndex: 0,
         wordWrap: false,
+        error: null,
       };
     }
   }
@@ -200,9 +202,21 @@ export default class ConfigDialog extends React.Component {
     try {
       const parsed = JSON.parse(this.state.value);
       const formatted = JSON.stringify(parsed, null, 2);
-      this.setState({ value: formatted });
-    } catch {
-      // Value is not valid JSON, do nothing
+      this.setState({ value: formatted, error: null });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      this.setState({ error: `Invalid JSON: ${message}` });
+    }
+  }
+
+  compactValue() {
+    try {
+      const parsed = JSON.parse(this.state.value);
+      const compacted = JSON.stringify(parsed);
+      this.setState({ value: compacted, error: null });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      this.setState({ error: `Invalid JSON: ${message}` });
     }
   }
 
@@ -289,7 +303,7 @@ export default class ConfigDialog extends React.Component {
           }
           input={EDITORS[this.state.type](
             this.state.value,
-            value => this.setState({ value }),
+            value => this.setState({ value, error: null }),
             this.state.wordWrap
           )}
         />
@@ -354,6 +368,11 @@ export default class ConfigDialog extends React.Component {
                 onClick={this.formatValue.bind(this)}
                 disabled={!this.canFormatValue()}
               />
+              <Button
+                value="Compact"
+                onClick={this.compactValue.bind(this)}
+                disabled={!this.canFormatValue()}
+              />
               <label style={{ display: 'flex', alignItems: 'center', gap: '8px', cursor: 'pointer' }}>
                 <Toggle
                   type={Toggle.Types.HIDE_LABELS}
@@ -363,6 +382,9 @@ export default class ConfigDialog extends React.Component {
                 />
                 <span>Word wrap</span>
               </label>
+              {this.state.error && (
+                <span style={{ color: '#d73a49', fontSize: '13px' }}>{this.state.error}</span>
+              )}
             </>
           )}
         </div>

--- a/src/dashboard/Data/Config/ConfigDialog.react.js
+++ b/src/dashboard/Data/Config/ConfigDialog.react.js
@@ -112,16 +112,26 @@ export default class ConfigDialog extends React.Component {
       name: '',
       masterKeyOnly: false,
       selectedIndex: null,
-      wordWrap: true,
+      wordWrap: false,
     };
     if (props.param.length > 0) {
+      // Auto-format JSON values on initial open
+      let initialValue = props.value;
+      if ((props.type === 'Object' || props.type === 'Array') && initialValue) {
+        try {
+          const parsed = JSON.parse(initialValue);
+          initialValue = JSON.stringify(parsed, null, 2);
+        } catch {
+          // Value is not valid JSON, keep original
+        }
+      }
       this.state = {
         name: props.param,
         type: props.type,
-        value: props.value,
+        value: initialValue,
         masterKeyOnly: props.masterKeyOnly,
         selectedIndex: 0,
-        wordWrap: true,
+        wordWrap: false,
       };
     }
   }

--- a/src/dashboard/Data/Config/ConfigDialog.react.js
+++ b/src/dashboard/Data/Config/ConfigDialog.react.js
@@ -379,8 +379,10 @@ export default class ConfigDialog extends React.Component {
                   value={this.state.wordWrap}
                   onChange={wordWrap => this.setState({ wordWrap })}
                   additionalStyles={{ margin: '0px' }}
+                  colorLeft="#cbcbcb"
+                  colorRight="#00db7c"
                 />
-                <span>Word wrap</span>
+                <span style={{ color: this.state.wordWrap ? '#333' : '#999' }}>Wrap</span>
               </label>
               {this.state.error && (
                 <span style={{ color: '#d73a49', fontSize: '13px' }}>{this.state.error}</span>

--- a/src/dashboard/Data/Config/ConfigDialog.react.js
+++ b/src/dashboard/Data/Config/ConfigDialog.react.js
@@ -54,7 +54,7 @@ const EDITORS = {
     <TextInput value={value || ''} onChange={numberValidator(onChange)} />
   ),
   Date: (value, onChange) => <DateTimeInput fixed={true} value={value} onChange={onChange} />,
-  Object: (value, onChange) => (
+  Object: (value, onChange, style) => (
     <NonPrintableHighlighter value={value} isJson={true} detectNonAlphanumeric={true}>
       <TextInput
         multiline={true}
@@ -62,10 +62,11 @@ const EDITORS = {
         placeholder={'{\n  ...\n}'}
         value={value || ''}
         onChange={onChange}
+        style={style}
       />
     </NonPrintableHighlighter>
   ),
-  Array: (value, onChange) => (
+  Array: (value, onChange, style) => (
     <NonPrintableHighlighter value={value} isJson={true} detectNonAlphanumeric={true}>
       <TextInput
         multiline={true}
@@ -73,6 +74,7 @@ const EDITORS = {
         placeholder={'[\n  ...\n]'}
         value={value}
         onChange={onChange}
+        style={style}
       />
     </NonPrintableHighlighter>
   ),
@@ -110,6 +112,7 @@ export default class ConfigDialog extends React.Component {
       name: '',
       masterKeyOnly: false,
       selectedIndex: null,
+      wordWrap: true,
     };
     if (props.param.length > 0) {
       this.state = {
@@ -118,6 +121,7 @@ export default class ConfigDialog extends React.Component {
         value: props.value,
         masterKeyOnly: props.masterKeyOnly,
         selectedIndex: 0,
+        wordWrap: true,
       };
     }
   }
@@ -281,21 +285,34 @@ export default class ConfigDialog extends React.Component {
                 <>
                   Use this to configure your app. You can change it at any time.
                   {(this.state.type === 'Object' || this.state.type === 'Array') && (
-                    <div style={{ marginTop: '10px' }}>
+                    <div style={{ marginTop: '10px', display: 'flex', alignItems: 'center', gap: '15px' }}>
                       <Button
                         value="Format"
                         onClick={this.formatValue.bind(this)}
                         disabled={!this.canFormatValue()}
                       />
+                      <label style={{ display: 'flex', alignItems: 'center', gap: '8px', cursor: 'pointer' }}>
+                        <Toggle
+                          type={Toggle.Types.HIDE_LABELS}
+                          value={this.state.wordWrap}
+                          onChange={wordWrap => this.setState({ wordWrap })}
+                          additionalStyles={{ margin: '0px' }}
+                        />
+                        <span>Word wrap</span>
+                      </label>
                     </div>
                   )}
                 </>
               }
             />
           }
-          input={EDITORS[this.state.type](this.state.value, value => {
-            this.setState({ value });
-          })}
+          input={EDITORS[this.state.type](
+            this.state.value,
+            value => this.setState({ value }),
+            (this.state.type === 'Object' || this.state.type === 'Array')
+              ? { whiteSpace: this.state.wordWrap ? 'pre-wrap' : 'pre', overflowX: 'auto' }
+              : undefined
+          )}
         />
 
         {

--- a/src/dashboard/Data/Config/ConfigDialog.react.js
+++ b/src/dashboard/Data/Config/ConfigDialog.react.js
@@ -18,6 +18,7 @@ import Parse from 'parse';
 import React from 'react';
 import TextInput from 'components/TextInput/TextInput.react';
 import Toggle from 'components/Toggle/Toggle.react';
+import Button from 'components/Button/Button.react';
 import validateNumeric from 'lib/validateNumeric';
 import styles from 'dashboard/Data/Browser/Browser.scss';
 import semver from 'semver/preload.js';
@@ -188,6 +189,28 @@ export default class ConfigDialog extends React.Component {
     });
   }
 
+  formatValue() {
+    try {
+      const parsed = JSON.parse(this.state.value);
+      const formatted = JSON.stringify(parsed, null, 2);
+      this.setState({ value: formatted });
+    } catch {
+      // Value is not valid JSON, do nothing
+    }
+  }
+
+  canFormatValue() {
+    if (this.state.type !== 'Object' && this.state.type !== 'Array') {
+      return false;
+    }
+    try {
+      JSON.parse(this.state.value);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   componentDidUpdate(prevProps) {
     // Update parameter value or masterKeyOnly if they have changed
     if (this.props.value !== prevProps.value || this.props.masterKeyOnly !== prevProps.masterKeyOnly) {
@@ -254,7 +277,20 @@ export default class ConfigDialog extends React.Component {
           label={
             <Label
               text="Value"
-              description="Use this to configure your app. You can change it at any time."
+              description={
+                <>
+                  Use this to configure your app. You can change it at any time.
+                  {(this.state.type === 'Object' || this.state.type === 'Array') && (
+                    <div style={{ marginTop: '10px' }}>
+                      <Button
+                        value="Format"
+                        onClick={this.formatValue.bind(this)}
+                        disabled={!this.canFormatValue()}
+                      />
+                    </div>
+                  )}
+                </>
+              }
             />
           }
           input={EDITORS[this.state.type](this.state.value, value => {

--- a/src/dashboard/Data/Config/ConfigDialog.react.js
+++ b/src/dashboard/Data/Config/ConfigDialog.react.js
@@ -19,6 +19,7 @@ import React from 'react';
 import TextInput from 'components/TextInput/TextInput.react';
 import Toggle from 'components/Toggle/Toggle.react';
 import Button from 'components/Button/Button.react';
+import JsonEditor from 'components/JsonEditor/JsonEditor.react';
 import validateNumeric from 'lib/validateNumeric';
 import styles from 'dashboard/Data/Browser/Browser.scss';
 import semver from 'semver/preload.js';
@@ -54,29 +55,21 @@ const EDITORS = {
     <TextInput value={value || ''} onChange={numberValidator(onChange)} />
   ),
   Date: (value, onChange) => <DateTimeInput fixed={true} value={value} onChange={onChange} />,
-  Object: (value, onChange, style) => (
-    <NonPrintableHighlighter value={value} isJson={true} detectNonAlphanumeric={true}>
-      <TextInput
-        multiline={true}
-        monospace={true}
-        placeholder={'{\n  ...\n}'}
-        value={value || ''}
-        onChange={onChange}
-        style={style}
-      />
-    </NonPrintableHighlighter>
+  Object: (value, onChange, wordWrap) => (
+    <JsonEditor
+      value={value || ''}
+      onChange={onChange}
+      placeholder={'{\n  ...\n}'}
+      wordWrap={wordWrap}
+    />
   ),
-  Array: (value, onChange, style) => (
-    <NonPrintableHighlighter value={value} isJson={true} detectNonAlphanumeric={true}>
-      <TextInput
-        multiline={true}
-        monospace={true}
-        placeholder={'[\n  ...\n]'}
-        value={value}
-        onChange={onChange}
-        style={style}
-      />
-    </NonPrintableHighlighter>
+  Array: (value, onChange, wordWrap) => (
+    <JsonEditor
+      value={value || ''}
+      onChange={onChange}
+      placeholder={'[\n  ...\n]'}
+      wordWrap={wordWrap}
+    />
   ),
   GeoPoint: (value, onChange) => <GeoPointInput value={value} onChange={onChange} />,
   File: (value, onChange) => (
@@ -297,9 +290,7 @@ export default class ConfigDialog extends React.Component {
           input={EDITORS[this.state.type](
             this.state.value,
             value => this.setState({ value }),
-            (this.state.type === 'Object' || this.state.type === 'Array')
-              ? { whiteSpace: this.state.wordWrap ? 'pre-wrap' : 'pre', overflowX: 'auto' }
-              : undefined
+            this.state.wordWrap
           )}
         />
 

--- a/src/dashboard/Data/Config/ConfigDialog.react.js
+++ b/src/dashboard/Data/Config/ConfigDialog.react.js
@@ -411,6 +411,8 @@ export default class ConfigDialog extends React.Component {
         iconSize={30}
         subtitle={'Dynamically configure parts of your app'}
         customFooter={customFooter}
+        onCancel={this.props.onCancel}
+        onConfirm={this.submit.bind(this)}
       >
         <LoaderContainer loading={this.props.loading}>
           {dialogContent}

--- a/src/dashboard/Data/Config/ConfigDialog.react.js
+++ b/src/dashboard/Data/Config/ConfigDialog.react.js
@@ -25,7 +25,10 @@ import styles from 'dashboard/Data/Browser/Browser.scss';
 import semver from 'semver/preload.js';
 import { dateStringUTC } from 'lib/DateUtils';
 import LoaderContainer from 'components/LoaderContainer/LoaderContainer.react';
+import ServerConfigStorage from 'lib/ServerConfigStorage';
 import { CurrentApp } from 'context/currentApp';
+
+const FORMATTING_CONFIG_KEY = 'config.formatting.syntax';
 
 const PARAM_TYPES = ['Boolean', 'String', 'Number', 'Date', 'Object', 'Array', 'GeoPoint', 'File'];
 
@@ -55,20 +58,22 @@ const EDITORS = {
     <TextInput value={value || ''} onChange={numberValidator(onChange)} />
   ),
   Date: (value, onChange) => <DateTimeInput fixed={true} value={value} onChange={onChange} />,
-  Object: (value, onChange, wordWrap) => (
+  Object: (value, onChange, wordWrap, syntaxColors) => (
     <JsonEditor
       value={value || ''}
       onChange={onChange}
       placeholder={'{\n  ...\n}'}
       wordWrap={wordWrap}
+      syntaxColors={syntaxColors}
     />
   ),
-  Array: (value, onChange, wordWrap) => (
+  Array: (value, onChange, wordWrap, syntaxColors) => (
     <JsonEditor
       value={value || ''}
       onChange={onChange}
       placeholder={'[\n  ...\n]'}
       wordWrap={wordWrap}
+      syntaxColors={syntaxColors}
     />
   ),
   GeoPoint: (value, onChange) => <GeoPointInput value={value} onChange={onChange} />,
@@ -107,6 +112,7 @@ export default class ConfigDialog extends React.Component {
       selectedIndex: null,
       wordWrap: false,
       error: null,
+      syntaxColors: null,
     };
     if (props.param.length > 0) {
       // Auto-format JSON values on initial open
@@ -127,7 +133,29 @@ export default class ConfigDialog extends React.Component {
         selectedIndex: 0,
         wordWrap: false,
         error: null,
+        syntaxColors: null,
       };
+    }
+  }
+
+  componentDidMount() {
+    this.loadSyntaxColors();
+  }
+
+  async loadSyntaxColors() {
+    try {
+      const serverStorage = new ServerConfigStorage(this.context);
+      if (serverStorage.isServerConfigEnabled()) {
+        const settings = await serverStorage.getConfig(
+          FORMATTING_CONFIG_KEY,
+          this.context.applicationId
+        );
+        if (settings?.colors) {
+          this.setState({ syntaxColors: settings.colors });
+        }
+      }
+    } catch {
+      // Silently fail - use default colors from CSS
     }
   }
 
@@ -304,7 +332,8 @@ export default class ConfigDialog extends React.Component {
           input={EDITORS[this.state.type](
             this.state.value,
             value => this.setState({ value, error: null }),
-            this.state.wordWrap
+            this.state.wordWrap,
+            this.state.syntaxColors
           )}
         />
 

--- a/src/dashboard/Data/Config/ConfigDialog.react.js
+++ b/src/dashboard/Data/Config/ConfigDialog.react.js
@@ -281,29 +281,7 @@ export default class ConfigDialog extends React.Component {
           label={
             <Label
               text="Value"
-              description={
-                <>
-                  Use this to configure your app. You can change it at any time.
-                  {(this.state.type === 'Object' || this.state.type === 'Array') && (
-                    <div style={{ marginTop: '10px', display: 'flex', alignItems: 'center', gap: '15px' }}>
-                      <Button
-                        value="Format"
-                        onClick={this.formatValue.bind(this)}
-                        disabled={!this.canFormatValue()}
-                      />
-                      <label style={{ display: 'flex', alignItems: 'center', gap: '8px', cursor: 'pointer' }}>
-                        <Toggle
-                          type={Toggle.Types.HIDE_LABELS}
-                          value={this.state.wordWrap}
-                          onChange={wordWrap => this.setState({ wordWrap })}
-                          additionalStyles={{ margin: '0px' }}
-                        />
-                        <span>Word wrap</span>
-                      </label>
-                    </div>
-                  )}
-                </>
-              }
+              description="Use this to configure your app. You can change it at any time."
             />
           }
           input={EDITORS[this.state.type](
@@ -364,6 +342,42 @@ export default class ConfigDialog extends React.Component {
       </div>
     );
 
+    const isJsonType = this.state.type === 'Object' || this.state.type === 'Array';
+    const customFooter = (
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '17px 28px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '15px' }}>
+          {isJsonType && (
+            <>
+              <Button
+                value="Format"
+                onClick={this.formatValue.bind(this)}
+                disabled={!this.canFormatValue()}
+              />
+              <label style={{ display: 'flex', alignItems: 'center', gap: '8px', cursor: 'pointer' }}>
+                <Toggle
+                  type={Toggle.Types.HIDE_LABELS}
+                  value={this.state.wordWrap}
+                  onChange={wordWrap => this.setState({ wordWrap })}
+                  additionalStyles={{ margin: '0px' }}
+                />
+                <span>Word wrap</span>
+              </label>
+            </>
+          )}
+        </div>
+        <div style={{ display: 'flex', gap: '12px' }}>
+          <Button value="Cancel" onClick={this.props.onCancel} />
+          <Button
+            primary={true}
+            color="blue"
+            value={newParam ? 'Create' : 'Save'}
+            onClick={this.submit.bind(this)}
+            disabled={!this.valid() || this.props.loading}
+          />
+        </div>
+      </div>
+    );
+
     return (
       <Modal
         type={Modal.Types.INFO}
@@ -371,11 +385,7 @@ export default class ConfigDialog extends React.Component {
         icon="gear-solid"
         iconSize={30}
         subtitle={'Dynamically configure parts of your app'}
-        disabled={!this.valid() || this.props.loading}
-        confirmText={newParam ? 'Create' : 'Save'}
-        cancelText="Cancel"
-        onCancel={this.props.onCancel}
-        onConfirm={this.submit.bind(this)}
+        customFooter={customFooter}
       >
         <LoaderContainer loading={this.props.loading}>
           {dialogContent}

--- a/src/dashboard/Settings/CloudConfigSettings.react.js
+++ b/src/dashboard/Settings/CloudConfigSettings.react.js
@@ -1,3 +1,4 @@
+import Button from 'components/Button/Button.react';
 import DashboardView from 'dashboard/DashboardView.react';
 import Field from 'components/Field/Field.react';
 import Fieldset from 'components/Fieldset/Fieldset.react';
@@ -10,6 +11,17 @@ import ServerConfigStorage from 'lib/ServerConfigStorage';
 import styles from 'dashboard/Settings/Settings.scss';
 
 const CONFIG_KEY = 'config.settings';
+const FORMATTING_CONFIG_KEY = 'config.formatting.syntax';
+
+const DEFAULT_SYNTAX_COLORS = {
+  property: '#005cc5',
+  string: '#000000',
+  number: '#098658',
+  boolean: '#d73a49',
+  null: '#d73a49',
+  punctuation: '#24292e',
+  operator: '#24292e',
+};
 
 export default class CloudConfigSettings extends DashboardView {
   constructor() {
@@ -20,6 +32,7 @@ export default class CloudConfigSettings extends DashboardView {
 
     this.state = {
       cloudConfigHistoryLimit: '',
+      syntaxColors: { ...DEFAULT_SYNTAX_COLORS },
       message: undefined,
       loading: true,
     };
@@ -46,6 +59,17 @@ export default class CloudConfigSettings extends DashboardView {
         if (settings.historyLimit !== undefined) {
           this.setState({ cloudConfigHistoryLimit: String(settings.historyLimit) });
         }
+      }
+
+      // Load formatting settings
+      const formattingSettings = await this.serverStorage.getConfig(
+        FORMATTING_CONFIG_KEY,
+        this.context.applicationId
+      );
+      if (formattingSettings && formattingSettings.colors) {
+        this.setState({
+          syntaxColors: { ...DEFAULT_SYNTAX_COLORS, ...formattingSettings.colors }
+        });
       }
     } catch {
       this.showNote('Failed to load Cloud Config settings.', true);
@@ -99,6 +123,66 @@ export default class CloudConfigSettings extends DashboardView {
       this.showNote(`Cloud Config history limit set to ${parsed}.`);
     } else {
       this.showNote('Failed to save setting.', true);
+    }
+  }
+
+  handleSyntaxColorChange(tokenType, color) {
+    this.setState(prevState => ({
+      syntaxColors: { ...prevState.syntaxColors, [tokenType]: color }
+    }));
+  }
+
+  allColorsMatchDefaults(colors) {
+    return Object.entries(DEFAULT_SYNTAX_COLORS).every(
+      ([key, defaultColor]) => colors[key]?.toLowerCase() === defaultColor.toLowerCase()
+    );
+  }
+
+  async saveSyntaxColor(tokenType) {
+    const color = this.state.syntaxColors[tokenType];
+
+    // Validate hex color
+    if (!/^#[0-9A-Fa-f]{6}$/.test(color)) {
+      this.showNote(`Invalid color format for ${tokenType}. Use hex format like #ff0000.`, true);
+      return;
+    }
+
+    try {
+      const current = await this.serverStorage.getConfig(
+        FORMATTING_CONFIG_KEY,
+        this.context.applicationId
+      );
+      const colors = { ...(current?.colors || {}), [tokenType]: color };
+
+      // If all colors match defaults, delete the config entry instead
+      if (this.allColorsMatchDefaults(colors)) {
+        await this.serverStorage.deleteConfig(
+          FORMATTING_CONFIG_KEY,
+          this.context.applicationId
+        );
+      } else {
+        await this.serverStorage.setConfig(
+          FORMATTING_CONFIG_KEY,
+          { colors },
+          this.context.applicationId
+        );
+      }
+      this.showNote(`${tokenType} color saved.`);
+    } catch {
+      this.showNote(`Failed to save ${tokenType} color.`, true);
+    }
+  }
+
+  async resetSyntaxColors() {
+    try {
+      await this.serverStorage.deleteConfig(
+        FORMATTING_CONFIG_KEY,
+        this.context.applicationId
+      );
+      this.setState({ syntaxColors: { ...DEFAULT_SYNTAX_COLORS } });
+      this.showNote('Syntax colors reset to defaults.');
+    } catch {
+      this.showNote('Failed to reset syntax colors.', true);
     }
   }
 
@@ -161,6 +245,58 @@ export default class CloudConfigSettings extends DashboardView {
                 />
               }
             />
+          </Fieldset>
+          <Fieldset
+            legend="Formatting"
+            description="Customize JSON syntax highlighting colors for the Cloud Config editor."
+          >
+            {Object.entries({
+              property: 'Property (keys)',
+              string: 'String',
+              number: 'Number',
+              boolean: 'Boolean',
+              null: 'Null',
+              punctuation: 'Punctuation (brackets, commas)',
+              operator: 'Operator (colons)',
+            }).map(([tokenType, label]) => (
+              <Field
+                key={tokenType}
+                labelWidth={62}
+                label={
+                  <Label
+                    text={label}
+                    description={`Default: ${DEFAULT_SYNTAX_COLORS[tokenType]}`}
+                  />
+                }
+                input={
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+                    <input
+                      type="color"
+                      value={this.state.syntaxColors[tokenType]}
+                      disabled={!serverConfigEnabled || this.state.loading}
+                      onChange={(e) => this.handleSyntaxColorChange(tokenType, e.target.value)}
+                      onBlur={() => this.saveSyntaxColor(tokenType)}
+                      style={{ width: '40px', height: '30px', cursor: 'pointer', border: 'none' }}
+                    />
+                    <TextInput
+                      placeholder={DEFAULT_SYNTAX_COLORS[tokenType]}
+                      value={this.state.syntaxColors[tokenType]}
+                      disabled={!serverConfigEnabled || this.state.loading}
+                      onChange={(value) => this.handleSyntaxColorChange(tokenType, value)}
+                      onBlur={() => this.saveSyntaxColor(tokenType)}
+                      style={{ width: '100px' }}
+                    />
+                  </div>
+                }
+              />
+            ))}
+            <div style={{ marginTop: '15px', paddingLeft: '62%' }}>
+              <Button
+                value="Reset to Defaults"
+                onClick={this.resetSyntaxColors.bind(this)}
+                disabled={!serverConfigEnabled || this.state.loading}
+              />
+            </div>
           </Fieldset>
         </div>
       </div>

--- a/src/dashboard/Settings/CloudConfigSettings.react.js
+++ b/src/dashboard/Settings/CloudConfigSettings.react.js
@@ -196,10 +196,17 @@ export default class CloudConfigSettings extends DashboardView {
 
   async resetSyntaxColors() {
     try {
+      // Wait for any in-flight saves to complete before deleting
+      await (this.pendingSyntaxColorSave || Promise.resolve());
+
       await this.serverStorage.deleteConfig(
         FORMATTING_CONFIG_KEY,
         this.context.applicationId
       );
+
+      // Reset the queue so future saves start fresh
+      this.pendingSyntaxColorSave = Promise.resolve();
+
       this.setState({ syntaxColors: { ...DEFAULT_SYNTAX_COLORS } });
       this.showNote('Syntax colors reset to defaults.');
     } catch {

--- a/src/dashboard/Settings/CloudConfigSettings.react.js
+++ b/src/dashboard/Settings/CloudConfigSettings.react.js
@@ -152,6 +152,15 @@ export default class CloudConfigSettings extends DashboardView {
         FORMATTING_CONFIG_KEY,
         this.context.applicationId
       );
+      const storedColor = current?.colors?.[tokenType];
+      const defaultColor = DEFAULT_SYNTAX_COLORS[tokenType];
+
+      // Skip if color hasn't changed from stored value (or default if not stored)
+      const previousColor = storedColor || defaultColor;
+      if (color.toLowerCase() === previousColor.toLowerCase()) {
+        return;
+      }
+
       const colors = { ...(current?.colors || {}), [tokenType]: color };
 
       // If all colors match defaults, delete the config entry instead

--- a/src/dashboard/Settings/CloudConfigSettings.react.js
+++ b/src/dashboard/Settings/CloudConfigSettings.react.js
@@ -29,6 +29,8 @@ export default class CloudConfigSettings extends DashboardView {
     this.section = 'App Settings';
     this.subsection = 'Cloud Config';
     this.serverStorage = null;
+    // Queue to serialize syntax color saves and prevent race conditions
+    this.pendingSyntaxColorSave = Promise.resolve();
 
     this.state = {
       cloudConfigHistoryLimit: '',
@@ -135,52 +137,61 @@ export default class CloudConfigSettings extends DashboardView {
   async saveSyntaxColor(tokenType) {
     const color = this.state.syntaxColors[tokenType];
 
-    // Validate hex color
+    // Validate hex color synchronously before queuing
     if (!/^#[0-9A-Fa-f]{6}$/.test(color)) {
       this.showNote(`Invalid color format for ${tokenType}. Use hex format like #ff0000.`, true);
       return;
     }
 
-    try {
-      const current = await this.serverStorage.getConfig(
-        FORMATTING_CONFIG_KEY,
-        this.context.applicationId
-      );
-      const storedColor = current?.colors?.[tokenType];
-      const defaultColor = DEFAULT_SYNTAX_COLORS[tokenType];
-
-      // Skip if color hasn't changed from stored value (or default if not stored)
-      const previousColor = storedColor || defaultColor;
-      if (color.toLowerCase() === previousColor.toLowerCase()) {
-        return;
-      }
-
-      // Build the new colors object, only including non-default values
-      const colors = { ...(current?.colors || {}) };
-      if (color.toLowerCase() === defaultColor.toLowerCase()) {
-        // Remove from storage if it matches the default
-        delete colors[tokenType];
-      } else {
-        colors[tokenType] = color;
-      }
-
-      // If no custom colors remain, delete the config entry
-      if (Object.keys(colors).length === 0) {
-        await this.serverStorage.deleteConfig(
+    // Chain onto the pending save to serialize read-modify-write operations
+    const saveOperation = this.pendingSyntaxColorSave.then(async () => {
+      try {
+        const current = await this.serverStorage.getConfig(
           FORMATTING_CONFIG_KEY,
           this.context.applicationId
         );
-      } else {
-        await this.serverStorage.setConfig(
-          FORMATTING_CONFIG_KEY,
-          { colors },
-          this.context.applicationId
-        );
+        const storedColor = current?.colors?.[tokenType];
+        const defaultColor = DEFAULT_SYNTAX_COLORS[tokenType];
+
+        // Skip if color hasn't changed from stored value (or default if not stored)
+        const previousColor = storedColor || defaultColor;
+        if (color.toLowerCase() === previousColor.toLowerCase()) {
+          return;
+        }
+
+        // Build the new colors object, only including non-default values
+        const colors = { ...(current?.colors || {}) };
+        if (color.toLowerCase() === defaultColor.toLowerCase()) {
+          // Remove from storage if it matches the default
+          delete colors[tokenType];
+        } else {
+          colors[tokenType] = color;
+        }
+
+        // If no custom colors remain, delete the config entry
+        if (Object.keys(colors).length === 0) {
+          await this.serverStorage.deleteConfig(
+            FORMATTING_CONFIG_KEY,
+            this.context.applicationId
+          );
+        } else {
+          await this.serverStorage.setConfig(
+            FORMATTING_CONFIG_KEY,
+            { colors },
+            this.context.applicationId
+          );
+        }
+        this.showNote(`${tokenType} color saved.`);
+      } catch {
+        this.showNote(`Failed to save ${tokenType} color.`, true);
       }
-      this.showNote(`${tokenType} color saved.`);
-    } catch {
-      this.showNote(`Failed to save ${tokenType} color.`, true);
-    }
+    });
+
+    // Update the queue with the new operation (catch to prevent queue breakage)
+    this.pendingSyntaxColorSave = saveOperation.catch(() => {});
+
+    // Await the operation for this call
+    await saveOperation;
   }
 
   async resetSyntaxColors() {

--- a/src/dashboard/Settings/CloudConfigSettings.react.js
+++ b/src/dashboard/Settings/CloudConfigSettings.react.js
@@ -132,12 +132,6 @@ export default class CloudConfigSettings extends DashboardView {
     }));
   }
 
-  allColorsMatchDefaults(colors) {
-    return Object.entries(DEFAULT_SYNTAX_COLORS).every(
-      ([key, defaultColor]) => colors[key]?.toLowerCase() === defaultColor.toLowerCase()
-    );
-  }
-
   async saveSyntaxColor(tokenType) {
     const color = this.state.syntaxColors[tokenType];
 
@@ -161,10 +155,17 @@ export default class CloudConfigSettings extends DashboardView {
         return;
       }
 
-      const colors = { ...(current?.colors || {}), [tokenType]: color };
+      // Build the new colors object, only including non-default values
+      const colors = { ...(current?.colors || {}) };
+      if (color.toLowerCase() === defaultColor.toLowerCase()) {
+        // Remove from storage if it matches the default
+        delete colors[tokenType];
+      } else {
+        colors[tokenType] = color;
+      }
 
-      // If all colors match defaults, delete the config entry instead
-      if (this.allColorsMatchDefaults(colors)) {
+      // If no custom colors remain, delete the config entry
+      if (Object.keys(colors).length === 0) {
         await this.serverStorage.deleteConfig(
           FORMATTING_CONFIG_KEY,
           this.context.applicationId


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-dashboard/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-dashboard/blob/alpha/LICENSE).

## Feature

Add syntax highlight and formatting for Cloud Config parameter value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New editable JSON editor with real-time syntax highlighting, auto-indentation, synchronized scrolling, change events and optional word-wrap.
  * Per-token syntax color customization with color pickers, save/reset controls and persisted settings.

* **Enhancements**
  * Config dialog: Format/Compact actions, word-wrap toggle, JSON auto-format on open and inline error handling.
  * Modal now uses a custom footer.
  * Toggle control accepts custom left/right colors for a gradient-styled switch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->