### PR TITLE
fix: View configuration dialog looses focus while typing and lacks syntax highlighting

### DIFF
--- a/src/components/Modal/Modal.react.js
+++ b/src/components/Modal/Modal.react.js
@@ -46,42 +46,48 @@ const Modal = ({
 }) => {
   const modalRef = React.useRef(null);
 
+  // Selector for all focusable elements (excluding buttons - they're handled via Enter key)
+  const focusableSelector = [
+    'input:not([disabled])',
+    'select:not([disabled])',
+    'textarea:not([disabled])',
+    'a[href]',
+    '[tabindex]:not([tabindex="-1"])',
+  ].join(', ');
+
+  const getFocusableElements = React.useCallback(() => {
+    const modal = modalRef.current;
+    if (!modal) {
+      return [];
+    }
+    return Array.from(modal.querySelectorAll(focusableSelector)).filter(el => {
+      // Filter out elements that are hidden or not visible
+      // offsetParent is null for hidden elements (display:none or in hidden ancestors)
+      // Also check for zero dimensions (collapsed elements)
+      if (el.offsetParent === null && el.tagName !== 'BODY') {
+        return false;
+      }
+      const rect = el.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) {
+        return false;
+      }
+      return true;
+    });
+  }, []);
+
+  // Focus the first focusable element only when modal mounts
+  React.useEffect(() => {
+    const focusableElements = getFocusableElements();
+    if (focusableElements.length > 0) {
+      focusableElements[0].focus();
+    }
+  }, []);
+
   // Focus trap and keyboard handling
   React.useEffect(() => {
     const modal = modalRef.current;
     if (!modal) {
       return;
-    }
-
-    // Selector for all focusable elements (excluding buttons - they're handled via Enter key)
-    const focusableSelector = [
-      'input:not([disabled])',
-      'select:not([disabled])',
-      'textarea:not([disabled])',
-      'a[href]',
-      '[tabindex]:not([tabindex="-1"])',
-    ].join(', ');
-
-    const getFocusableElements = () => {
-      return Array.from(modal.querySelectorAll(focusableSelector)).filter(el => {
-        // Filter out elements that are hidden or not visible
-        // offsetParent is null for hidden elements (display:none or in hidden ancestors)
-        // Also check for zero dimensions (collapsed elements)
-        if (el.offsetParent === null && el.tagName !== 'BODY') {
-          return false;
-        }
-        const rect = el.getBoundingClientRect();
-        if (rect.width === 0 || rect.height === 0) {
-          return false;
-        }
-        return true;
-      });
-    };
-
-    // Focus the first focusable element when modal opens
-    const focusableElements = getFocusableElements();
-    if (focusableElements.length > 0) {
-      focusableElements[0].focus();
     }
 
     const handleKeyDown = (e) => {

--- a/src/dashboard/Data/Config/ConfigDialog.react.js
+++ b/src/dashboard/Data/Config/ConfigDialog.react.js
@@ -448,6 +448,7 @@ export default class ConfigDialog extends React.Component {
         iconSize={30}
         subtitle={'Dynamically configure parts of your app'}
         customFooter={customFooter}
+        disabled={!this.valid() || this.props.loading}
         onCancel={this.props.onCancel}
         onConfirm={this.submit.bind(this)}
       >

--- a/src/dashboard/Data/Views/EditViewDialog.react.js
+++ b/src/dashboard/Data/Views/EditViewDialog.react.js
@@ -66,8 +66,8 @@ export default class EditViewDialog extends React.Component {
         type={Modal.Types.INFO}
         icon="edit-solid"
         iconSize={40}
-        title="Edit view?"
-        subtitle="Update the data source configuration."
+        title="Edit view"
+        subtitle="Update the data source configuration"
         confirmText="Save"
         cancelText="Cancel"
         disabled={!this.valid()}

--- a/src/dashboard/Data/Views/EditViewDialog.react.js
+++ b/src/dashboard/Data/Views/EditViewDialog.react.js
@@ -191,6 +191,7 @@ export default class EditViewDialog extends React.Component {
         title="Edit view"
         subtitle="Update the data source configuration"
         customFooter={customFooter}
+        disabled={!this.valid()}
         onCancel={onCancel}
         onConfirm={this.submit.bind(this)}
       >

--- a/src/dashboard/Data/Views/EditViewDialog.react.js
+++ b/src/dashboard/Data/Views/EditViewDialog.react.js
@@ -1,11 +1,16 @@
+import Button from 'components/Button/Button.react';
 import Checkbox from 'components/Checkbox/Checkbox.react';
 import Dropdown from 'components/Dropdown/Dropdown.react';
 import Option from 'components/Dropdown/Option.react';
 import Field from 'components/Field/Field.react';
+import JsonEditor from 'components/JsonEditor/JsonEditor.react';
 import Label from 'components/Label/Label.react';
 import Modal from 'components/Modal/Modal.react';
 import TextInput from 'components/TextInput/TextInput.react';
+import Toggle from 'components/Toggle/Toggle.react';
 import React from 'react';
+import ServerConfigStorage from 'lib/ServerConfigStorage';
+import { CurrentApp } from 'context/currentApp';
 
 function isValidJSON(value) {
   try {
@@ -16,7 +21,11 @@ function isValidJSON(value) {
   }
 }
 
+const FORMATTING_CONFIG_KEY = 'config.formatting.syntax';
+
 export default class EditViewDialog extends React.Component {
+  static contextType = CurrentApp;
+
   constructor(props) {
     super();
     const view = props.view || {};
@@ -39,7 +48,60 @@ export default class EditViewDialog extends React.Component {
       showCounter: !!view.showCounter,
       requireTextInput: !!view.requireTextInput,
       requireFileUpload: !!view.requireFileUpload,
+      wordWrap: false,
+      error: null,
+      syntaxColors: null,
     };
+  }
+
+  componentDidMount() {
+    this.loadSyntaxColors();
+  }
+
+  async loadSyntaxColors() {
+    try {
+      const serverStorage = new ServerConfigStorage(this.context);
+      if (serverStorage.isServerConfigEnabled()) {
+        const settings = await serverStorage.getConfig(
+          FORMATTING_CONFIG_KEY,
+          this.context.applicationId
+        );
+        if (settings?.colors) {
+          this.setState({ syntaxColors: settings.colors });
+        }
+      }
+    } catch {
+      // Silently fail - use default colors from CSS
+    }
+  }
+
+  formatValue() {
+    try {
+      const parsed = JSON.parse(this.state.query);
+      this.setState({ query: JSON.stringify(parsed, null, 2), error: null });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      this.setState({ error: `Invalid JSON: ${message}` });
+    }
+  }
+
+  compactValue() {
+    try {
+      const parsed = JSON.parse(this.state.query);
+      this.setState({ query: JSON.stringify(parsed), error: null });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      this.setState({ error: `Invalid JSON: ${message}` });
+    }
+  }
+
+  canFormatValue() {
+    try {
+      JSON.parse(this.state.query);
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   valid() {
@@ -59,8 +121,68 @@ export default class EditViewDialog extends React.Component {
     }
   }
 
+  submit() {
+    this.props.onConfirm({
+      id: this.state.id, // Preserve the view ID
+      name: this.state.name,
+      className: this.state.dataSourceType === 'query' ? this.state.className : null,
+      query: this.state.dataSourceType === 'query' ? JSON.parse(this.state.query) : null,
+      cloudFunction: this.state.dataSourceType === 'cloudFunction' ? this.state.cloudFunction : null,
+      showCounter: this.state.showCounter,
+      requireTextInput: this.state.dataSourceType === 'cloudFunction' ? this.state.requireTextInput : false,
+      requireFileUpload: this.state.dataSourceType === 'cloudFunction' ? this.state.requireFileUpload : false,
+    });
+  }
+
   render() {
-    const { classes, onConfirm, onCancel } = this.props;
+    const { classes, onCancel } = this.props;
+    const isQuery = this.state.dataSourceType === 'query';
+
+    const customFooter = (
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '17px 28px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '15px' }}>
+          {isQuery && (
+            <>
+              <Button
+                value="Format"
+                onClick={this.formatValue.bind(this)}
+                disabled={!this.canFormatValue()}
+              />
+              <Button
+                value="Compact"
+                onClick={this.compactValue.bind(this)}
+                disabled={!this.canFormatValue()}
+              />
+              <label style={{ display: 'flex', alignItems: 'center', gap: '8px', cursor: 'pointer' }}>
+                <Toggle
+                  type={Toggle.Types.HIDE_LABELS}
+                  value={this.state.wordWrap}
+                  onChange={wordWrap => this.setState({ wordWrap })}
+                  additionalStyles={{ margin: '0px' }}
+                  colorLeft="#cbcbcb"
+                  colorRight="#00db7c"
+                />
+                <span style={{ color: this.state.wordWrap ? '#333' : '#999' }}>Wrap</span>
+              </label>
+              {this.state.error && (
+                <span style={{ color: '#d73a49', fontSize: '13px' }}>{this.state.error}</span>
+              )}
+            </>
+          )}
+        </div>
+        <div style={{ display: 'flex', gap: '12px' }}>
+          <Button value="Cancel" onClick={onCancel} />
+          <Button
+            primary={true}
+            color="blue"
+            value="Save"
+            onClick={this.submit.bind(this)}
+            disabled={!this.valid()}
+          />
+        </div>
+      </div>
+    );
+
     return (
       <Modal
         type={Modal.Types.INFO}
@@ -68,22 +190,9 @@ export default class EditViewDialog extends React.Component {
         iconSize={40}
         title="Edit view"
         subtitle="Update the data source configuration"
-        confirmText="Save"
-        cancelText="Cancel"
-        disabled={!this.valid()}
+        customFooter={customFooter}
         onCancel={onCancel}
-        onConfirm={() =>
-          onConfirm({
-            id: this.state.id, // Preserve the view ID
-            name: this.state.name,
-            className: this.state.dataSourceType === 'query' ? this.state.className : null,
-            query: this.state.dataSourceType === 'query' ? JSON.parse(this.state.query) : null,
-            cloudFunction: this.state.dataSourceType === 'cloudFunction' ? this.state.cloudFunction : null,
-            showCounter: this.state.showCounter,
-            requireTextInput: this.state.dataSourceType === 'cloudFunction' ? this.state.requireTextInput : false,
-            requireFileUpload: this.state.dataSourceType === 'cloudFunction' ? this.state.requireFileUpload : false,
-          })
-        }
+        onConfirm={this.submit.bind(this)}
       >
         <Field
           label={<Label text="Name" />}
@@ -106,7 +215,7 @@ export default class EditViewDialog extends React.Component {
             </Dropdown>
           }
         />
-        {this.state.dataSourceType === 'query' && (
+        {isQuery && (
           <Field
             label={<Label text="Class" />}
             input={
@@ -126,26 +235,29 @@ export default class EditViewDialog extends React.Component {
         <Field
           label={
             <Label
-              text={this.state.dataSourceType === 'query' ? 'Query' : 'Cloud Function'}
+              text={isQuery ? 'Query' : 'Cloud Function'}
               description={
-                this.state.dataSourceType === 'query'
+                isQuery
                   ? 'An aggregation pipeline that returns an array of items.'
                   : 'A Parse Cloud Function that returns an array of items.'
               }
             />
           }
           input={
-            <TextInput
-              multiline={this.state.dataSourceType === 'query'}
-              value={this.state.dataSourceType === 'query' ? this.state.query : this.state.cloudFunction}
-              onChange={value =>
-                this.setState(
-                  this.state.dataSourceType === 'query'
-                    ? { query: value }
-                    : { cloudFunction: value }
-                )
-              }
-            />
+            isQuery ? (
+              <JsonEditor
+                value={this.state.query}
+                onChange={query => this.setState({ query, error: null })}
+                placeholder={'[\n  ...\n]'}
+                wordWrap={this.state.wordWrap}
+                syntaxColors={this.state.syntaxColors}
+              />
+            ) : (
+              <TextInput
+                value={this.state.cloudFunction}
+                onChange={cloudFunction => this.setState({ cloudFunction })}
+              />
+            )
           }
         />
         <Field


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-dashboard/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-dashboard/blob/alpha/LICENSE).

## Issue

View configuration dialog looses focus while typing and lacks syntax highlighting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JSON editor with syntax colors for query inputs, plus Format, Compact and Wrap controls and inline validation/error feedback in the dialog footer
  * Save/Cancel footer controls tailored for query editing

* **Bug Fixes**
  * Dialog now prevents confirmation when the form is invalid or loading

* **Refactor**
  * Improved modal focus handling for more stable behavior on open
<!-- end of auto-generated comment: release notes by coderabbit.ai -->