### PR TITLE
feat: Add reload button to info panel on long loading time

### DIFF
--- a/src/components/AggregationPanel/AggregationPanel.js
+++ b/src/components/AggregationPanel/AggregationPanel.js
@@ -1,6 +1,7 @@
+import Icon from 'components/Icon/Icon.react';
 import LoaderDots from 'components/LoaderDots/LoaderDots.react';
 import Parse from 'parse';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import styles from './AggregationPanel.scss';
 import {
   AudioElement,
@@ -28,10 +29,14 @@ const AggregationPanel = ({
   panelTitle = null,
   style,
   onContextMenu,
+  onReload,
 }) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const [nestedData, setNestedData] = useState(null);
   const [isLoadingNested, setIsLoadingNested] = useState(false);
+  const [showReloadButton, setShowReloadButton] = useState(false);
+  const [reloadCount, setReloadCount] = useState(0);
+  const reloadTimerRef = useRef(null);
 
   useEffect(() => {
     if (Object.keys(errorAggregatedData).length !== 0) {
@@ -44,6 +49,19 @@ const AggregationPanel = ({
     () => depth === 0 && selectedObjectId && isLoadingCloudFunction && showAggregatedData,
     [depth, selectedObjectId, isLoadingCloudFunction, showAggregatedData]
   );
+
+  const isLoading = depth === 0 ? isLoadingInfoPanel : isLoadingNested;
+
+  useEffect(() => {
+    clearTimeout(reloadTimerRef.current);
+    if (isLoading) {
+      setShowReloadButton(false);
+      reloadTimerRef.current = setTimeout(() => setShowReloadButton(true), 5_000);
+    } else {
+      setShowReloadButton(false);
+    }
+    return () => clearTimeout(reloadTimerRef.current);
+  }, [isLoading, reloadCount]);
 
   const shouldShowAggregatedData = useMemo(
     () =>
@@ -92,6 +110,16 @@ const AggregationPanel = ({
     setIsExpanded(false);
     fetchNestedData();
   }, [fetchNestedData]);
+
+  const handleReload = useCallback(() => {
+    setShowReloadButton(false);
+    setReloadCount(c => c + 1);
+    if (depth === 0 && onReload) {
+      onReload();
+    } else {
+      fetchNestedData();
+    }
+  }, [depth, onReload, fetchNestedData]);
 
   const renderSegmentContent = (segment, index) => (
     <div key={index} className={styles.segmentContainer} style={segment.style}>
@@ -179,6 +207,14 @@ const AggregationPanel = ({
             {isLoadingNested ? (
               <div className={styles.loader}>
                 <LoaderDots />
+                {showReloadButton && (
+                  <button
+                    onClick={handleReload}
+                    className={styles.reloadButton}
+                  >
+                    <Icon name="refresh-solid" width={20} height={20} fill="#169cee" />
+                  </button>
+                )}
               </div>
             ) : (
               nestedData &&
@@ -213,6 +249,14 @@ const AggregationPanel = ({
       {isLoadingInfoPanel ? (
         <div className={styles.center}>
           <LoaderDots />
+          {showReloadButton && onReload && (
+            <button
+              onClick={handleReload}
+              className={styles.reloadButton}
+            >
+              <Icon name="refresh-outline" width={20} height={20} fill="#169cee" />
+            </button>
+          )}
         </div>
       ) : shouldShowAggregatedData ? (
         <div className={styles.mainContent}>

--- a/src/components/AggregationPanel/AggregationPanel.js
+++ b/src/components/AggregationPanel/AggregationPanel.js
@@ -36,7 +36,9 @@ const AggregationPanel = ({
   const [isLoadingNested, setIsLoadingNested] = useState(false);
   const [showReloadButton, setShowReloadButton] = useState(false);
   const [reloadCount, setReloadCount] = useState(0);
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
   const reloadTimerRef = useRef(null);
+  const elapsedIntervalRef = useRef(null);
 
   useEffect(() => {
     if (Object.keys(errorAggregatedData).length !== 0) {
@@ -54,13 +56,20 @@ const AggregationPanel = ({
 
   useEffect(() => {
     clearTimeout(reloadTimerRef.current);
+    clearInterval(elapsedIntervalRef.current);
     if (isLoading) {
       setShowReloadButton(false);
-      reloadTimerRef.current = setTimeout(() => setShowReloadButton(true), 5_000);
+      setElapsedSeconds(0);
+      elapsedIntervalRef.current = setInterval(() => setElapsedSeconds(s => s + 1), 1_000);
+      reloadTimerRef.current = setTimeout(() => setShowReloadButton(true), 3_000);
     } else {
       setShowReloadButton(false);
+      setElapsedSeconds(0);
     }
-    return () => clearTimeout(reloadTimerRef.current);
+    return () => {
+      clearTimeout(reloadTimerRef.current);
+      clearInterval(elapsedIntervalRef.current);
+    };
   }, [isLoading, reloadCount]);
 
   const shouldShowAggregatedData = useMemo(
@@ -207,6 +216,7 @@ const AggregationPanel = ({
             {isLoadingNested ? (
               <div className={styles.loader}>
                 <LoaderDots />
+                {showReloadButton && <span className={styles.elapsedTimer}>{elapsedSeconds}s</span>}
                 {showReloadButton && (
                   <button
                     onClick={handleReload}
@@ -249,6 +259,7 @@ const AggregationPanel = ({
       {isLoadingInfoPanel ? (
         <div className={styles.center}>
           <LoaderDots />
+          {showReloadButton && onReload && <span className={styles.elapsedTimer}>{elapsedSeconds}s</span>}
           {showReloadButton && onReload && (
             <button
               onClick={handleReload}

--- a/src/components/AggregationPanel/AggregationPanel.js
+++ b/src/components/AggregationPanel/AggregationPanel.js
@@ -216,14 +216,16 @@ const AggregationPanel = ({
             {isLoadingNested ? (
               <div className={styles.loader}>
                 <LoaderDots />
-                {showReloadButton && <span className={styles.elapsedTimer}>{elapsedSeconds}s</span>}
                 {showReloadButton && (
-                  <button
-                    onClick={handleReload}
-                    className={styles.reloadButton}
-                  >
-                    <Icon name="refresh-solid" width={20} height={20} fill="#169cee" />
-                  </button>
+                  <div className={styles.reloadControls}>
+                    <span className={styles.elapsedTimer}>{elapsedSeconds}s</span>
+                    <button
+                      onClick={handleReload}
+                      className={styles.reloadButton}
+                    >
+                      <Icon name="refresh-solid" width={20} height={20} fill="#169cee" />
+                    </button>
+                  </div>
                 )}
               </div>
             ) : (
@@ -259,14 +261,16 @@ const AggregationPanel = ({
       {isLoadingInfoPanel ? (
         <div className={styles.center}>
           <LoaderDots />
-          {showReloadButton && onReload && <span className={styles.elapsedTimer}>{elapsedSeconds}s</span>}
           {showReloadButton && onReload && (
-            <button
-              onClick={handleReload}
-              className={styles.reloadButton}
-            >
-              <Icon name="refresh-outline" width={20} height={20} fill="#169cee" />
-            </button>
+            <div className={styles.reloadControls}>
+              <span className={styles.elapsedTimer}>{elapsedSeconds}s</span>
+              <button
+                onClick={handleReload}
+                className={styles.reloadButton}
+              >
+                <Icon name="refresh-outline" width={20} height={20} fill="#169cee" />
+              </button>
+            </div>
           )}
         </div>
       ) : shouldShowAggregatedData ? (

--- a/src/components/AggregationPanel/AggregationPanel.scss
+++ b/src/components/AggregationPanel/AggregationPanel.scss
@@ -169,6 +169,15 @@
     justify-content: center;
 }
 
+.elapsedTimer {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    color: #999;
+    font-size: 12px;
+    margin-top: 6px;
+}
+
 .reloadButton {
     position: absolute;
     left: 50%;
@@ -179,7 +188,7 @@
     cursor: pointer;
     color: $blue;
     font-size: 13px;
-    margin-top: 8px;
+    margin-top: 16px;
 
     &:hover {
         color: $darkBlue;

--- a/src/components/AggregationPanel/AggregationPanel.scss
+++ b/src/components/AggregationPanel/AggregationPanel.scss
@@ -170,28 +170,30 @@
     justify-content: center;
 }
 
-.elapsedTimer {
+.reloadControls {
     position: absolute;
     left: 50%;
     transform: translateX(-50%);
-    color: #999;
-    font-size: 12px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
     margin-top: 6px;
     animation: fadeIn 0.5s ease-in;
 }
 
+.elapsedTimer {
+    color: #999;
+    font-size: 12px;
+}
+
 .reloadButton {
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
     background: none;
     border: none;
     padding: 8px 12px;
     cursor: pointer;
     color: $blue;
     font-size: 13px;
-    margin-top: 16px;
-    animation: fadeIn 0.5s ease-in;
+    margin-top: 10px;
 
     &:hover {
         color: $darkBlue;

--- a/src/components/AggregationPanel/AggregationPanel.scss
+++ b/src/components/AggregationPanel/AggregationPanel.scss
@@ -163,6 +163,7 @@
 }
 
 .loader {
+    position: relative;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/src/components/AggregationPanel/AggregationPanel.scss
+++ b/src/components/AggregationPanel/AggregationPanel.scss
@@ -176,6 +176,7 @@
     color: #999;
     font-size: 12px;
     margin-top: 6px;
+    animation: fadeIn 0.5s ease-in;
 }
 
 .reloadButton {
@@ -189,14 +190,20 @@
     color: $blue;
     font-size: 13px;
     margin-top: 16px;
+    animation: fadeIn 0.5s ease-in;
 
     &:hover {
         color: $darkBlue;
     }
 }
 
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
 .segmentContainer {
-    border-left: 1px solid #e3e3ea;    
+    border-left: 1px solid #e3e3ea;
     border-bottom: 1px solid #e3e3ea;
     margin-bottom: 16px;
   }

--- a/src/components/AggregationPanel/AggregationPanel.scss
+++ b/src/components/AggregationPanel/AggregationPanel.scss
@@ -164,8 +164,26 @@
 
 .loader {
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
+}
+
+.reloadButton {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    background: none;
+    border: none;
+    padding: 8px 12px;
+    cursor: pointer;
+    color: $blue;
+    font-size: 13px;
+    margin-top: 8px;
+
+    &:hover {
+        color: $darkBlue;
+    }
 }
 
 .segmentContainer {

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -2681,6 +2681,7 @@ export default class DataBrowser extends React.Component {
                             appName={this.props.appName}
                             className={this.props.className}
                             onContextMenu={this.handleAggregationPanelTextContextMenu}
+                            onReload={() => this.props.callCloudFunction(this.state.selectedObjectId, this.props.className, this.props.app.applicationId)}
                           />
                         );
                       }
@@ -2744,6 +2745,7 @@ export default class DataBrowser extends React.Component {
                                 appName={this.props.appName}
                                 className={this.props.className}
                                 onContextMenu={this.handleAggregationPanelTextContextMenu}
+                                onReload={() => this.props.callCloudFunction(objectId, this.props.className, this.props.app.applicationId)}
                               />
                             </div>
                             {index < this.state.displayedObjectIds.length - 1 && (
@@ -2767,6 +2769,7 @@ export default class DataBrowser extends React.Component {
                     appName={this.props.appName}
                     className={this.props.className}
                     onContextMenu={this.handleAggregationPanelTextContextMenu}
+                    onReload={() => this.props.callCloudFunction(this.state.selectedObjectId, this.props.className, this.props.app.applicationId)}
                   />
                 )}
               </div>


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-dashboard/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-dashboard/blob/alpha/LICENSE).

## Feature

Add reload button to info panel on long loading time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reload capability to aggregation panels (top-level and nested) so users can refresh data on demand.
  * Reload control appears after 3 seconds of loading and shows an elapsed time counter while loading.
  * Reload actions now invoke the panel refresh flow so external data sources can be re-requested.

* **Style**
  * Loading UI updated with fade-in animation, repositioned timer/reload button, and adjusted loader layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->