### PR TITLE
feat: Add keyboard shortcut to scroll info panels to top

### DIFF
--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -829,9 +829,33 @@ export default class DataBrowser extends React.Component {
       return;
     }
 
+    // Handle shortcuts that work regardless of cell selection
+    const shortcuts = this.state.keyboardShortcuts;
+
+    // Scroll info panels to top shortcut (only if panels are visible)
+    if (shortcuts && matchesShortcut(e, shortcuts.dataBrowserScrollInfoPanelsToTop)) {
+      if (this.state.isPanelVisible) {
+        // Scroll outer container
+        if (this.aggregationPanelRef?.current) {
+          this.aggregationPanelRef.current.scrollTop = 0;
+        }
+        // Scroll each individual panel column
+        this.panelColumnRefs.forEach((ref) => {
+          if (ref?.current) {
+            ref.current.scrollTop = 0;
+          }
+        });
+        // Pause auto-scroll with 1s resume delay
+        if (this.state.isAutoScrolling) {
+          this.pauseAutoScrollWithResume();
+        }
+        e.preventDefault();
+      }
+      return;
+    }
+
     // Handle "Run script on selected rows" shortcut
     // Only works when in editable mode (onEditSelectedRow exists) and rows are selected
-    const shortcuts = this.state.keyboardShortcuts;
     if (shortcuts && matchesShortcut(e, shortcuts.dataBrowserRunScriptOnSelectedRows)) {
       const selection = this.props.selection || {};
       const selectionLength = Object.keys(selection).length;

--- a/src/dashboard/Settings/KeyboardShortcutsSettings.react.js
+++ b/src/dashboard/Settings/KeyboardShortcutsSettings.react.js
@@ -27,6 +27,7 @@ export default class KeyboardShortcutsSettings extends DashboardView {
       dataBrowserReloadData: '',
       dataBrowserToggleInfoPanels: '',
       dataBrowserRunScriptOnSelectedRows: '',
+      dataBrowserScrollInfoPanelsToTop: '',
       hasChanges: false,
       message: undefined,
       loading: true,
@@ -57,6 +58,7 @@ export default class KeyboardShortcutsSettings extends DashboardView {
         dataBrowserReloadData: shortcuts.dataBrowserReloadData?.key || '',
         dataBrowserToggleInfoPanels: shortcuts.dataBrowserToggleInfoPanels?.key || '',
         dataBrowserRunScriptOnSelectedRows: shortcuts.dataBrowserRunScriptOnSelectedRows?.key || '',
+        dataBrowserScrollInfoPanelsToTop: shortcuts.dataBrowserScrollInfoPanelsToTop?.key || '',
         hasChanges: false,
         loading: false,
       });
@@ -91,6 +93,7 @@ export default class KeyboardShortcutsSettings extends DashboardView {
       dataBrowserReloadData: this.state.dataBrowserReloadData ? createShortcut(this.state.dataBrowserReloadData) : null,
       dataBrowserToggleInfoPanels: this.state.dataBrowserToggleInfoPanels ? createShortcut(this.state.dataBrowserToggleInfoPanels) : null,
       dataBrowserRunScriptOnSelectedRows: this.state.dataBrowserRunScriptOnSelectedRows ? createShortcut(this.state.dataBrowserRunScriptOnSelectedRows) : null,
+      dataBrowserScrollInfoPanelsToTop: this.state.dataBrowserScrollInfoPanelsToTop ? createShortcut(this.state.dataBrowserScrollInfoPanelsToTop) : null,
     };
 
     // Validate shortcuts (only if they are set)
@@ -109,11 +112,22 @@ export default class KeyboardShortcutsSettings extends DashboardView {
       return;
     }
 
-    // Check for duplicates among shortcuts without meta modifier (only if set)
-    if (shortcuts.dataBrowserReloadData && shortcuts.dataBrowserToggleInfoPanels &&
-        shortcuts.dataBrowserReloadData.key.toLowerCase() === shortcuts.dataBrowserToggleInfoPanels.key.toLowerCase()) {
-      this.showNote('Keyboard shortcuts must be unique. Please use different keys.', true);
+    if (shortcuts.dataBrowserScrollInfoPanelsToTop && !isValidShortcut(shortcuts.dataBrowserScrollInfoPanelsToTop)) {
+      this.showNote('Invalid key for "Scroll Info Panels to Top". Please enter a valid key.', true);
       return;
+    }
+
+    // Check for duplicates among shortcuts without meta modifier (only if set)
+    const activeShortcuts = Object.entries(shortcuts)
+      .filter(([, v]) => v?.key)
+      .map(([name, v]) => [name, v.key.toLowerCase()]);
+    const seen = new Set();
+    for (const [, key] of activeShortcuts) {
+      if (seen.has(key)) {
+        this.showNote('Keyboard shortcuts must be unique. Please use different keys.', true);
+        return;
+      }
+      seen.add(key);
     }
 
     try {
@@ -226,6 +240,25 @@ export default class KeyboardShortcutsSettings extends DashboardView {
                   value={this.state.dataBrowserRunScriptOnSelectedRows}
                   disabled={this.state.loading}
                   onChange={this.handleFieldChange.bind(this, 'dataBrowserRunScriptOnSelectedRows')}
+                  onFocus={this.handleInputFocus.bind(this)}
+                  maxLength={1}
+                />
+              }
+            />
+            <Field
+              labelWidth={62}
+              label={
+                <Label
+                  text="Scroll Info Panels to Top"
+                  description={'Scrolls the info panels to the top.'}
+                />
+              }
+              input={
+                <TextInput
+                  placeholder={this.state.loading ? 'Loading...' : DEFAULT_SHORTCUTS.dataBrowserScrollInfoPanelsToTop.key}
+                  value={this.state.dataBrowserScrollInfoPanelsToTop}
+                  disabled={this.state.loading}
+                  onChange={this.handleFieldChange.bind(this, 'dataBrowserScrollInfoPanelsToTop')}
                   onFocus={this.handleInputFocus.bind(this)}
                   maxLength={1}
                 />

--- a/src/lib/KeyboardShortcutsPreferences.js
+++ b/src/lib/KeyboardShortcutsPreferences.js
@@ -15,6 +15,7 @@ export const DEFAULT_SHORTCUTS = {
   dataBrowserReloadData: { key: 'r', ctrl: false, shift: false, alt: false, meta: false },
   dataBrowserToggleInfoPanels: { key: 'p', ctrl: false, shift: false, alt: false, meta: false },
   dataBrowserRunScriptOnSelectedRows: { key: 's', ctrl: false, shift: false, alt: false, meta: false },
+  dataBrowserScrollInfoPanelsToTop: { key: 'u', ctrl: false, shift: false, alt: false, meta: false },
 };
 
 /**


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-dashboard/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-dashboard/blob/alpha/LICENSE).

## Feature

Add keyboard shortcut to scroll info panels to top.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a keyboard shortcut to quickly scroll data browser panels to the top (default: U key). When triggered, the shortcut scrolls all panel columns to the top and pauses any active auto-scroll functionality. Users can fully customize the shortcut key and modifiers through keyboard shortcuts preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->