### PR TITLE
fix: Non-printable character box missing when editing Cloud Config parameter

### DIFF
--- a/src/components/NonPrintableHighlighter/NonPrintableHighlighter.scss
+++ b/src/components/NonPrintableHighlighter/NonPrintableHighlighter.scss
@@ -105,7 +105,7 @@
 
 // Info badge styles for non-alphanumeric character detection
 .infoContainer {
-  margin-top: 8px;
+  margin-top: -4px;
 }
 
 .infoBadge {

--- a/src/dashboard/Data/Config/ConfigDialog.react.js
+++ b/src/dashboard/Data/Config/ConfigDialog.react.js
@@ -59,22 +59,26 @@ const EDITORS = {
   ),
   Date: (value, onChange) => <DateTimeInput fixed={true} value={value} onChange={onChange} />,
   Object: (value, onChange, wordWrap, syntaxColors) => (
-    <JsonEditor
-      value={value || ''}
-      onChange={onChange}
-      placeholder={'{\n  ...\n}'}
-      wordWrap={wordWrap}
-      syntaxColors={syntaxColors}
-    />
+    <NonPrintableHighlighter value={value} isJson={true} detectNonAlphanumeric={true}>
+      <JsonEditor
+        value={value || ''}
+        onChange={onChange}
+        placeholder={'{\n  ...\n}'}
+        wordWrap={wordWrap}
+        syntaxColors={syntaxColors}
+      />
+    </NonPrintableHighlighter>
   ),
   Array: (value, onChange, wordWrap, syntaxColors) => (
-    <JsonEditor
-      value={value || ''}
-      onChange={onChange}
-      placeholder={'[\n  ...\n]'}
-      wordWrap={wordWrap}
-      syntaxColors={syntaxColors}
-    />
+    <NonPrintableHighlighter value={value} isJson={true} detectNonAlphanumeric={true}>
+      <JsonEditor
+        value={value || ''}
+        onChange={onChange}
+        placeholder={'[\n  ...\n]'}
+        wordWrap={wordWrap}
+        syntaxColors={syntaxColors}
+      />
+    </NonPrintableHighlighter>
   ),
   GeoPoint: (value, onChange) => <GeoPointInput value={value} onChange={onChange} />,
   File: (value, onChange) => (


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-dashboard/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-dashboard/blob/alpha/LICENSE).

## Issue

Non-printable character box not visible when editing Cloud Config parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and handling of non-printable characters in JSON configuration editors.

* **Style**
  * Adjusted spacing in the information container for better visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->