### PR TITLE
feat: Add support for checkbox, toggle, text input elements to script form

### DIFF
--- a/README.md
+++ b/README.md
@@ -1559,6 +1559,7 @@ A drop-down to select a single item from a list.
 | Parameter | Value  | Optional | Description                      |
 |-----------|--------|----------|----------------------------------|
 | `element`    | `String` | No       | Must be `"dropDown"`.         |
+| `name`       | `String` | No       | The key used in `formData`.   |
 | `label`     | `String` | No       | The display label shown next to the dropdown. |
 | `description` | `String` | Yes      | Secondary text below the label. |
 |  `items` | `Array` | No | The selectable options. |

--- a/README.md
+++ b/README.md
@@ -1560,9 +1560,49 @@ A drop-down to select a single item from a list.
 |-----------|--------|----------|----------------------------------|
 | `element`    | `String` | No       | Must be `"dropDown"`.         |
 | `label`     | `String` | No       | The display label shown next to the dropdown. |
+| `description` | `String` | Yes      | Secondary text below the label. |
 |  `items` | `Array` | No | The selectable options. |
 |  `items[].title` | `String` | No | The display text of the option. |
 |  `items[].value` | `String` | No | The value of the option. |
+
+###### Checkbox
+
+A checkbox for boolean input.
+
+| Parameter | Value  | Optional | Default | Description                      |
+|-----------|--------|----------|---------|----------------------------------|
+| `element`     | `String` | No       | -       | Must be `"checkbox"`.         |
+| `name`        | `String` | No       | -       | The key used in `formData`.   |
+| `label`       | `String` | No       | -       | The display label.            |
+| `description` | `String` | Yes      | -       | Secondary text below the label. |
+| `default`     | `Boolean`| Yes      | `false` | The initial checked state.    |
+
+###### Toggle
+
+A toggle switch for boolean input.
+
+| Parameter    | Value    | Optional | Default | Description                      |
+|-------------|----------|----------|---------|----------------------------------|
+| `element`      | `String` | No       | -       | Must be `"toggle"`.           |
+| `name`         | `String` | No       | -       | The key used in `formData`.   |
+| `label`        | `String` | No       | -       | The display label.            |
+| `description`  | `String` | Yes      | -       | Secondary text below the label. |
+| `default`      | `Boolean`| Yes      | `false` | The initial toggle state.     |
+| `labelTrue`    | `String` | Yes      | `"Yes"` | Label for the `true` side.    |
+| `labelFalse`   | `String` | Yes      | `"No"`  | Label for the `false` side.   |
+
+###### Text Input
+
+A single-line text input.
+
+| Parameter    | Value    | Optional | Default | Description                      |
+|-------------|----------|----------|---------|----------------------------------|
+| `element`      | `String` | No       | -       | Must be `"textInput"`.        |
+| `name`         | `String` | No       | -       | The key used in `formData`.   |
+| `label`        | `String` | No       | -       | The display label.            |
+| `description`  | `String` | Yes      | -       | Secondary text below the label. |
+| `placeholder`  | `String` | Yes      | `""`    | Placeholder text.             |
+| `default`      | `String` | Yes      | `""`    | The initial value.            |
 
 ### Graph
 

--- a/src/dashboard/Data/Browser/ScriptResponseModal.react.js
+++ b/src/dashboard/Data/Browser/ScriptResponseModal.react.js
@@ -94,25 +94,25 @@ export default class ScriptResponseModal extends React.Component {
       const hasCustomLabels = element.labelTrue || element.labelFalse;
       const toggleProps = hasCustomLabels
         ? {
-            type: Toggle.Types.TWO_WAY,
-            optionLeft: element.labelFalse || 'No',
-            optionRight: element.labelTrue || 'Yes',
-            value: this.state.formData[key]
-              ? (element.labelTrue || 'Yes')
-              : (element.labelFalse || 'No'),
-            onChange: value =>
-              this.setState(prev => ({
-                formData: { ...prev.formData, [key]: value === (element.labelTrue || 'Yes') },
-              })),
-          }
+          type: Toggle.Types.TWO_WAY,
+          optionLeft: element.labelFalse || 'No',
+          optionRight: element.labelTrue || 'Yes',
+          value: this.state.formData[key]
+            ? (element.labelTrue || 'Yes')
+            : (element.labelFalse || 'No'),
+          onChange: value =>
+            this.setState(prev => ({
+              formData: { ...prev.formData, [key]: value === (element.labelTrue || 'Yes') },
+            })),
+        }
         : {
-            type: Toggle.Types.YES_NO,
-            value: this.state.formData[key],
-            onChange: value =>
-              this.setState(prev => ({
-                formData: { ...prev.formData, [key]: value },
-              })),
-          };
+          type: Toggle.Types.YES_NO,
+          value: this.state.formData[key],
+          onChange: value =>
+            this.setState(prev => ({
+              formData: { ...prev.formData, [key]: value },
+            })),
+        };
 
       return (
         <Field

--- a/src/dashboard/Data/Browser/ScriptResponseModal.react.js
+++ b/src/dashboard/Data/Browser/ScriptResponseModal.react.js
@@ -11,6 +11,9 @@ import Field from 'components/Field/Field.react';
 import Label from 'components/Label/Label.react';
 import Dropdown from 'components/Dropdown/Dropdown.react';
 import Option from 'components/Dropdown/Option.react';
+import Checkbox from 'components/Checkbox/Checkbox.react';
+import Toggle from 'components/Toggle/Toggle.react';
+import TextInput from 'components/TextInput/TextInput.react';
 
 export default class ScriptResponseModal extends React.Component {
   constructor(props) {
@@ -21,6 +24,12 @@ export default class ScriptResponseModal extends React.Component {
       const key = element.name || String(index);
       if (element.element === 'dropDown' && element.items?.length > 0) {
         formData[key] = element.items[0].value;
+      } else if (element.element === 'checkbox') {
+        formData[key] = element.default ?? false;
+      } else if (element.element === 'toggle') {
+        formData[key] = element.default ?? false;
+      } else if (element.element === 'textInput') {
+        formData[key] = element.default ?? '';
       }
     });
 
@@ -39,7 +48,7 @@ export default class ScriptResponseModal extends React.Component {
       return (
         <Field
           key={key}
-          label={<Label text={element.label || element.name || 'Select'} />}
+          label={<Label text={element.label || element.name || 'Select'} description={element.description} />}
           input={
             <Dropdown
               fixed={true}
@@ -56,6 +65,79 @@ export default class ScriptResponseModal extends React.Component {
                 </Option>
               ))}
             </Dropdown>
+          }
+        />
+      );
+    }
+
+    if (element.element === 'checkbox') {
+      return (
+        <Field
+          key={key}
+          label={<Label text={element.label || element.name || 'Checkbox'} description={element.description} />}
+          input={
+            <Checkbox
+              label=""
+              checked={this.state.formData[key]}
+              onChange={value =>
+                this.setState(prev => ({
+                  formData: { ...prev.formData, [key]: value },
+                }))
+              }
+            />
+          }
+        />
+      );
+    }
+
+    if (element.element === 'toggle') {
+      const hasCustomLabels = element.labelTrue || element.labelFalse;
+      const toggleProps = hasCustomLabels
+        ? {
+            type: Toggle.Types.TWO_WAY,
+            optionLeft: element.labelFalse || 'No',
+            optionRight: element.labelTrue || 'Yes',
+            value: this.state.formData[key]
+              ? (element.labelTrue || 'Yes')
+              : (element.labelFalse || 'No'),
+            onChange: value =>
+              this.setState(prev => ({
+                formData: { ...prev.formData, [key]: value === (element.labelTrue || 'Yes') },
+              })),
+          }
+        : {
+            type: Toggle.Types.YES_NO,
+            value: this.state.formData[key],
+            onChange: value =>
+              this.setState(prev => ({
+                formData: { ...prev.formData, [key]: value },
+              })),
+          };
+
+      return (
+        <Field
+          key={key}
+          label={<Label text={element.label || element.name || 'Toggle'} description={element.description} />}
+          input={<Toggle {...toggleProps} />}
+        />
+      );
+    }
+
+    if (element.element === 'textInput') {
+      return (
+        <Field
+          key={key}
+          label={<Label text={element.label || element.name || 'Text'} description={element.description} />}
+          input={
+            <TextInput
+              placeholder={element.placeholder || ''}
+              value={this.state.formData[key]}
+              onChange={value =>
+                this.setState(prev => ({
+                  formData: { ...prev.formData, [key]: value },
+                }))
+              }
+            />
           }
         />
       );

--- a/src/lib/tests/ScriptResponseModal.test.js
+++ b/src/lib/tests/ScriptResponseModal.test.js
@@ -1,0 +1,220 @@
+/**
+ * @jest-environment jsdom
+ */
+jest.dontMock('../../dashboard/Data/Browser/ScriptResponseModal.react');
+jest.dontMock('../../components/Field/Field.react');
+jest.dontMock('../../components/Label/Label.react');
+jest.dontMock('../../components/Checkbox/Checkbox.react');
+jest.dontMock('../../components/Toggle/Toggle.react');
+jest.dontMock('../../components/TextInput/TextInput.react');
+jest.dontMock('../../components/Dropdown/Dropdown.react');
+jest.dontMock('../../components/Dropdown/Option.react');
+jest.dontMock('../../components/Modal/Modal.react');
+jest.dontMock('../../components/Button/Button.react');
+jest.dontMock('../../components/Icon/Icon.react');
+jest.dontMock('../Position');
+
+// Mock Popover to avoid createPortal issues with react-test-renderer
+jest.mock('../../components/Popover/Popover.react', () => {
+  const React = require('react');
+  return class Popover extends React.Component {
+    render() {
+      return <div>{this.props.children}</div>;
+    }
+  };
+});
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+const ScriptResponseModal = require('../../dashboard/Data/Browser/ScriptResponseModal.react').default;
+
+const defaultProps = {
+  objectIds: ['obj1'],
+  onCancel: jest.fn(),
+  onConfirm: jest.fn(),
+};
+
+describe('ScriptResponseModal', () => {
+  describe('checkbox element', () => {
+    it('initializes with default false', () => {
+      const form = {
+        elements: [{ element: 'checkbox', name: 'confirmed', label: 'Confirm' }],
+      };
+      const component = renderer.create(<ScriptResponseModal form={form} {...defaultProps} />);
+      const instance = component.getInstance();
+      expect(instance.state.formData.confirmed).toBe(false);
+    });
+
+    it('initializes with custom default', () => {
+      const form = {
+        elements: [{ element: 'checkbox', name: 'confirmed', label: 'Confirm', default: true }],
+      };
+      const component = renderer.create(<ScriptResponseModal form={form} {...defaultProps} />);
+      const instance = component.getInstance();
+      expect(instance.state.formData.confirmed).toBe(true);
+    });
+
+    it('renders with description', () => {
+      const form = {
+        elements: [{
+          element: 'checkbox',
+          name: 'confirmed',
+          label: 'Confirm',
+          description: 'Please confirm',
+        }],
+      };
+      const tree = renderer.create(<ScriptResponseModal form={form} {...defaultProps} />).toJSON();
+      expect(JSON.stringify(tree)).toContain('Please confirm');
+    });
+  });
+
+  describe('toggle element', () => {
+    it('initializes with default false', () => {
+      const form = {
+        elements: [{ element: 'toggle', name: 'enabled', label: 'Enable' }],
+      };
+      const component = renderer.create(<ScriptResponseModal form={form} {...defaultProps} />);
+      const instance = component.getInstance();
+      expect(instance.state.formData.enabled).toBe(false);
+    });
+
+    it('initializes with custom default true', () => {
+      const form = {
+        elements: [{ element: 'toggle', name: 'enabled', label: 'Enable', default: true }],
+      };
+      const component = renderer.create(<ScriptResponseModal form={form} {...defaultProps} />);
+      const instance = component.getInstance();
+      expect(instance.state.formData.enabled).toBe(true);
+    });
+
+    it('renders with description', () => {
+      const form = {
+        elements: [{
+          element: 'toggle',
+          name: 'enabled',
+          label: 'Enable',
+          description: 'Toggle this feature',
+        }],
+      };
+      const tree = renderer.create(<ScriptResponseModal form={form} {...defaultProps} />).toJSON();
+      expect(JSON.stringify(tree)).toContain('Toggle this feature');
+    });
+
+    it('renders with custom labels', () => {
+      const form = {
+        elements: [{
+          element: 'toggle',
+          name: 'enabled',
+          label: 'Enable',
+          labelTrue: 'Enabled',
+          labelFalse: 'Disabled',
+        }],
+      };
+      const tree = renderer.create(<ScriptResponseModal form={form} {...defaultProps} />).toJSON();
+      const json = JSON.stringify(tree);
+      expect(json).toContain('Enabled');
+      expect(json).toContain('Disabled');
+    });
+  });
+
+  describe('textInput element', () => {
+    it('initializes with default empty string', () => {
+      const form = {
+        elements: [{ element: 'textInput', name: 'reason', label: 'Reason' }],
+      };
+      const component = renderer.create(<ScriptResponseModal form={form} {...defaultProps} />);
+      const instance = component.getInstance();
+      expect(instance.state.formData.reason).toBe('');
+    });
+
+    it('initializes with custom default', () => {
+      const form = {
+        elements: [{ element: 'textInput', name: 'reason', label: 'Reason', default: 'N/A' }],
+      };
+      const component = renderer.create(<ScriptResponseModal form={form} {...defaultProps} />);
+      const instance = component.getInstance();
+      expect(instance.state.formData.reason).toBe('N/A');
+    });
+
+    it('renders with placeholder', () => {
+      const form = {
+        elements: [{
+          element: 'textInput',
+          name: 'reason',
+          label: 'Reason',
+          placeholder: 'Enter reason...',
+        }],
+      };
+      const tree = renderer.create(<ScriptResponseModal form={form} {...defaultProps} />).toJSON();
+      expect(JSON.stringify(tree)).toContain('Enter reason...');
+    });
+
+    it('renders with description', () => {
+      const form = {
+        elements: [{
+          element: 'textInput',
+          name: 'reason',
+          label: 'Reason',
+          description: 'Provide a reason',
+        }],
+      };
+      const tree = renderer.create(<ScriptResponseModal form={form} {...defaultProps} />).toJSON();
+      expect(JSON.stringify(tree)).toContain('Provide a reason');
+    });
+  });
+
+  describe('dropDown element (existing)', () => {
+    it('initializes with first item value', () => {
+      const form = {
+        elements: [{
+          element: 'dropDown',
+          name: 'role',
+          label: 'Role',
+          items: [{ title: 'Admin', value: 'admin' }, { title: 'User', value: 'user' }],
+        }],
+      };
+      const component = renderer.create(<ScriptResponseModal form={form} {...defaultProps} />);
+      const instance = component.getInstance();
+      expect(instance.state.formData.role).toBe('admin');
+    });
+  });
+
+  describe('mixed elements', () => {
+    it('initializes all element types correctly', () => {
+      const form = {
+        elements: [
+          { element: 'dropDown', name: 'role', items: [{ title: 'Admin', value: 'admin' }] },
+          { element: 'checkbox', name: 'confirmed', default: true },
+          { element: 'toggle', name: 'enabled' },
+          { element: 'textInput', name: 'reason', default: 'test' },
+        ],
+      };
+      const component = renderer.create(<ScriptResponseModal form={form} {...defaultProps} />);
+      const instance = component.getInstance();
+      expect(instance.state.formData).toEqual({
+        role: 'admin',
+        confirmed: true,
+        enabled: false,
+        reason: 'test',
+      });
+    });
+  });
+
+  describe('form submission', () => {
+    it('calls onConfirm with formData', () => {
+      const onConfirm = jest.fn();
+      const form = {
+        elements: [
+          { element: 'checkbox', name: 'confirmed', default: true },
+          { element: 'textInput', name: 'reason', default: 'hello' },
+        ],
+      };
+      const component = renderer.create(
+        <ScriptResponseModal form={form} objectIds={['obj1']} onCancel={jest.fn()} onConfirm={onConfirm} />
+      );
+      const instance = component.getInstance();
+      instance.handleConfirm();
+      expect(onConfirm).toHaveBeenCalledWith({ confirmed: true, reason: 'hello' });
+    });
+  });
+});

--- a/testing/preprocessor.js
+++ b/testing/preprocessor.js
@@ -29,9 +29,9 @@ module.exports = {
       const rel = path.relative(path.dirname(filename), srcDir);
       relPrefix = rel ? rel.replace(/\\/g, '/') + '/' : './';
     }
-    src = src.replace(/from 'stylesheets/g, "from '" + relPrefix + 'stylesheets');
-    src = src.replace(/from 'lib/g, "from '" + relPrefix + 'lib');
-    src = src.replace(/from 'components/g, "from '" + relPrefix + 'components');
+    src = src.replace(/from 'stylesheets/g, 'from \'' + relPrefix + 'stylesheets');
+    src = src.replace(/from 'lib/g, 'from \'' + relPrefix + 'lib');
+    src = src.replace(/from 'components/g, 'from \'' + relPrefix + 'components');
 
     // Ignore all files within node_modules
     // babel files can be .js, .es, .jsx or .es6

--- a/testing/preprocessor.js
+++ b/testing/preprocessor.js
@@ -6,7 +6,10 @@
  * the root directory of this source tree.
  */
 const babel = require('@babel/core');
+const path = require('path');
 const extractClassnames = require('./extractClassnames');
+
+const srcDir = path.resolve(__dirname, '..', 'src');
 
 module.exports = {
   process: function (src, filename) {
@@ -18,9 +21,17 @@ module.exports = {
     }
 
     // Let Jest handle our custom module resolution
-    src = src.replace(/from 'stylesheets/g, 'from \'../../stylesheets');
-    src = src.replace(/from 'lib/g, 'from \'../../lib');
-    src = src.replace(/from 'components/g, 'from \'../../components');
+    // Compute relative prefix from file's directory to src/ so that
+    // bare imports like 'components/...' resolve correctly regardless
+    // of the file's depth within the src tree.
+    let relPrefix = '../../';
+    if (filename.startsWith(srcDir + path.sep)) {
+      const rel = path.relative(path.dirname(filename), srcDir);
+      relPrefix = rel ? rel.replace(/\\/g, '/') + '/' : './';
+    }
+    src = src.replace(/from 'stylesheets/g, "from '" + relPrefix + 'stylesheets');
+    src = src.replace(/from 'lib/g, "from '" + relPrefix + 'lib');
+    src = src.replace(/from 'components/g, "from '" + relPrefix + 'components');
 
     // Ignore all files within node_modules
     // babel files can be .js, .es, .jsx or .es6


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-dashboard/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-dashboard/blob/alpha/LICENSE).

## Issue

Add support for checkbox, toggle, text input elements to script form.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Checkbox, Toggle, and Text Input to the Script Response Form.
  * Drop-Down now supports an optional description field.

* **Documentation**
  * Expanded Script Response Form docs with new element parameter tables, defaults, and examples.

* **Tests**
  * Added comprehensive tests covering new form elements, defaults, rendering, and form submission.

* **Chores**
  * Improved test import preprocessing to resolve project paths dynamically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->