### PR TITLE
fix: Cloud Config parameter modal overlays non-printable character info box

### DIFF
--- a/src/components/NonPrintableHighlighter/NonPrintableHighlighter.scss
+++ b/src/components/NonPrintableHighlighter/NonPrintableHighlighter.scss
@@ -10,6 +10,8 @@
 .container {
   position: relative;
   width: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 .warningContainer {
@@ -105,7 +107,7 @@
 
 // Info badge styles for non-alphanumeric character detection
 .infoContainer {
-  margin-top: -4px;
+  margin-top: 0;
 }
 
 .infoBadge {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-dashboard/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-dashboard/blob/alpha/LICENSE).

## Issue

Cloud Config parameter modal overlays non-printable character info box.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the non-printable highlighter component layout for improved organization.
  * Adjusted non-alphanumeric info badge spacing for better visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->