### PR TITLE
feat: Add support for script execution invoking dashboard form for user input

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,7 +665,9 @@ Return a `ScriptResponse` from the Cloud Function:
 Parse.Cloud.define('assignRole', async (req) => {
   return {
     __type: 'ScriptResponse',
-    payload: { someKey: 'passedThrough' },
+    payload: {
+      requestId: '123-456-789'
+    },
     form: {
       title: 'Assign Role',
       icon: 'gears',
@@ -677,7 +679,6 @@ Parse.Cloud.define('assignRole', async (req) => {
           label: 'Role',
           items: [
             { title: 'Admin', value: 'admin' },
-            { title: 'Team', value: 'moderator' },
             { title: 'User', value: 'user' }
           ]
         }
@@ -693,18 +694,11 @@ Then define the callback Cloud Function that receives the form data:
 
 ```js
 Parse.Cloud.define('assignRoleCallback', async (req) => {
-  const {
-    // Selected Parse Object (pointer)
-    object,
-    // Pass-through data from the initial response
-    payload,
-    // Form values, e.g. { role: 'admin' }
-    formData,
-    } = req.params;
+  const { object, payload, formData } = req.params;
   const role = formData.role;
   object.set('role', role);
   await object.save(null, { useMasterKey: true });
-  return `Assigned role "${role}" to ${object.id}.`;
+  return `Assigned role "${role}" to ${object.id} (request ${payload.requestId}).`;
 }, {
   requireMaster: true
 });

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Parse Dashboard is a standalone dashboard for managing your [Parse Server](https
     - [Persistent Filters](#persistent-filters)
     - [Keyboard Shortcuts](#keyboard-shortcuts)
     - [Scripts](#scripts)
+      - [Script Response Form](#script-response-form)
     - [Resource Cache](#resource-cache)
 - [Running as Express Middleware](#running-as-express-middleware)
   - [Browser Control API (Development Only)](#browser-control-api-development-only)
@@ -653,6 +654,80 @@ Parse.Cloud.define('deleteAccount', async (req) => {
 ```
 
 </details>
+
+#### Script Response Form
+
+A Cloud Function invoked by a script can return a structured response that shows a modal dialog with form elements. When the user submits the form, the values are sent to a callback Cloud Function specified in the response.
+
+Return a `ScriptResponse` from the Cloud Function:
+
+```js
+Parse.Cloud.define('assignRole', async (req) => {
+  return {
+    __type: 'ScriptResponse',
+    payload: { someKey: 'passedThrough' },
+    form: {
+      title: 'Assign Role',
+      icon: 'gears',
+      cloudCodeFunction: 'assignRoleCallback',
+      elements: [
+        {
+          element: 'dropDown',
+          name: 'role',
+          label: 'Role',
+          items: [
+            { title: 'Admin', value: 'admin' },
+            { title: 'Team', value: 'moderator' },
+            { title: 'User', value: 'user' }
+          ]
+        }
+      ]
+    }
+  };
+}, {
+  requireMaster: true
+});
+```
+
+Then define the callback Cloud Function that receives the form data:
+
+```js
+Parse.Cloud.define('assignRoleCallback', async (req) => {
+  const {
+    // Selected Parse Object (pointer)
+    object,
+    // Pass-through data from the initial response
+    payload,
+    // Form values, e.g. { role: 'admin' }
+    formData,
+    } = req.params;
+  const role = formData.role;
+  object.set('role', role);
+  await object.save(null, { useMasterKey: true });
+  return `Assigned role "${role}" to ${object.id}.`;
+}, {
+  requireMaster: true
+});
+```
+
+**Response fields:**
+
+| Field | Type | Optional | Default | Description |
+|---|---|---|---|---|
+| `__type` | `String` | No | - | Must be `"ScriptResponse"` to indicate a structured response. |
+| `payload` | `Object` | Yes | - | Pass-through data forwarded to the callback Cloud Function. |
+| `form.title` | `String` | Yes | `"Script"` | The modal title. |
+| `form.icon` | `String` | Yes | `"gears"` | The modal icon. |
+| `form.cloudCodeFunction` | `String` | Yes | Script `cloudCodeFunction` | The callback Cloud Function to invoke on form submission. |
+| `form.elements` | `Array` | No | - | The form elements to display in the modal. |
+
+**Supported form elements:**
+
+| Element | Fields | Description |
+|---|---|---|
+| `dropDown` | `name`, `label`, `items` | A dropdown menu. Each item has a `title` (display text) and `value`. |
+
+**Batch behavior:** When executing a script on multiple selected rows, the Cloud Function is called for the first object. If the response is a `ScriptResponse`, the modal is shown once. On submission, the callback Cloud Function is called for all selected objects.
 
 ### Resource Cache
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Parse Dashboard is a standalone dashboard for managing your [Parse Server](https
       - [Prefetching](#prefetching)
     - [Scripts](#scripts)
       - [Script Response Form](#script-response-form)
+        - [Response Fields](#response-fields)
+        - [Form Elements](#form-elements)
     - [Graph](#graph)
       - [Calculated Values](#calculated-values)
       - [Formula Operator](#formula-operator)
@@ -1530,7 +1532,7 @@ Parse.Cloud.define('assignRoleCallback', async (req) => {
 });
 ```
 
-**Response fields:**
+##### Response Fields
 
 | Field | Type | Optional | Default | Description |
 |---|---|---|---|---|
@@ -1541,11 +1543,16 @@ Parse.Cloud.define('assignRoleCallback', async (req) => {
 | `form.cloudCodeFunction` | `String` | Yes | Script `cloudCodeFunction` | The callback Cloud Function to invoke on form submission. |
 | `form.elements` | `Array` | No | - | The form elements to display in the modal. |
 
-**Supported form elements:**
+##### Form Elements
 
-| Element | Fields | Description |
-|---|---|---|
-| `dropDown` | `name`, `label`, `items` | A dropdown menu. Each item has a `title` (display text) and `value`. |
+| Property | Type | Optional | Description |
+|------|---|---|---|
+| `dropDown` | - |  - | A dropdown menu. |
+|  `dropDown.name` | `String` | No | The unique field name used to identify this element in the form submission. |
+|  `dropDown.label` | `String` | No | The display label shown above the dropdown. |
+|  `dropDown.items` | `Array` | No | The selectable options. |
+|  `dropDown.items[].title` | `String` | No | The display text of the option. |
+|  `dropDown.items[].value` | `String` | No | The value of the option. |
 
 > [!NOTE]
 > When executing a script on multiple selected rows, the Cloud Function is called for the first object. If the response is a `ScriptResponse`, the modal is shown once. On submission, the callback Cloud Function is called for all selected objects.

--- a/README.md
+++ b/README.md
@@ -51,8 +51,6 @@ Parse Dashboard is a standalone dashboard for managing your [Parse Server](https
     - [Custom order in the filter popup](#custom-order-in-the-filter-popup)
     - [Persistent Filters](#persistent-filters)
     - [Keyboard Shortcuts](#keyboard-shortcuts)
-    - [Scripts](#scripts)
-      - [Script Response Form](#script-response-form)
     - [Resource Cache](#resource-cache)
 - [Running as Express Middleware](#running-as-express-middleware)
   - [Browser Control API (Development Only)](#browser-control-api-development-only)
@@ -89,6 +87,8 @@ Parse Dashboard is a standalone dashboard for managing your [Parse Server](https
         - [Panel Item](#panel-item)
       - [Auto-Scroll](#auto-scroll)
       - [Prefetching](#prefetching)
+    - [Scripts](#scripts)
+      - [Script Response Form](#script-response-form)
     - [Graph](#graph)
       - [Calculated Values](#calculated-values)
       - [Formula Operator](#formula-operator)
@@ -550,178 +550,6 @@ You can conveniently create a filter definition without having to write it by ha
 Configure custom keyboard shortcuts for dashboard actions in **App Settings > Keyboard Shortcuts**.
 
 Delete a shortcut key to disable the shortcut.
-
-### Scripts
-
-You can specify scripts to execute Cloud Functions with the `scripts` option:
-
-```json
-"apps": [
-  {
-    "scripts": [
-      {
-        "title": "Delete Account",
-        "classes": ["_User"],
-        "cloudCodeFunction": "deleteAccount",
-        "showConfirmationDialog": true,
-        "confirmationDialogStyle": "critical"
-      }
-    ]
-  }
-]
-```
-
-You can also specify custom fields with the `scrips` option:
-
-```json
-"apps": [
-  {
-    "scripts": [
-      {
-        "title": "Delete account",
-        "classes": [
-          {
-            "name": "_User",
-            "fields": [
-              { "name": "createdAt", "validator": "value => value > new Date(\"2025\")" }
-            ]
-          }
-        ],
-        "cloudCodeFunction": "deleteAccount"
-      }
-    ]
-  }
-]
-
-```
-
-Next, define the Cloud Function in Parse Server that will be called. The object that has been selected in the data browser will be made available as a request parameter:
-
-```js
-Parse.Cloud.define('deleteAccount', async (req) => {
-  req.params.object.set('deleted', true);
-  await req.params.object.save(null, {useMasterKey: true});
-}, {
-  requireMaster: true
-});
-```
-
-The field which the script was invoked on can be accessed by `selectedField`:
-
-```js
-Parse.Cloud.define('deleteAccount', async (req) => {
-  if (req.params.selectedField !== 'objectId') {
-    throw new Parse.Error(Parse.Error.SCRIPT_FAILED, 'Deleting accounts is only available on the objectId field.');
-  }
-  req.params.object.set('deleted', true);
-  await req.params.object.save(null, {useMasterKey: true});
-}, {
-  requireMaster: true
-});
-```
-
-⚠️ Depending on your Parse Server version you may need to set the Parse Server option `encodeParseObjectInCloudFunction` to `true` so that the selected object in the data browser is made available in the Cloud Function as an instance of `Parse.Object`. If the option is not set, is set to `false`, or you are using an older version of Parse Server, the object is made available as a plain JavaScript object and needs to be converted from a JSON object to a `Parse.Object` instance with `req.params.object = Parse.Object.fromJSON(req.params.object);`, before you can call any `Parse.Object` properties and methods on it.
-
-For older versions of Parse Server:
-
-<details>
-<summary>Parse Server &gt;=4.4.0 &lt;6.2.0</summary>
-
-```js
-Parse.Cloud.define('deleteAccount', async (req) => {
-  req.params.object = Parse.Object.fromJSON(req.params.object);
-  req.params.object.set('deleted', true);
-  await req.params.object.save(null, {useMasterKey: true});
-}, {
-  requireMaster: true
-});
-```
-
-</details>
-
-<details>
-<summary>Parse Server &gt;=2.1.4 &lt;4.4.0</summary>
-
-```js
-Parse.Cloud.define('deleteAccount', async (req) => {
-  if (!req.master || !req.params.object) {
-    throw 'Unauthorized';
-  }
-  req.params.object = Parse.Object.fromJSON(req.params.object);
-  req.params.object.set('deleted', true);
-  await req.params.object.save(null, {useMasterKey: true});
-});
-```
-
-</details>
-
-#### Script Response Form
-
-A Cloud Function invoked by a script can return a structured response that shows a modal dialog with form elements. When the user submits the form, the values are sent to a callback Cloud Function specified in the response.
-
-Return a `ScriptResponse` from the Cloud Function:
-
-```js
-Parse.Cloud.define('assignRole', async (req) => {
-  return {
-    __type: 'ScriptResponse',
-    payload: {
-      requestId: '123-456-789'
-    },
-    form: {
-      title: 'Assign Role',
-      icon: 'gears',
-      cloudCodeFunction: 'assignRoleCallback',
-      elements: [
-        {
-          element: 'dropDown',
-          name: 'role',
-          label: 'Role',
-          items: [
-            { title: 'Admin', value: 'admin' },
-            { title: 'User', value: 'user' }
-          ]
-        }
-      ]
-    }
-  };
-}, {
-  requireMaster: true
-});
-```
-
-Then define the callback Cloud Function that receives the form data:
-
-```js
-Parse.Cloud.define('assignRoleCallback', async (req) => {
-  const { object, payload, formData } = req.params;
-  const role = formData.role;
-  object.set('role', role);
-  await object.save(null, { useMasterKey: true });
-  return `Assigned role "${role}" to ${object.id} (request ${payload.requestId}).`;
-}, {
-  requireMaster: true
-});
-```
-
-**Response fields:**
-
-| Field | Type | Optional | Default | Description |
-|---|---|---|---|---|
-| `__type` | `String` | No | - | Must be `"ScriptResponse"` to indicate a structured response. |
-| `payload` | `Object` | Yes | - | Pass-through data forwarded to the callback Cloud Function. |
-| `form.title` | `String` | Yes | `"Script"` | The modal title. |
-| `form.icon` | `String` | Yes | `"gears"` | The modal icon. |
-| `form.cloudCodeFunction` | `String` | Yes | Script `cloudCodeFunction` | The callback Cloud Function to invoke on form submission. |
-| `form.elements` | `Array` | No | - | The form elements to display in the modal. |
-
-**Supported form elements:**
-
-| Element | Fields | Description |
-|---|---|---|
-| `dropDown` | `name`, `label`, `items` | A dropdown menu. Each item has a `title` (display text) and `value`. |
-
-**Batch behavior:** When executing a script on multiple selected rows, the Cloud Function is called for the first object. If the response is a `ScriptResponse`, the modal is shown once. On submission, the callback Cloud Function is called for all selected objects.
 
 ### Resource Cache
 
@@ -1548,6 +1376,179 @@ To reduce the time for info panel data to appear, data can be prefetched.
 Prefetching is particularly useful when navigating through lists of objects. To optimize performance and avoid unnecessary data loading, prefetching is triggered only after the user has moved through 3 consecutive rows using the keyboard down-arrow key or by mouse click.
 
 When `prefetchObjects` is enabled, media content (images, videos, and audio) in the info panel can also be prefetched to improve loading performance. By default, all media types are prefetched, but you can selectively disable prefetching for specific media types using the `prefetchImage`, `prefetchVideo`, and `prefetchAudio` options.
+
+### Scripts
+
+You can specify scripts to execute Cloud Functions with the `scripts` option:
+
+```json
+"apps": [
+  {
+    "scripts": [
+      {
+        "title": "Delete Account",
+        "classes": ["_User"],
+        "cloudCodeFunction": "deleteAccount",
+        "showConfirmationDialog": true,
+        "confirmationDialogStyle": "critical"
+      }
+    ]
+  }
+]
+```
+
+You can also specify custom fields with the `scrips` option:
+
+```json
+"apps": [
+  {
+    "scripts": [
+      {
+        "title": "Delete account",
+        "classes": [
+          {
+            "name": "_User",
+            "fields": [
+              { "name": "createdAt", "validator": "value => value > new Date(\"2025\")" }
+            ]
+          }
+        ],
+        "cloudCodeFunction": "deleteAccount"
+      }
+    ]
+  }
+]
+
+```
+
+Next, define the Cloud Function in Parse Server that will be called. The object that has been selected in the data browser will be made available as a request parameter:
+
+```js
+Parse.Cloud.define('deleteAccount', async (req) => {
+  req.params.object.set('deleted', true);
+  await req.params.object.save(null, {useMasterKey: true});
+}, {
+  requireMaster: true
+});
+```
+
+The field which the script was invoked on can be accessed by `selectedField`:
+
+```js
+Parse.Cloud.define('deleteAccount', async (req) => {
+  if (req.params.selectedField !== 'objectId') {
+    throw new Parse.Error(Parse.Error.SCRIPT_FAILED, 'Deleting accounts is only available on the objectId field.');
+  }
+  req.params.object.set('deleted', true);
+  await req.params.object.save(null, {useMasterKey: true});
+}, {
+  requireMaster: true
+});
+```
+
+⚠️ Depending on your Parse Server version you may need to set the Parse Server option `encodeParseObjectInCloudFunction` to `true` so that the selected object in the data browser is made available in the Cloud Function as an instance of `Parse.Object`. If the option is not set, is set to `false`, or you are using an older version of Parse Server, the object is made available as a plain JavaScript object and needs to be converted from a JSON object to a `Parse.Object` instance with `req.params.object = Parse.Object.fromJSON(req.params.object);`, before you can call any `Parse.Object` properties and methods on it.
+
+For older versions of Parse Server:
+
+<details>
+<summary>Parse Server &gt;=4.4.0 &lt;6.2.0</summary>
+
+```js
+Parse.Cloud.define('deleteAccount', async (req) => {
+  req.params.object = Parse.Object.fromJSON(req.params.object);
+  req.params.object.set('deleted', true);
+  await req.params.object.save(null, {useMasterKey: true});
+}, {
+  requireMaster: true
+});
+```
+
+</details>
+
+<details>
+<summary>Parse Server &gt;=2.1.4 &lt;4.4.0</summary>
+
+```js
+Parse.Cloud.define('deleteAccount', async (req) => {
+  if (!req.master || !req.params.object) {
+    throw 'Unauthorized';
+  }
+  req.params.object = Parse.Object.fromJSON(req.params.object);
+  req.params.object.set('deleted', true);
+  await req.params.object.save(null, {useMasterKey: true});
+});
+```
+
+</details>
+
+#### Script Response Form
+
+A Cloud Function invoked by a script can return a structured response that shows a modal dialog with form elements. When the user submits the form, the values are sent to a callback Cloud Function specified in the response.
+
+Return a `ScriptResponse` from the Cloud Function:
+
+```js
+Parse.Cloud.define('assignRole', async (req) => {
+  return {
+    __type: 'ScriptResponse',
+    payload: {
+      requestId: '123-456-789'
+    },
+    form: {
+      title: 'Assign Role',
+      icon: 'gears',
+      cloudCodeFunction: 'assignRoleCallback',
+      elements: [
+        {
+          element: 'dropDown',
+          name: 'role',
+          label: 'Role',
+          items: [
+            { title: 'Admin', value: 'admin' },
+            { title: 'User', value: 'user' }
+          ]
+        }
+      ]
+    }
+  };
+}, {
+  requireMaster: true
+});
+```
+
+Then define the callback Cloud Function that receives the form data:
+
+```js
+Parse.Cloud.define('assignRoleCallback', async (req) => {
+  const { object, payload, formData } = req.params;
+  const role = formData.role;
+  object.set('role', role);
+  await object.save(null, { useMasterKey: true });
+  return `Assigned role "${role}" to ${object.id} (request ${payload.requestId}).`;
+}, {
+  requireMaster: true
+});
+```
+
+**Response fields:**
+
+| Field | Type | Optional | Default | Description |
+|---|---|---|---|---|
+| `__type` | `String` | No | - | Must be `"ScriptResponse"` to indicate a structured response. |
+| `payload` | `Object` | Yes | - | Pass-through data forwarded to the callback Cloud Function. |
+| `form.title` | `String` | Yes | `"Script"` | The modal title. |
+| `form.icon` | `String` | Yes | `"gears"` | The modal icon. |
+| `form.cloudCodeFunction` | `String` | Yes | Script `cloudCodeFunction` | The callback Cloud Function to invoke on form submission. |
+| `form.elements` | `Array` | No | - | The form elements to display in the modal. |
+
+**Supported form elements:**
+
+| Element | Fields | Description |
+|---|---|---|
+| `dropDown` | `name`, `label`, `items` | A dropdown menu. Each item has a `title` (display text) and `value`. |
+
+> [!NOTE]
+> When executing a script on multiple selected rows, the Cloud Function is called for the first object. If the response is a `ScriptResponse`, the modal is shown once. On submission, the callback Cloud Function is called for all selected objects.
 
 ### Graph
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Parse Dashboard is a standalone dashboard for managing your [Parse Server](https
       - [Script Response Form](#script-response-form)
         - [Response Fields](#response-fields)
         - [Form Elements](#form-elements)
+          - [Drop-Down](#drop-down)
     - [Graph](#graph)
       - [Calculated Values](#calculated-values)
       - [Formula Operator](#formula-operator)
@@ -1399,7 +1400,7 @@ You can specify scripts to execute Cloud Functions with the `scripts` option:
 ]
 ```
 
-You can also specify custom fields with the `scrips` option:
+You can also specify custom fields with the `scripts` option:
 
 ```json
 "apps": [
@@ -1532,6 +1533,9 @@ Parse.Cloud.define('assignRoleCallback', async (req) => {
 });
 ```
 
+> [!NOTE]
+> When executing a script on multiple selected rows, the Cloud Function is called for the first object. If the response is a `ScriptResponse`, the modal is shown once. On submission, the callback Cloud Function is called for all selected objects.
+
 ##### Response Fields
 
 | Field | Type | Optional | Default | Description |
@@ -1545,17 +1549,21 @@ Parse.Cloud.define('assignRoleCallback', async (req) => {
 
 ##### Form Elements
 
-| Property | Type | Optional | Description |
-|------|---|---|---|
-| `dropDown` | - |  - | A dropdown menu. |
-|  `dropDown.name` | `String` | No | The unique field name used to identify this element in the form submission. |
-|  `dropDown.label` | `String` | No | The display label shown above the dropdown. |
-|  `dropDown.items` | `Array` | No | The selectable options. |
-|  `dropDown.items[].title` | `String` | No | The display text of the option. |
-|  `dropDown.items[].value` | `String` | No | The value of the option. |
+| Parameter | Value  | Optional | Description                      |
+|-----------|--------|----------|----------------------------------|
+|  `elements` | `Array` | No | The form elements. Elements are rendered in the order they are defined. |
 
-> [!NOTE]
-> When executing a script on multiple selected rows, the Cloud Function is called for the first object. If the response is a `ScriptResponse`, the modal is shown once. On submission, the callback Cloud Function is called for all selected objects.
+###### Drop-Down
+
+A drop-down to select a single item from a list.
+
+| Parameter | Value  | Optional | Description                      |
+|-----------|--------|----------|----------------------------------|
+| `element`    | `String` | No       | Must be `"dropDown"`.         |
+| `label`     | `String` | No       | The display label shown next to the dropdown. |
+|  `items` | `Array` | No | The selectable options. |
+|  `items[].title` | `String` | No | The display text of the option. |
+|  `items[].value` | `String` | No | The value of the option. |
 
 ### Graph
 

--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -401,7 +401,8 @@ export default class BrowserCell extends Component {
       this.props.objectId,
       this.props.showNote,
       this.props.reloadDataTableAfterScript ? this.props.onRefresh : null,
-      this.props.reloadDataTableAfterScript ? null : this.props.onRefreshObjects
+      this.props.reloadDataTableAfterScript ? null : this.props.onRefreshObjects,
+      this.props.onScriptModalResponse
     );
   }
 

--- a/src/components/BrowserRow/BrowserRow.react.js
+++ b/src/components/BrowserRow/BrowserRow.react.js
@@ -187,6 +187,7 @@ export default class BrowserRow extends Component {
               onRefresh={this.props.onRefresh}
               onRefreshObjects={this.props.onRefreshObjects}
               reloadDataTableAfterScript={this.props.reloadDataTableAfterScript}
+              onScriptModalResponse={this.props.onScriptModalResponse}
               scripts={this.props.scripts}
               handleCellClick={this.props.handleCellClick}
               selectedCells={this.props.selectedCells}

--- a/src/components/FormModal/FormModal.react.js
+++ b/src/components/FormModal/FormModal.react.js
@@ -17,6 +17,15 @@ export default class FormModal extends React.Component {
       errorMessage: '',
       inProgress: false,
     };
+    this._isMounted = false;
+  }
+
+  componentDidMount() {
+    this._isMounted = true;
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
   }
 
   render() {
@@ -55,13 +64,17 @@ export default class FormModal extends React.Component {
               onClose();
               clearFields();
               onSuccess(result);
-              this.setState({ inProgress: false });
+              if (this._isMounted) {
+                this.setState({ inProgress: false });
+              }
             })
             .catch(({ message, error, notice, errors = [] }) => {
-              this.setState({
-                errorMessage: errors.join(' ') || message || error || notice || 'An error occurred',
-                inProgress: false,
-              });
+              if (this._isMounted) {
+                this.setState({
+                  errorMessage: errors.join(' ') || message || error || notice || 'An error occurred',
+                  inProgress: false,
+                });
+              }
             });
         }}
         onCancel={() => {

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -2185,9 +2185,10 @@ class Browser extends DashboardView {
     this.setState({ scriptResponseModal: null });
   }
 
-  async confirmScriptResponseModal(formData) {
+  confirmScriptResponseModal(formData) {
     const { form, payload, className, objectIds } = this.state.scriptResponseModal;
-    await executeScriptCallback(
+    this.setState({ scriptResponseModal: null, selection: {} });
+    executeScriptCallback(
       form.cloudCodeFunction,
       className,
       objectIds,
@@ -2197,7 +2198,6 @@ class Browser extends DashboardView {
       this.state.reloadDataTableAfterScript ? this.refresh : null,
       this.state.reloadDataTableAfterScript ? null : (ids) => this.dataBrowserRef.current?.handleRefreshObjects(ids)
     );
-    this.setState({ selection: {} });
   }
 
   async confirmExecuteScriptRows(script) {

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -3144,6 +3144,15 @@ class Browser extends DashboardView {
           onConfirm={this.confirmAttachSelectedRows}
         />
       );
+    } else if (this.state.scriptResponseModal) {
+      extras = (
+        <ScriptResponseModal
+          form={this.state.scriptResponseModal.form}
+          objectIds={this.state.scriptResponseModal.objectIds}
+          onCancel={this.cancelScriptResponseModal}
+          onConfirm={this.confirmScriptResponseModal}
+        />
+      );
     } else if (this.state.showExecuteScriptRowsDialog) {
       extras = (
         <ExecuteScriptRowsDialog
@@ -3152,14 +3161,6 @@ class Browser extends DashboardView {
           onCancel={this.cancelExecuteScriptRowsDialog}
           onConfirm={this.confirmExecuteScriptRows}
           processedScripts={this.state.processedScripts}
-        />
-      );
-    } else if (this.state.scriptResponseModal) {
-      extras = (
-        <ScriptResponseModal
-          form={this.state.scriptResponseModal.form}
-          onCancel={this.cancelScriptResponseModal}
-          onConfirm={this.confirmScriptResponseModal}
         />
       );
     } else if (this.state.showCloneSelectedRowsDialog) {

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -20,6 +20,7 @@ import DeleteRowsDialog from 'dashboard/Data/Browser/DeleteRowsDialog.react';
 import DropClassDialog from 'dashboard/Data/Browser/DropClassDialog.react';
 import EditRowDialog from 'dashboard/Data/Browser/EditRowDialog.react';
 import ExecuteScriptRowsDialog from 'dashboard/Data/Browser/ExecuteScriptRowsDialog.react';
+import ScriptResponseModal from 'dashboard/Data/Browser/ScriptResponseModal.react';
 import ExportDialog from 'dashboard/Data/Browser/ExportDialog.react';
 import ExportSchemaDialog from 'dashboard/Data/Browser/ExportSchemaDialog.react';
 import ExportSelectedRowsDialog from 'dashboard/Data/Browser/ExportSelectedRowsDialog.react';
@@ -43,6 +44,7 @@ import subscribeTo from 'lib/subscribeTo';
 import { withRouter } from 'lib/withRouter';
 import FilterPreferencesManager from 'lib/FilterPreferencesManager';
 import { prefersServerStorage } from 'lib/StoragePreferences';
+import { isModalResponse, executeScriptCallback } from 'lib/ScriptUtils';
 import Parse from 'parse';
 import React from 'react';
 import { Helmet } from 'react-helmet';
@@ -201,6 +203,8 @@ class Browser extends DashboardView {
       selectedCellsCount: 0,
       selectedData: [],
 
+      scriptResponseModal: null,
+
       // Cloud Config array params for context menu
       arrayConfigParams: [],
       showAddToConfigDialog: false,
@@ -237,6 +241,9 @@ class Browser extends DashboardView {
     this.showExecuteScriptRowsDialog = this.showExecuteScriptRowsDialog.bind(this);
     this.confirmExecuteScriptRows = this.confirmExecuteScriptRows.bind(this);
     this.cancelExecuteScriptRowsDialog = this.cancelExecuteScriptRowsDialog.bind(this);
+    this.handleScriptModalResponse = this.handleScriptModalResponse.bind(this);
+    this.cancelScriptResponseModal = this.cancelScriptResponseModal.bind(this);
+    this.confirmScriptResponseModal = this.confirmScriptResponseModal.bind(this);
     this.refreshObjects = this.refreshObjects.bind(this);
     this.toggleReloadDataTableAfterScript = this.toggleReloadDataTableAfterScript.bind(this);
     this.confirmAttachSelectedRows = this.confirmAttachSelectedRows.bind(this);
@@ -2161,6 +2168,38 @@ class Browser extends DashboardView {
     });
   }
 
+  handleScriptModalResponse({ response, script, className, objectIds }) {
+    this.setState({
+      showExecuteScriptRowsDialog: false,
+      scriptResponseModal: {
+        modal: response.modal,
+        payload: response.payload,
+        script,
+        className,
+        objectIds,
+      },
+    });
+  }
+
+  cancelScriptResponseModal() {
+    this.setState({ scriptResponseModal: null });
+  }
+
+  async confirmScriptResponseModal(formData) {
+    const { modal, payload, className, objectIds } = this.state.scriptResponseModal;
+    await executeScriptCallback(
+      modal.cloudCodeFunction,
+      className,
+      objectIds,
+      payload,
+      formData,
+      this.showNote,
+      this.state.reloadDataTableAfterScript ? this.refresh : null,
+      this.state.reloadDataTableAfterScript ? null : (ids) => this.dataBrowserRef.current?.handleRefreshObjects(ids)
+    );
+    this.setState({ selection: {} });
+  }
+
   async confirmExecuteScriptRows(script) {
     const batchSize = script.executionBatchSize || 1;
     try {
@@ -2168,13 +2207,64 @@ class Browser extends DashboardView {
         Parse.Object.extend(this.props.params.className).createWithoutData(key)
       );
 
-      let totalErrorCount = 0;
-      let batchCount = 0;
-      const totalBatchCount = Math.ceil(objects.length / batchSize);
+      // Probe first object for modal response
+      const probeResponse = await Parse.Cloud.run(
+        script.cloudCodeFunction,
+        { object: objects[0].toPointer() },
+        { useMasterKey: true }
+      ).catch(error => ({ __probeError: error }));
 
-      for (let i = 0; i < objects.length; i += batchSize) {
+      if (isModalResponse(probeResponse)) {
+        this.handleScriptModalResponse({
+          response: probeResponse,
+          script,
+          className: this.props.params.className,
+          objectIds: objects.map(o => o.id),
+        });
+        return;
+      }
+
+      // Handle probe result for first object
+      this.setState(prevState => ({
+        processedScripts: prevState.processedScripts + 1,
+      }));
+
+      if (probeResponse?.__probeError) {
+        const error = probeResponse.__probeError;
+        const errorMessage = `Error running script "${script.title}" on "${objects[0].id}": ${error.message}`;
+        this.showNote(errorMessage, true);
+      } else {
+        const note =
+          (typeof probeResponse === 'object' ? JSON.stringify(probeResponse) : probeResponse) ||
+          `Ran script "${script.title}" on "${objects[0].id}".`;
+        this.showNote(note);
+      }
+
+      // Continue with remaining objects
+      const remainingObjects = objects.slice(1);
+      if (remainingObjects.length === 0) {
+        const objectIds = objects.map(obj => obj.id);
+        if (this.state.reloadDataTableAfterScript) {
+          this.setState(
+            { selection: {}, showExecuteScriptRowsDialog: false },
+            () => this.refresh()
+          );
+        } else {
+          this.setState(
+            { selection: {}, showExecuteScriptRowsDialog: false },
+            () => this.dataBrowserRef.current?.handleRefreshObjects(objectIds)
+          );
+        }
+        return;
+      }
+
+      let totalErrorCount = probeResponse?.__probeError ? 1 : 0;
+      let batchCount = 0;
+      const totalBatchCount = Math.ceil(remainingObjects.length / batchSize) + 1;
+
+      for (let i = 0; i < remainingObjects.length; i += batchSize) {
         batchCount++;
-        const batch = objects.slice(i, i + batchSize);
+        const batch = remainingObjects.slice(i, i + batchSize);
         const promises = batch.map(object =>
           Parse.Cloud.run(
             script.cloudCodeFunction,
@@ -2216,7 +2306,7 @@ class Browser extends DashboardView {
 
         if (objects.length > 1) {
           this.showNote(
-            `Ran script "${script.title}" on ${batch.length} objects in batch ${batchCount}/${totalBatchCount} with ${batchErrorCount} errors.`,
+            `Ran script "${script.title}" on ${batch.length} objects in batch ${batchCount + 1}/${totalBatchCount} with ${batchErrorCount} errors.`,
             batchErrorCount > 0
           );
         }
@@ -2224,7 +2314,7 @@ class Browser extends DashboardView {
 
       if (objects.length > 1) {
         this.showNote(
-          `Ran script "${script.title}" on ${objects.length} objects in ${batchCount} batches with ${totalErrorCount} errors.`,
+          `Ran script "${script.title}" on ${objects.length} objects in ${batchCount + 1} batches with ${totalErrorCount} errors.`,
           totalErrorCount > 0
         );
       }
@@ -2858,6 +2948,7 @@ class Browser extends DashboardView {
               onRefreshObjects={this.refreshObjects}
               reloadDataTableAfterScript={this.state.reloadDataTableAfterScript}
               toggleReloadDataTableAfterScript={this.toggleReloadDataTableAfterScript}
+              onScriptModalResponse={this.handleScriptModalResponse}
               onAttachRows={this.showAttachRowsDialog}
               onAttachSelectedRows={this.showAttachSelectedRowsDialog}
               onExecuteScriptRows={this.showExecuteScriptRowsDialog}
@@ -3061,6 +3152,14 @@ class Browser extends DashboardView {
           onCancel={this.cancelExecuteScriptRowsDialog}
           onConfirm={this.confirmExecuteScriptRows}
           processedScripts={this.state.processedScripts}
+        />
+      );
+    } else if (this.state.scriptResponseModal) {
+      extras = (
+        <ScriptResponseModal
+          modal={this.state.scriptResponseModal.modal}
+          onCancel={this.cancelScriptResponseModal}
+          onConfirm={this.confirmScriptResponseModal}
         />
       );
     } else if (this.state.showCloneSelectedRowsDialog) {

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -44,7 +44,7 @@ import subscribeTo from 'lib/subscribeTo';
 import { withRouter } from 'lib/withRouter';
 import FilterPreferencesManager from 'lib/FilterPreferencesManager';
 import { prefersServerStorage } from 'lib/StoragePreferences';
-import { isModalResponse, executeScriptCallback } from 'lib/ScriptUtils';
+import { isFormResponse, executeScriptCallback } from 'lib/ScriptUtils';
 import Parse from 'parse';
 import React from 'react';
 import { Helmet } from 'react-helmet';
@@ -2172,7 +2172,7 @@ class Browser extends DashboardView {
     this.setState({
       showExecuteScriptRowsDialog: false,
       scriptResponseModal: {
-        modal: response.modal,
+        form: response.form,
         payload: response.payload,
         script,
         className,
@@ -2186,9 +2186,9 @@ class Browser extends DashboardView {
   }
 
   async confirmScriptResponseModal(formData) {
-    const { modal, payload, className, objectIds } = this.state.scriptResponseModal;
+    const { form, payload, className, objectIds } = this.state.scriptResponseModal;
     await executeScriptCallback(
-      modal.cloudCodeFunction,
+      form.cloudCodeFunction,
       className,
       objectIds,
       payload,
@@ -2214,7 +2214,7 @@ class Browser extends DashboardView {
         { useMasterKey: true }
       ).catch(error => ({ __probeError: error }));
 
-      if (isModalResponse(probeResponse)) {
+      if (isFormResponse(probeResponse)) {
         this.handleScriptModalResponse({
           response: probeResponse,
           script,
@@ -3157,7 +3157,7 @@ class Browser extends DashboardView {
     } else if (this.state.scriptResponseModal) {
       extras = (
         <ScriptResponseModal
-          modal={this.state.scriptResponseModal.modal}
+          form={this.state.scriptResponseModal.form}
           onCancel={this.cancelScriptResponseModal}
           onConfirm={this.confirmScriptResponseModal}
         />

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -2186,10 +2186,10 @@ class Browser extends DashboardView {
   }
 
   confirmScriptResponseModal(formData) {
-    const { form, payload, className, objectIds } = this.state.scriptResponseModal;
+    const { form, payload, script, className, objectIds } = this.state.scriptResponseModal;
     this.setState({ scriptResponseModal: null, selection: {} });
     executeScriptCallback(
-      form.cloudCodeFunction,
+      form.cloudCodeFunction || script.cloudCodeFunction,
       className,
       objectIds,
       payload,

--- a/src/dashboard/Data/Browser/BrowserTable.react.js
+++ b/src/dashboard/Data/Browser/BrowserTable.react.js
@@ -200,6 +200,7 @@ export default class BrowserTable extends React.Component {
                     onRefresh={this.props.onRefresh}
                     onRefreshObjects={this.props.onRefreshObjects}
                     reloadDataTableAfterScript={this.props.reloadDataTableAfterScript}
+                    onScriptModalResponse={this.props.onScriptModalResponse}
                     scripts={this.context.scripts}
                     selectedCells={this.props.selectedCells}
                     handleCellClick={this.props.handleCellClick}
@@ -387,6 +388,7 @@ export default class BrowserTable extends React.Component {
             onRefresh={this.props.onRefresh}
             onRefreshObjects={this.props.onRefreshObjects}
             reloadDataTableAfterScript={this.props.reloadDataTableAfterScript}
+            onScriptModalResponse={this.props.onScriptModalResponse}
             scripts={this.context.scripts}
             selectedCells={this.props.selectedCells}
             handleCellClick={this.props.handleCellClick}

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -1342,7 +1342,8 @@ export default class DataBrowser extends React.Component {
                   objectId,
                   this.props.showNote,
                   this.props.reloadDataTableAfterScript ? this.props.onRefresh : null,
-                  this.props.reloadDataTableAfterScript ? null : this.handleRefreshObjects
+                  this.props.reloadDataTableAfterScript ? null : this.handleRefreshObjects,
+                  this.props.onScriptModalResponse
                 );
               }
             },
@@ -2953,7 +2954,8 @@ export default class DataBrowser extends React.Component {
                 this.state.selectedScript.objectId,
                 this.props.showNote,
                 this.props.reloadDataTableAfterScript ? this.props.onRefresh : null,
-                this.props.reloadDataTableAfterScript ? null : this.handleRefreshObjects
+                this.props.reloadDataTableAfterScript ? null : this.handleRefreshObjects,
+                this.props.onScriptModalResponse
               );
               this.setState({ showScriptConfirmationDialog: false, selectedScript: null });
             }}

--- a/src/dashboard/Data/Browser/ScriptResponseModal.react.js
+++ b/src/dashboard/Data/Browser/ScriptResponseModal.react.js
@@ -6,7 +6,7 @@
  * the root directory of this source tree.
  */
 import React from 'react';
-import FormModal from 'components/FormModal/FormModal.react';
+import Modal from 'components/Modal/Modal.react';
 import Field from 'components/Field/Field.react';
 import Label from 'components/Label/Label.react';
 import Dropdown from 'components/Dropdown/Dropdown.react';
@@ -29,7 +29,7 @@ export default class ScriptResponseModal extends React.Component {
   }
 
   handleConfirm() {
-    return this.props.onConfirm(this.state.formData);
+    this.props.onConfirm(this.state.formData);
   }
 
   renderElement(element, index) {
@@ -68,18 +68,17 @@ export default class ScriptResponseModal extends React.Component {
     const { form, onCancel } = this.props;
 
     return (
-      <FormModal
-        open
+      <Modal
+        type={Modal.Types.VALID}
         icon={form.icon || 'gears'}
         iconSize={40}
         title={form.title || 'Script'}
-        submitText="Submit"
-        inProgressText="Submitting\u2026"
-        onClose={onCancel}
-        onSubmit={this.handleConfirm}
+        confirmText="Submit"
+        onConfirm={this.handleConfirm}
+        onCancel={onCancel}
       >
         {(form.elements || []).map((element, index) => this.renderElement(element, index))}
-      </FormModal>
+      </Modal>
     );
   }
 }

--- a/src/dashboard/Data/Browser/ScriptResponseModal.react.js
+++ b/src/dashboard/Data/Browser/ScriptResponseModal.react.js
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2016-present, Parse, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+import React from 'react';
+import FormModal from 'components/FormModal/FormModal.react';
+import Field from 'components/Field/Field.react';
+import Label from 'components/Label/Label.react';
+import Dropdown from 'components/Dropdown/Dropdown.react';
+import Option from 'components/Dropdown/Option.react';
+
+export default class ScriptResponseModal extends React.Component {
+  constructor(props) {
+    super(props);
+
+    const formData = {};
+    (props.modal?.elements || []).forEach((element, index) => {
+      const key = element.name || String(index);
+      if (element.element === 'dropDown' && element.items?.length > 0) {
+        formData[key] = element.items[0].value;
+      }
+    });
+
+    this.state = { formData };
+    this.handleConfirm = this.handleConfirm.bind(this);
+  }
+
+  handleConfirm() {
+    return this.props.onConfirm(this.state.formData);
+  }
+
+  renderElement(element, index) {
+    const key = element.name || String(index);
+
+    if (element.element === 'dropDown') {
+      return (
+        <Field
+          key={key}
+          label={<Label text={element.label || element.name || 'Select'} />}
+          input={
+            <Dropdown
+              fixed={true}
+              value={this.state.formData[key]}
+              onChange={value =>
+                this.setState(prev => ({
+                  formData: { ...prev.formData, [key]: value },
+                }))
+              }
+            >
+              {(element.items || []).map(item => (
+                <Option key={item.value} value={item.value}>
+                  {item.title}
+                </Option>
+              ))}
+            </Dropdown>
+          }
+        />
+      );
+    }
+
+    return null;
+  }
+
+  render() {
+    const { modal, onCancel } = this.props;
+
+    return (
+      <FormModal
+        open
+        icon={modal.icon || 'gears'}
+        iconSize={40}
+        title={modal.title || 'Script'}
+        submitText="Submit"
+        inProgressText="Submitting\u2026"
+        onClose={onCancel}
+        onSubmit={this.handleConfirm}
+      >
+        {(modal.elements || []).map((element, index) => this.renderElement(element, index))}
+      </FormModal>
+    );
+  }
+}

--- a/src/dashboard/Data/Browser/ScriptResponseModal.react.js
+++ b/src/dashboard/Data/Browser/ScriptResponseModal.react.js
@@ -17,7 +17,7 @@ export default class ScriptResponseModal extends React.Component {
     super(props);
 
     const formData = {};
-    (props.modal?.elements || []).forEach((element, index) => {
+    (props.form?.elements || []).forEach((element, index) => {
       const key = element.name || String(index);
       if (element.element === 'dropDown' && element.items?.length > 0) {
         formData[key] = element.items[0].value;
@@ -65,20 +65,20 @@ export default class ScriptResponseModal extends React.Component {
   }
 
   render() {
-    const { modal, onCancel } = this.props;
+    const { form, onCancel } = this.props;
 
     return (
       <FormModal
         open
-        icon={modal.icon || 'gears'}
+        icon={form.icon || 'gears'}
         iconSize={40}
-        title={modal.title || 'Script'}
+        title={form.title || 'Script'}
         submitText="Submit"
         inProgressText="Submitting\u2026"
         onClose={onCancel}
         onSubmit={this.handleConfirm}
       >
-        {(modal.elements || []).map((element, index) => this.renderElement(element, index))}
+        {(form.elements || []).map((element, index) => this.renderElement(element, index))}
       </FormModal>
     );
   }

--- a/src/dashboard/Data/Browser/ScriptResponseModal.react.js
+++ b/src/dashboard/Data/Browser/ScriptResponseModal.react.js
@@ -65,7 +65,10 @@ export default class ScriptResponseModal extends React.Component {
   }
 
   render() {
-    const { form, onCancel } = this.props;
+    const { form, objectIds, onCancel } = this.props;
+    const subtitle = objectIds.length === 1
+      ? `Running on object ${objectIds[0]}`
+      : `Running on ${objectIds.length} objects`;
 
     return (
       <Modal
@@ -73,6 +76,7 @@ export default class ScriptResponseModal extends React.Component {
         icon={form.icon || 'gears'}
         iconSize={40}
         title={form.title || 'Script'}
+        subtitle={subtitle}
         confirmText="Submit"
         onConfirm={this.handleConfirm}
         onCancel={onCancel}

--- a/src/lib/ScriptUtils.js
+++ b/src/lib/ScriptUtils.js
@@ -53,6 +53,22 @@ export function getValidScripts(scripts, className, field) {
 }
 
 /**
+ * Checks if a script response is a ScriptResponse with a modal definition.
+ * Uses __type: "ScriptResponse" as a discriminator to avoid collisions
+ * with existing cloud functions that may return objects with a "modal" key.
+ * @param {*} response - The response from a cloud function
+ * @returns {boolean}
+ */
+export function isModalResponse(response) {
+  return (
+    response != null &&
+    typeof response === 'object' &&
+    response.__type === 'ScriptResponse' &&
+    response.modal != null
+  );
+}
+
+/**
  * Executes a Parse Cloud Code script
  * @param {Object} script - The script configuration
  * @param {string} className - The Parse class name
@@ -60,8 +76,9 @@ export function getValidScripts(scripts, className, field) {
  * @param {Function} showNote - Callback to show notification
  * @param {Function} onRefresh - Callback to refresh all data
  * @param {Function} onRefreshObjects - Callback to refresh specific objects by IDs
+ * @param {Function} onModalResponse - Callback when response contains a modal definition
  */
-export async function executeScript(script, className, objectId, showNote, onRefresh, onRefreshObjects) {
+export async function executeScript(script, className, objectId, showNote, onRefresh, onRefreshObjects, onModalResponse) {
   try {
     const object = Parse.Object.extend(className).createWithoutData(objectId);
     const response = await Parse.Cloud.run(
@@ -69,9 +86,28 @@ export async function executeScript(script, className, objectId, showNote, onRef
       { object: object.toPointer() },
       { useMasterKey: true }
     );
-    showNote?.(
-      response || `Ran script "${script.title}" on "${className}" object "${object.id}".`
-    );
+    console.log('[ScriptUtils] executeScript response:', JSON.stringify(response));
+    console.log('[ScriptUtils] response type:', typeof response);
+    console.log('[ScriptUtils] response.__type:', response?.__type);
+    console.log('[ScriptUtils] response.modal:', response?.modal);
+    console.log('[ScriptUtils] isModalResponse:', isModalResponse(response));
+    console.log('[ScriptUtils] onModalResponse defined:', !!onModalResponse);
+    console.log('[ScriptUtils] response keys:', response ? Object.keys(response) : 'null');
+    if (isModalResponse(response) && onModalResponse) {
+      console.log('[ScriptUtils] -> showing modal');
+      onModalResponse({
+        response,
+        script,
+        className,
+        objectIds: [objectId],
+      });
+      return;
+    }
+    console.log('[ScriptUtils] -> showing note (no modal)');
+    const note =
+      (typeof response === 'object' ? JSON.stringify(response) : response) ||
+      `Ran script "${script.title}" on "${className}" object "${object.id}".`;
+    showNote?.(note);
     if (onRefreshObjects) {
       onRefreshObjects([objectId]);
     } else {
@@ -80,5 +116,65 @@ export async function executeScript(script, className, objectId, showNote, onRef
   } catch (e) {
     showNote?.(e.message, true);
     console.error(`Could not run ${script.title}:`, e);
+  }
+}
+
+/**
+ * Executes a script callback after modal submission
+ * @param {string} cloudCodeFunction - The callback cloud function name
+ * @param {string} className - The Parse class name
+ * @param {string[]} objectIds - Array of object IDs to execute on
+ * @param {Object} payload - Pass-through payload from the initial response
+ * @param {Object} formData - Form values from the modal
+ * @param {Function} showNote - Callback to show notification
+ * @param {Function} onRefresh - Callback to refresh all data
+ * @param {Function} onRefreshObjects - Callback to refresh specific objects by IDs
+ */
+export async function executeScriptCallback(cloudCodeFunction, className, objectIds, payload, formData, showNote, onRefresh, onRefreshObjects) {
+  try {
+    const objects = objectIds.map(id =>
+      Parse.Object.extend(className).createWithoutData(id)
+    );
+
+    const results = await Promise.all(
+      objects.map(object =>
+        Parse.Cloud.run(
+          cloudCodeFunction,
+          { object: object.toPointer(), payload, formData },
+          { useMasterKey: true }
+        )
+          .then(response => ({ objectId: object.id, response }))
+          .catch(error => ({ objectId: object.id, error }))
+      )
+    );
+
+    let errorCount = 0;
+    results.forEach(({ objectId, response, error }) => {
+      if (error) {
+        errorCount++;
+        showNote?.(`Error running callback on "${objectId}": ${error.message}`, true);
+      } else {
+        const note =
+          (typeof response === 'object' ? JSON.stringify(response) : response) ||
+          `Ran callback on "${objectId}".`;
+        showNote?.(note);
+      }
+    });
+
+    if (objectIds.length > 1) {
+      showNote?.(
+        `Ran callback on ${objectIds.length} objects with ${errorCount} errors.`,
+        errorCount > 0
+      );
+    }
+
+    if (onRefreshObjects) {
+      onRefreshObjects(objectIds);
+    } else {
+      onRefresh?.();
+    }
+  } catch (e) {
+    showNote?.(e.message, true);
+    console.error(`Could not run callback ${cloudCodeFunction}:`, e);
   }
 }

--- a/src/lib/ScriptUtils.js
+++ b/src/lib/ScriptUtils.js
@@ -53,18 +53,18 @@ export function getValidScripts(scripts, className, field) {
 }
 
 /**
- * Checks if a script response is a ScriptResponse with a modal definition.
+ * Checks if a script response is a ScriptResponse with a form definition.
  * Uses __type: "ScriptResponse" as a discriminator to avoid collisions
- * with existing cloud functions that may return objects with a "modal" key.
+ * with existing cloud functions that may return objects with a "form" key.
  * @param {*} response - The response from a cloud function
  * @returns {boolean}
  */
-export function isModalResponse(response) {
+export function isFormResponse(response) {
   return (
     response != null &&
     typeof response === 'object' &&
     response.__type === 'ScriptResponse' &&
-    response.modal != null
+    response.form != null
   );
 }
 
@@ -76,9 +76,9 @@ export function isModalResponse(response) {
  * @param {Function} showNote - Callback to show notification
  * @param {Function} onRefresh - Callback to refresh all data
  * @param {Function} onRefreshObjects - Callback to refresh specific objects by IDs
- * @param {Function} onModalResponse - Callback when response contains a modal definition
+ * @param {Function} onFormResponse - Callback when response contains a form definition
  */
-export async function executeScript(script, className, objectId, showNote, onRefresh, onRefreshObjects, onModalResponse) {
+export async function executeScript(script, className, objectId, showNote, onRefresh, onRefreshObjects, onFormResponse) {
   try {
     const object = Parse.Object.extend(className).createWithoutData(objectId);
     const response = await Parse.Cloud.run(
@@ -86,16 +86,8 @@ export async function executeScript(script, className, objectId, showNote, onRef
       { object: object.toPointer() },
       { useMasterKey: true }
     );
-    console.log('[ScriptUtils] executeScript response:', JSON.stringify(response));
-    console.log('[ScriptUtils] response type:', typeof response);
-    console.log('[ScriptUtils] response.__type:', response?.__type);
-    console.log('[ScriptUtils] response.modal:', response?.modal);
-    console.log('[ScriptUtils] isModalResponse:', isModalResponse(response));
-    console.log('[ScriptUtils] onModalResponse defined:', !!onModalResponse);
-    console.log('[ScriptUtils] response keys:', response ? Object.keys(response) : 'null');
-    if (isModalResponse(response) && onModalResponse) {
-      console.log('[ScriptUtils] -> showing modal');
-      onModalResponse({
+    if (isFormResponse(response) && onFormResponse) {
+      onFormResponse({
         response,
         script,
         className,
@@ -103,7 +95,6 @@ export async function executeScript(script, className, objectId, showNote, onRef
       });
       return;
     }
-    console.log('[ScriptUtils] -> showing note (no modal)');
     const note =
       (typeof response === 'object' ? JSON.stringify(response) : response) ||
       `Ran script "${script.title}" on "${className}" object "${object.id}".`;
@@ -120,7 +111,7 @@ export async function executeScript(script, className, objectId, showNote, onRef
 }
 
 /**
- * Executes a script callback after modal submission
+ * Executes a script callback after form submission
  * @param {string} cloudCodeFunction - The callback cloud function name
  * @param {string} className - The Parse class name
  * @param {string[]} objectIds - Array of object IDs to execute on


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-dashboard/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-dashboard/blob/alpha/LICENSE).

## Feature

Add support for script execution invoking dashboard form for user input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scripts can prompt interactive response modals (with dropdowns) when run across rows, enabling per-row payloads and targeted refreshes; batch execution now probes and handles form responses before full runs, with clearer per-object and aggregate result messages.

* **Bug Fixes**
  * Prevented state updates after form modal unmount to avoid memory leaks.

* **Documentation**
  * Reorganized and greatly expanded Scripts docs with examples for script responses, form payloads, and callback-driven workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->