### PR TITLE
feat: Add support for reversing info panel auto-scroll direction while holding Command+Option keys

### DIFF
--- a/src/dashboard/Dashboard.js
+++ b/src/dashboard/Dashboard.js
@@ -57,6 +57,7 @@ import DashboardSettings from './Settings/DashboardSettings/DashboardSettings.re
 import Security from './Settings/Security/Security.react';
 import KeyboardShortcutsSettings from './Settings/KeyboardShortcutsSettings.react';
 import CloudConfigSettings from './Settings/CloudConfigSettings.react';
+import DataBrowserSettings from './Settings/DataBrowserSettings.react';
 import semver from 'semver';
 import packageInfo from '../../package.json';
 
@@ -239,6 +240,7 @@ export default class Dashboard extends React.Component {
         <Route path="security" element={<Security />} />
         <Route path="keyboard-shortcuts" element={<KeyboardShortcutsSettings />} />
         <Route path="cloud-config" element={<CloudConfigSettings />} />
+        <Route path="data-browser" element={<DataBrowserSettings />} />
         <Route path="general" element={<GeneralSettings />} />
         <Route path="keys" element={<SecuritySettings />} />
         <Route path="users" element={<UsersSettings />} />

--- a/src/dashboard/DashboardView.react.js
+++ b/src/dashboard/DashboardView.react.js
@@ -227,6 +227,10 @@ export default class DashboardView extends React.Component {
         link: '/settings/dashboard',
       },
       {
+        name: 'Data Browser',
+        link: '/settings/data-browser',
+      },
+      {
         name: 'Cloud Config',
         link: '/settings/cloud-config',
       },

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -1934,8 +1934,11 @@ export default class DataBrowser extends React.Component {
     }
 
     // Animate scroll smoothly using requestAnimationFrame
+    // Capture reverse state at step start so it stays consistent with scrollAmount
+    // throughout the animation (prevents jump if state changes mid-frame)
+    const isReversing = this.state.reverseAutoScrollActive;
     let scrollAmount = this.state.autoScrollAmount;
-    if (this.state.reverseAutoScrollActive) {
+    if (isReversing) {
       scrollAmount = -scrollAmount * this.state.reverseAutoScrollSpeedFactor;
     }
     // Animation duration: 300ms base, scaled by scroll amount (max 500ms)
@@ -1969,6 +1972,13 @@ export default class DataBrowser extends React.Component {
         return;
       }
 
+      // If reverse state changed mid-animation, restart the step immediately
+      // from the current scroll position with the correct direction
+      if (this.state.reverseAutoScrollActive !== isReversing) {
+        this.performAutoScrollStep();
+        return;
+      }
+
       const elapsed = currentTime - startTime;
       const progress = Math.min(elapsed / duration, 1);
 
@@ -1981,7 +1991,7 @@ export default class DataBrowser extends React.Component {
 
       // Sync scroll to other panels
       if (this.state.panelCount > 1 && this.state.syncPanelScroll) {
-        if (this.state.reverseAutoScrollActive) {
+        if (isReversing) {
           // During reverse auto-scroll, use the max scrollTop as the base for all panels
           // so that shorter panels stay put until the longest panel catches up,
           // matching the behavior of manual wheel scrolling (handleWrapperWheel)

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -40,6 +40,7 @@ const GRAPH_PANEL_VISIBLE = 'graphPanelVisible';
 const GRAPH_PANEL_WIDTH = 'graphPanelWidth';
 const AGGREGATION_PANEL_AUTO_SCROLL = 'aggregationPanelAutoScroll';
 const AGGREGATION_PANEL_AUTO_SCROLL_REQUIRE_HOVER = 'aggregationPanelAutoScrollRequireHover';
+const REVERSE_AUTO_SCROLL_SPEED_FACTOR = 0.5;
 
 function formatValueForCopy(value, type) {
   if (value === undefined) {
@@ -199,6 +200,7 @@ export default class DataBrowser extends React.Component {
       mouseOverPanelHeader: false, // Whether the mouse is over the panel header row
       commandKeyPressed: false, // Whether the Command/Meta key is currently pressed
       optionKeyPressed: false, // Whether the Option/Alt key is currently pressed (pauses auto-scroll)
+      reverseAutoScrollActive: false, // Whether Cmd+Option are both held (reverses auto-scroll at half speed)
     };
 
     // Flag to skip panel clearing in componentDidUpdate during selective object refresh
@@ -265,6 +267,7 @@ export default class DataBrowser extends React.Component {
     this.handlePanelHeaderMouseLeave = this.handlePanelHeaderMouseLeave.bind(this);
     this.handleOptionKeyDown = this.handleOptionKeyDown.bind(this);
     this.handleOptionKeyUp = this.handleOptionKeyUp.bind(this);
+    this.handleWindowBlur = this.handleWindowBlur.bind(this);
     this.handleMouseButtonDown = this.handleMouseButtonDown.bind(this);
     this.handleMouseButtonUp = this.handleMouseButtonUp.bind(this);
     this.saveOrderTimeout = null;
@@ -366,6 +369,7 @@ export default class DataBrowser extends React.Component {
     window.addEventListener('mouseup', this.handleMouseButtonUp);
     // Native context menu detection for auto-scroll pause
     this.nativeContextMenuTracker = this.setupNativeContextMenuDetection();
+    window.addEventListener('blur', this.handleWindowBlur);
 
     // Load keyboard shortcuts from server
     try {
@@ -409,6 +413,7 @@ export default class DataBrowser extends React.Component {
     document.body.removeEventListener('keyup', this.handleOptionKeyUp);
     window.removeEventListener('mousedown', this.handleMouseButtonDown);
     window.removeEventListener('mouseup', this.handleMouseButtonUp);
+    window.removeEventListener('blur', this.handleWindowBlur);
     if (this.nativeContextMenuTracker) {
       this.nativeContextMenuTracker.dispose();
     }
@@ -1581,17 +1586,29 @@ export default class DataBrowser extends React.Component {
 
   handleAutoScrollKeyDown(e) {
     // Command/Meta key = keyCode 91 (left) or 93 (right)
-    // Only track that Command key is held; don't stop auto-scroll or enter
-    // recording mode until the user actually scrolls (handled in handleAutoScrollWheel)
-    if ((e.keyCode === 91 || e.keyCode === 93) && this.state.autoScrollEnabled && this.state.isPanelVisible && !this.state.isRecordingAutoScroll) {
-      this.setState({ commandKeyPressed: true });
+    if ((e.keyCode === 91 || e.keyCode === 93) && this.state.autoScrollEnabled && this.state.isPanelVisible) {
+      if (this.state.optionKeyPressed && this.state.isAutoScrolling) {
+        // Option already held + Cmd pressed = activate reverse auto-scroll
+        // Clear optionKeyPressed to unblock auto-scroll
+        this.setState({
+          commandKeyPressed: true,
+          optionKeyPressed: false,
+          reverseAutoScrollActive: true,
+        });
+      } else if (!this.state.isRecordingAutoScroll) {
+        // Normal behavior: track Command key for potential scroll recording
+        this.setState({ commandKeyPressed: true });
+      }
     }
   }
 
   handleAutoScrollKeyUp(e) {
     // Command/Meta key = keyCode 91 (left) or 93 (right)
     if (e.keyCode === 91 || e.keyCode === 93) {
-      if (this.state.isRecordingAutoScroll) {
+      if (this.state.reverseAutoScrollActive) {
+        // Deactivate reverse mode; skip recording-mode logic
+        this.setState({ commandKeyPressed: false, reverseAutoScrollActive: false });
+      } else if (this.state.isRecordingAutoScroll) {
         const { recordedScrollDelta, recordingScrollStart, recordingScrollEnd } = this.state;
 
         // Only start auto-scroll if we actually recorded some scrolling
@@ -1770,19 +1787,42 @@ export default class DataBrowser extends React.Component {
     }, 50);
   }
 
+  handleWindowBlur() {
+    // Reset all modifier key tracking state when the window loses focus,
+    // since keyup events won't fire while the window is not focused
+    if (this.state.commandKeyPressed || this.state.optionKeyPressed || this.state.reverseAutoScrollActive) {
+      this.setState({
+        commandKeyPressed: false,
+        optionKeyPressed: false,
+        reverseAutoScrollActive: false,
+      });
+    }
+  }
+
   handleOptionKeyDown(e) {
     // Option/Alt key = keyCode 18
-    // Track Option key state to pause auto-scroll while held
-    if (e.keyCode === 18 && !this.state.optionKeyPressed) {
-      this.setState({ optionKeyPressed: true });
+    if (e.keyCode === 18) {
+      if (this.state.commandKeyPressed && this.state.isAutoScrolling) {
+        // Cmd already held + Option pressed = activate reverse auto-scroll
+        // Don't set optionKeyPressed (which would block auto-scroll)
+        this.setState({ reverseAutoScrollActive: true });
+      } else if (!this.state.optionKeyPressed) {
+        // Normal behavior: track Option key to pause auto-scroll
+        this.setState({ optionKeyPressed: true });
+      }
     }
   }
 
   handleOptionKeyUp(e) {
     // Option/Alt key = keyCode 18
-    // Track Option key release to resume auto-scroll
-    if (e.keyCode === 18 && this.state.optionKeyPressed) {
-      this.setState({ optionKeyPressed: false });
+    if (e.keyCode === 18) {
+      if (this.state.reverseAutoScrollActive) {
+        // Deactivate reverse mode; don't trigger normal option-pause cleanup
+        this.setState({ reverseAutoScrollActive: false });
+      } else if (this.state.optionKeyPressed) {
+        // Normal behavior: release Option key pause
+        this.setState({ optionKeyPressed: false });
+      }
     }
   }
 
@@ -1836,6 +1876,7 @@ export default class DataBrowser extends React.Component {
       recordedScrollDelta: 0,
       recordingScrollStart: null,
       recordingScrollEnd: null,
+      reverseAutoScrollActive: false,
     });
   }
 
@@ -1878,7 +1919,10 @@ export default class DataBrowser extends React.Component {
     }
 
     // Animate scroll smoothly using requestAnimationFrame
-    const scrollAmount = this.state.autoScrollAmount;
+    let scrollAmount = this.state.autoScrollAmount;
+    if (this.state.reverseAutoScrollActive) {
+      scrollAmount = -scrollAmount * REVERSE_AUTO_SCROLL_SPEED_FACTOR;
+    }
     // Animation duration: 300ms base, scaled by scroll amount (max 500ms)
     const duration = Math.min(300 + Math.abs(scrollAmount) * 0.5, 500);
     const startTime = performance.now();
@@ -1886,10 +1930,14 @@ export default class DataBrowser extends React.Component {
 
     // Get starting positions for multi-panel sync
     const panelStartPositions = [];
+    let maxPanelStartScrollTop = 0;
     if (this.state.panelCount > 1 && this.state.syncPanelScroll) {
       this.panelColumnRefs.forEach((ref) => {
         if (ref && ref.current) {
           panelStartPositions.push(ref.current.scrollTop);
+          if (ref.current.scrollTop > maxPanelStartScrollTop) {
+            maxPanelStartScrollTop = ref.current.scrollTop;
+          }
         } else {
           panelStartPositions.push(null);
         }
@@ -1918,11 +1966,23 @@ export default class DataBrowser extends React.Component {
 
       // Sync scroll to other panels
       if (this.state.panelCount > 1 && this.state.syncPanelScroll) {
-        this.panelColumnRefs.forEach((ref, index) => {
-          if (ref && ref.current && panelStartPositions[index] !== null) {
-            ref.current.scrollTop = panelStartPositions[index] + (scrollAmount * easeOut);
-          }
-        });
+        if (this.state.reverseAutoScrollActive) {
+          // During reverse auto-scroll, use the max scrollTop as the base for all panels
+          // so that shorter panels stay put until the longest panel catches up,
+          // matching the behavior of manual wheel scrolling (handleWrapperWheel)
+          const newPanelScrollTop = maxPanelStartScrollTop + (scrollAmount * easeOut);
+          this.panelColumnRefs.forEach((ref) => {
+            if (ref && ref.current) {
+              ref.current.scrollTop = newPanelScrollTop;
+            }
+          });
+        } else {
+          this.panelColumnRefs.forEach((ref, index) => {
+            if (ref && ref.current && panelStartPositions[index] !== null) {
+              ref.current.scrollTop = panelStartPositions[index] + (scrollAmount * easeOut);
+            }
+          });
+        }
       }
 
       if (progress < 1) {

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -23,6 +23,7 @@ import { ResizableBox } from 'react-resizable';
 import ScriptConfirmationModal from '../../../components/ScriptConfirmationModal/ScriptConfirmationModal.react';
 import styles from './Databrowser.scss';
 import KeyboardShortcutsManager, { matchesShortcut } from 'lib/KeyboardShortcutsPreferences';
+import ServerConfigStorage from 'lib/ServerConfigStorage';
 
 import AggregationPanel from '../../../components/AggregationPanel/AggregationPanel';
 import { buildRelatedTextFieldsMenuItem } from '../../../lib/RelatedRecordsUtils';
@@ -40,7 +41,6 @@ const GRAPH_PANEL_VISIBLE = 'graphPanelVisible';
 const GRAPH_PANEL_WIDTH = 'graphPanelWidth';
 const AGGREGATION_PANEL_AUTO_SCROLL = 'aggregationPanelAutoScroll';
 const AGGREGATION_PANEL_AUTO_SCROLL_REQUIRE_HOVER = 'aggregationPanelAutoScrollRequireHover';
-const REVERSE_AUTO_SCROLL_SPEED_FACTOR = 0.5;
 
 function formatValueForCopy(value, type) {
   if (value === undefined) {
@@ -200,7 +200,8 @@ export default class DataBrowser extends React.Component {
       mouseOverPanelHeader: false, // Whether the mouse is over the panel header row
       commandKeyPressed: false, // Whether the Command/Meta key is currently pressed
       optionKeyPressed: false, // Whether the Option/Alt key is currently pressed (pauses auto-scroll)
-      reverseAutoScrollActive: false, // Whether Cmd+Option are both held (reverses auto-scroll at half speed)
+      reverseAutoScrollActive: false, // Whether Cmd+Option are both held (reverses auto-scroll direction)
+      reverseAutoScrollSpeedFactor: 1, // Speed multiplier for reverse auto-scroll
     };
 
     // Flag to skip panel clearing in componentDidUpdate during selective object refresh
@@ -378,6 +379,20 @@ export default class DataBrowser extends React.Component {
       this.setState({ keyboardShortcuts: shortcuts });
     } catch (error) {
       console.warn('Failed to load keyboard shortcuts:', error);
+    }
+
+    // Load data browser settings from server
+    try {
+      const serverStorage = new ServerConfigStorage(this.props.app);
+      const panelSettings = await serverStorage.getConfig(
+        'browser.panels.settings',
+        this.props.app.applicationId
+      );
+      if (panelSettings !== null && typeof panelSettings === 'object' && typeof panelSettings.reverseAutoScrollSpeedFactor === 'number' && panelSettings.reverseAutoScrollSpeedFactor > 0) {
+        this.setState({ reverseAutoScrollSpeedFactor: panelSettings.reverseAutoScrollSpeedFactor });
+      }
+    } catch (error) {
+      console.warn('Failed to load data browser settings:', error);
     }
 
     // Load graphs on initial mount
@@ -1921,7 +1936,7 @@ export default class DataBrowser extends React.Component {
     // Animate scroll smoothly using requestAnimationFrame
     let scrollAmount = this.state.autoScrollAmount;
     if (this.state.reverseAutoScrollActive) {
-      scrollAmount = -scrollAmount * REVERSE_AUTO_SCROLL_SPEED_FACTOR;
+      scrollAmount = -scrollAmount * this.state.reverseAutoScrollSpeedFactor;
     }
     // Animation duration: 300ms base, scaled by scroll amount (max 500ms)
     const duration = Math.min(300 + Math.abs(scrollAmount) * 0.5, 500);

--- a/src/dashboard/Settings/DataBrowserSettings.react.js
+++ b/src/dashboard/Settings/DataBrowserSettings.react.js
@@ -1,0 +1,155 @@
+import DashboardView from 'dashboard/DashboardView.react';
+import Field from 'components/Field/Field.react';
+import Fieldset from 'components/Fieldset/Fieldset.react';
+import Label from 'components/Label/Label.react';
+import React from 'react';
+import TextInput from 'components/TextInput/TextInput.react';
+import Toolbar from 'components/Toolbar/Toolbar.react';
+import Notification from 'dashboard/Data/Browser/Notification.react';
+import ServerConfigStorage from 'lib/ServerConfigStorage';
+import styles from 'dashboard/Settings/Settings.scss';
+
+const CONFIG_KEY = 'browser.panels.settings';
+const DEFAULT_VALUE = 1;
+
+export default class DataBrowserSettings extends DashboardView {
+  constructor() {
+    super();
+    this.section = 'App Settings';
+    this.subsection = 'Data Browser';
+    this.serverStorage = null;
+
+    this.state = {
+      reverseAutoScrollSpeedFactor: '',
+      loading: true,
+      message: undefined,
+    };
+  }
+
+  componentDidMount() {
+    if (this.context) {
+      this.serverStorage = new ServerConfigStorage(this.context);
+      this.loadSettings();
+    }
+  }
+
+  componentWillUnmount() {
+    clearTimeout(this.noteTimeout);
+  }
+
+  async loadSettings() {
+    try {
+      const value = await this.serverStorage.getConfig(
+        CONFIG_KEY,
+        this.context.applicationId
+      );
+      if (value !== null && value !== undefined && typeof value === 'object' && typeof value.reverseAutoScrollSpeedFactor === 'number') {
+        this.setState({ reverseAutoScrollSpeedFactor: String(value.reverseAutoScrollSpeedFactor) });
+      }
+    } catch {
+      this.showNote('Failed to load Data Browser settings.', true);
+    } finally {
+      this.setState({ loading: false });
+    }
+  }
+
+  handleReverseAutoScrollSpeedFactorChange(value) {
+    this.setState({ reverseAutoScrollSpeedFactor: value });
+  }
+
+  async saveReverseAutoScrollSpeedFactor() {
+    const value = this.state.reverseAutoScrollSpeedFactor.trim();
+
+    if (value === '') {
+      try {
+        await this.serverStorage.deleteConfig(
+          CONFIG_KEY,
+          this.context.applicationId
+        );
+        this.showNote('Reverse auto-scroll speed factor reset to default.');
+      } catch {
+        this.showNote('Failed to reset setting.', true);
+      }
+      return;
+    }
+
+    const parsed = parseFloat(value);
+    if (isNaN(parsed) || parsed <= 0) {
+      this.showNote('Please enter a valid positive number.', true);
+      return;
+    }
+
+    try {
+      if (parsed === DEFAULT_VALUE) {
+        await this.serverStorage.deleteConfig(
+          CONFIG_KEY,
+          this.context.applicationId
+        );
+      } else {
+        await this.serverStorage.setConfig(
+          CONFIG_KEY,
+          { reverseAutoScrollSpeedFactor: parsed },
+          this.context.applicationId
+        );
+      }
+      this.setState({ reverseAutoScrollSpeedFactor: String(parsed) });
+      this.showNote(`Reverse auto-scroll speed factor set to ${parsed}.`);
+    } catch {
+      this.showNote('Failed to save setting.', true);
+    }
+  }
+
+  showNote(message, isError = false) {
+    if (!message) {
+      return;
+    }
+
+    clearTimeout(this.noteTimeout);
+
+    this.setState({ message: { text: message, isError } });
+
+    this.noteTimeout = setTimeout(() => {
+      this.setState({ message: undefined });
+    }, 3500);
+  }
+
+  renderContent() {
+    const message = this.state.message;
+    const serverConfigEnabled = this.serverStorage && this.serverStorage.isServerConfigEnabled();
+    const notAvailableMessage = !this.state.loading && !serverConfigEnabled
+      ? 'Server configuration is not enabled for this app. Please add a \'config\' section to your app configuration.'
+      : null;
+
+    return (
+      <div>
+        <Toolbar section="Settings" subsection="Data Browser" />
+        <Notification
+          note={notAvailableMessage || (message && message.text)}
+          isErrorNote={notAvailableMessage ? true : (message && message.isError)}
+        />
+        <div className={styles.settings_page}>
+          <Fieldset legend="Info Panels">
+            <Field
+              labelWidth={62}
+              label={
+                <Label
+                  text="Reverse Auto-Scroll Speed Factor"
+                  description="Speed multiplier when reversing auto-scroll (Cmd+Option). Default is 1 (full speed). Use 0.5 for half speed."
+                />
+              }
+              input={
+                <TextInput
+                  placeholder={this.state.loading ? 'Loading...' : '1'}
+                  value={this.state.reverseAutoScrollSpeedFactor}
+                  disabled={!serverConfigEnabled || this.state.loading}
+                  onChange={this.handleReverseAutoScrollSpeedFactorChange.bind(this)}
+                  onBlur={this.saveReverseAutoScrollSpeedFactor.bind(this)}
+                />
+              }
+            />
+          </Fieldset>
+        </div>
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-dashboard/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-dashboard/blob/alpha/LICENSE).

## Issue

Add support for reversing scroll direction during auto-scrolling info panels while holding Command+Option keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Data Browser settings section to the dashboard Settings menu.
  * Introduced reverse auto-scroll functionality, togglable via keyboard modifier.
  * Added configurable reverse auto-scroll speed setting with user-facing controls and server-backed configuration persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->