### PR TITLE
feat: Add Regex string validation when editing Cloud Config parameter

### DIFF
--- a/src/components/NonPrintableHighlighter/NonPrintableHighlighter.react.js
+++ b/src/components/NonPrintableHighlighter/NonPrintableHighlighter.react.js
@@ -519,6 +519,7 @@ export function getRegexValidationFromJson(jsonStr) {
  * Props:
  * - value: The string value to check
  * - isJson: If true, only check string values within the parsed JSON (for Array/Object types)
+ * - detectNonPrintable: If true, detect and display non-printable characters
  * - detectNonAlphanumeric: If true, also detect and display non-alphanumeric characters
  * - detectRegex: If true, detect and display regex validation status for string values
  * - children: The input element to wrap
@@ -534,10 +535,10 @@ export default class NonPrintableHighlighter extends React.Component {
   }
 
   render() {
-    const { value, children, isJson, detectNonAlphanumeric, detectRegex } = this.props;
-    const { totalCount, chars } = isJson
-      ? getNonPrintableCharsFromJson(value)
-      : getNonPrintableChars(value);
+    const { value, children, isJson, detectNonPrintable, detectNonAlphanumeric, detectRegex } = this.props;
+    const { totalCount, chars } = detectNonPrintable
+      ? (isJson ? getNonPrintableCharsFromJson(value) : getNonPrintableChars(value))
+      : { totalCount: 0, chars: [] };
     const hasNonPrintable = totalCount > 0;
 
     // Get non-alphanumeric characters if detection is enabled

--- a/src/components/NonPrintableHighlighter/NonPrintableHighlighter.react.js
+++ b/src/components/NonPrintableHighlighter/NonPrintableHighlighter.react.js
@@ -130,6 +130,7 @@ const NON_PRINTABLE_REGEX = new RegExp(
 // Regex for non-alphanumeric characters (anything not a-z, A-Z, 0-9)
 const NON_ALPHANUMERIC_REGEX = /[^a-zA-Z0-9]/g;
 
+
 /**
  * Check if a string contains non-printable characters
  */
@@ -444,14 +445,82 @@ export function getNonPrintableCharsFromJson(jsonStr) {
 }
 
 /**
+ * Check if a string is a valid regular expression pattern
+ * Tests without flags, with 'u' (unicode), and with 'v' (unicodeSets) since some
+ * patterns are only valid with specific flags (e.g., \p{L} requires 'u') and others
+ * become invalid with 'u' (e.g., lone surrogates). The 'u' and 'v' flags are mutually
+ * exclusive with overlapping but different validity sets.
+ * Returns { isValid: boolean, requiredFlag: string | null, error: string | null }
+ * - isValid: true if the pattern is valid in at least one mode
+ * - requiredFlag: null if valid without flags, 'unicode' or 'unicodeSets' if a flag is needed
+ *   (picks the least restrictive flag: prefers unicode over unicodeSets)
+ * - error: error message if invalid in all modes, null otherwise
+ */
+export function getRegexValidation(str) {
+  if (!str || typeof str !== 'string') {
+    return { isValid: false, requiredFlag: null, error: 'Empty value' };
+  }
+
+  // Test modes in order of preference: no flags first, then /u, then /v
+  const modes = [
+    { flags: '', flag: null },
+    { flags: 'u', flag: 'unicode' },
+    { flags: 'v', flag: 'unicodeSets' },
+  ];
+
+  let lastError = null;
+
+  for (const { flags, flag } of modes) {
+    try {
+      new RegExp(str, flags);
+      return { isValid: true, requiredFlag: flag, error: null };
+    } catch (e) {
+      lastError = e.message;
+    }
+  }
+
+  return { isValid: false, requiredFlag: null, error: lastError };
+}
+
+/**
+ * Check regex validity for all string values within a parsed JSON object/array
+ * Returns { results: [{ path, value, isValid, error }] }
+ * Only includes string values; non-string values are skipped.
+ */
+export function getRegexValidationFromJson(jsonStr) {
+  if (!jsonStr || typeof jsonStr !== 'string') {
+    return { results: [] };
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(jsonStr);
+  } catch {
+    return { results: [] };
+  }
+
+  const stringValuesWithPaths = extractStringValuesWithPaths(parsed);
+  const results = [];
+
+  for (const { value, path } of stringValuesWithPaths) {
+    const { isValid, requiredFlag, error } = getRegexValidation(value);
+    results.push({ path, value, isValid, requiredFlag, error });
+  }
+
+  return { results };
+}
+
+/**
  * NonPrintableHighlighter component
  * Displays a warning indicator when non-printable characters are detected in the value
  * Optionally displays an info indicator when non-alphanumeric characters are detected
+ * Optionally displays a regex validation indicator when detectRegex is enabled
  *
  * Props:
  * - value: The string value to check
  * - isJson: If true, only check string values within the parsed JSON (for Array/Object types)
  * - detectNonAlphanumeric: If true, also detect and display non-alphanumeric characters
+ * - detectRegex: If true, detect and display regex validation status for string values
  * - children: The input element to wrap
  */
 export default class NonPrintableHighlighter extends React.Component {
@@ -460,11 +529,12 @@ export default class NonPrintableHighlighter extends React.Component {
     this.state = {
       showDetails: false,
       showNonAlphanumericDetails: false,
+      showRegexDetails: false,
     };
   }
 
   render() {
-    const { value, children, isJson, detectNonAlphanumeric } = this.props;
+    const { value, children, isJson, detectNonAlphanumeric, detectRegex } = this.props;
     const { totalCount, chars } = isJson
       ? getNonPrintableCharsFromJson(value)
       : getNonPrintableChars(value);
@@ -475,6 +545,27 @@ export default class NonPrintableHighlighter extends React.Component {
       ? (isJson ? getNonAlphanumericCharsFromJson(value) : getNonAlphanumericChars(value))
       : { totalCount: 0, chars: [] };
     const hasNonAlphanumeric = nonAlphanumericResult.totalCount > 0;
+
+    // Get regex validation if detection is enabled
+    const regexResult = detectRegex
+      ? (isJson
+        ? getRegexValidationFromJson(value)
+        : (value && typeof value === 'string'
+          ? { results: [{ path: null, value, ...getRegexValidation(value) }] }
+          : { results: [] }))
+      : { results: [] };
+    const hasRegexResults = regexResult.results.length > 0;
+    const requiredFlags = hasRegexResults
+      ? [...new Set(regexResult.results
+        .filter(r => r.isValid && r.requiredFlag)
+        .map(r => r.requiredFlag))]
+      : [];
+    const invalidCount = hasRegexResults
+      ? regexResult.results.filter(r => !r.isValid).length
+      : 0;
+    const regexNotes = [
+      ...(requiredFlags.length > 0 ? [`${requiredFlags.join(', ')}`] : []),
+    ];
 
     return (
       <div className={styles.container}>
@@ -545,6 +636,46 @@ export default class NonPrintableHighlighter extends React.Component {
                         <span className={styles.charPositions}>
                           in {locations.length <= 3 ? locations.join(', ') : `${locations.slice(0, 3).join(', ')}...`}
                         </span>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+        {hasRegexResults && (
+          <div className={styles.regexContainer}>
+            <div
+              className={`${styles.regexBadge} ${this.state.showRegexDetails ? styles.expanded : ''}`}
+              onClick={() => this.setState({ showRegexDetails: !this.state.showRegexDetails })}
+              title="Click for details"
+            >
+              <span className={styles.regexIcon}>ℛ</span>
+              <span className={styles.regexText}>
+                <span className={invalidCount > 0 ? styles.regexLabelInvalid : undefined}>
+                  {isJson
+                    ? `${regexResult.results.filter(r => r.isValid).length}/${regexResult.results.length} valid regex pattern${regexResult.results.length > 1 ? 's' : ''}`
+                    : (regexResult.results[0].isValid ? 'Valid regex pattern' : 'Invalid regex pattern')
+                  }
+                </span>
+                {regexNotes.length > 0 && ` (${regexNotes.join(', ')})`}
+              </span>
+            </div>
+            {this.state.showRegexDetails && (
+              <div className={styles.regexDetailsPanel}>
+                <div className={styles.charList}>
+                  {regexResult.results.map(({ path, isValid, requiredFlag, error }, i) => (
+                    <div key={i} className={styles.charItem}>
+                      {path && <span className={styles.charCode}>{path}</span>}
+                      <span className={isValid ? styles.regexLabelValid : styles.regexLabelInvalid}>
+                        {isValid ? 'Valid' : 'Invalid'}
+                      </span>
+                      {isValid && requiredFlag && (
+                        <span className={styles.charPositions}>{requiredFlag}</span>
+                      )}
+                      {!isValid && error && (
+                        <span className={styles.charPositions}>{error}</span>
                       )}
                     </div>
                   ))}

--- a/src/components/NonPrintableHighlighter/NonPrintableHighlighter.scss
+++ b/src/components/NonPrintableHighlighter/NonPrintableHighlighter.scss
@@ -159,3 +159,67 @@
   font-weight: 600;
   color: #1565c0;
 }
+
+// Regex validation badge styles
+.regexContainer {
+  margin-top: 0;
+}
+
+.regexBadge {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  width: 100%;
+  padding: 8px 10px;
+  background: #e8f5e9;
+  border: 1px solid #4caf50;
+  border-radius: 4px;
+  cursor: pointer;
+  user-select: none;
+  transition: background-color 0.15s ease;
+
+  &:hover {
+    background: #c8e6c9;
+  }
+
+  &.expanded {
+    border-radius: 4px 4px 0 0;
+    border-bottom: 1px solid #4caf50;
+  }
+}
+
+.regexIcon {
+  color: #2e7d32;
+  font-size: 14px;
+  font-family: monospace;
+  font-weight: 700;
+}
+
+.regexText {
+  color: #2e7d32;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.regexDetailsPanel {
+  padding: 10px 12px;
+  background: #f1f8e9;
+  border: 1px solid #a5d6a7;
+  border-top: none;
+  border-radius: 0 0 4px 4px;
+}
+
+.regexLabelValid {
+  font-family: monospace;
+  font-size: 11px;
+  font-weight: 600;
+  color: #2e7d32;
+}
+
+.regexLabelInvalid {
+  font-family: monospace;
+  font-size: 11px;
+  font-weight: 600;
+  color: #d32f2f;
+}

--- a/src/dashboard/Data/Config/ConfigDialog.react.js
+++ b/src/dashboard/Data/Config/ConfigDialog.react.js
@@ -51,7 +51,7 @@ const EDITORS = {
     <Toggle type={Toggle.Types.TRUE_FALSE} value={!!value} onChange={onChange} />
   ),
   String: (value, onChange, wordWrap, syntaxColors, options = {}) => (
-    <NonPrintableHighlighter value={value} detectNonAlphanumeric={true} detectRegex={!!options.detectRegex}>
+    <NonPrintableHighlighter value={value} detectNonPrintable={!!options.detectNonPrintable} detectNonAlphanumeric={true} detectRegex={!!options.detectRegex}>
       <TextInput multiline={true} value={value || ''} onChange={onChange} />
     </NonPrintableHighlighter>
   ),
@@ -60,7 +60,7 @@ const EDITORS = {
   ),
   Date: (value, onChange) => <DateTimeInput fixed={true} value={value} onChange={onChange} />,
   Object: (value, onChange, wordWrap, syntaxColors, options = {}) => (
-    <NonPrintableHighlighter value={value} isJson={true} detectNonAlphanumeric={true} detectRegex={!!options.detectRegex}>
+    <NonPrintableHighlighter value={value} isJson={true} detectNonPrintable={!!options.detectNonPrintable} detectNonAlphanumeric={true} detectRegex={!!options.detectRegex}>
       <JsonEditor
         value={value || ''}
         onChange={onChange}
@@ -71,7 +71,7 @@ const EDITORS = {
     </NonPrintableHighlighter>
   ),
   Array: (value, onChange, wordWrap, syntaxColors, options = {}) => (
-    <NonPrintableHighlighter value={value} isJson={true} detectNonAlphanumeric={true} detectRegex={!!options.detectRegex}>
+    <NonPrintableHighlighter value={value} isJson={true} detectNonPrintable={!!options.detectNonPrintable} detectNonAlphanumeric={true} detectRegex={!!options.detectRegex}>
       <JsonEditor
         value={value || ''}
         onChange={onChange}
@@ -129,7 +129,8 @@ export default class ConfigDialog extends React.Component {
       wordWrap: false,
       error: null,
       syntaxColors: null,
-      detectRegex: false,
+      detectNonPrintable: true,
+      detectRegex: true,
     };
     if (props.param.length > 0) {
       let initialValue = props.value;
@@ -146,7 +147,8 @@ export default class ConfigDialog extends React.Component {
         wordWrap: false,
         error: initialError,
         syntaxColors: null,
-        detectRegex: false,
+        detectNonPrintable: true,
+        detectRegex: true,
       };
     }
   }
@@ -181,6 +183,9 @@ export default class ConfigDialog extends React.Component {
           CONFIG_KEY,
           this.context.applicationId
         );
+        if (settings?.detectNonPrintable !== undefined) {
+          this.setState({ detectNonPrintable: !!settings.detectNonPrintable });
+        }
         if (settings?.detectRegex !== undefined) {
           this.setState({ detectRegex: !!settings.detectRegex });
         }
@@ -367,7 +372,7 @@ export default class ConfigDialog extends React.Component {
             value => this.setState({ value, error: null }),
             this.state.wordWrap,
             this.state.syntaxColors,
-            { detectRegex: this.state.detectRegex }
+            { detectNonPrintable: this.state.detectNonPrintable, detectRegex: this.state.detectRegex }
           )}
         />
 

--- a/src/dashboard/Data/Config/ConfigDialog.react.js
+++ b/src/dashboard/Data/Config/ConfigDialog.react.js
@@ -155,7 +155,7 @@ export default class ConfigDialog extends React.Component {
 
   componentDidMount() {
     this.loadSyntaxColors();
-    this.loadDetectRegexSetting();
+    this.loadValueAnalysisSettings();
   }
 
   async loadSyntaxColors() {
@@ -175,7 +175,7 @@ export default class ConfigDialog extends React.Component {
     }
   }
 
-  async loadDetectRegexSetting() {
+  async loadValueAnalysisSettings() {
     try {
       const serverStorage = new ServerConfigStorage(this.context);
       if (serverStorage.isServerConfigEnabled()) {
@@ -191,7 +191,7 @@ export default class ConfigDialog extends React.Component {
         }
       }
     } catch {
-      // Silently fail - keep default (false)
+      // Silently fail - keep defaults (true)
     }
   }
 

--- a/src/dashboard/Data/Config/ConfigDialog.react.js
+++ b/src/dashboard/Data/Config/ConfigDialog.react.js
@@ -28,6 +28,7 @@ import LoaderContainer from 'components/LoaderContainer/LoaderContainer.react';
 import ServerConfigStorage from 'lib/ServerConfigStorage';
 import { CurrentApp } from 'context/currentApp';
 
+const CONFIG_KEY = 'config.settings';
 const FORMATTING_CONFIG_KEY = 'config.formatting.syntax';
 
 const PARAM_TYPES = ['Boolean', 'String', 'Number', 'Date', 'Object', 'Array', 'GeoPoint', 'File'];
@@ -49,8 +50,8 @@ const EDITORS = {
   Boolean: (value, onChange) => (
     <Toggle type={Toggle.Types.TRUE_FALSE} value={!!value} onChange={onChange} />
   ),
-  String: (value, onChange) => (
-    <NonPrintableHighlighter value={value} detectNonAlphanumeric={true}>
+  String: (value, onChange, wordWrap, syntaxColors, options = {}) => (
+    <NonPrintableHighlighter value={value} detectNonAlphanumeric={true} detectRegex={!!options.detectRegex}>
       <TextInput multiline={true} value={value || ''} onChange={onChange} />
     </NonPrintableHighlighter>
   ),
@@ -58,8 +59,8 @@ const EDITORS = {
     <TextInput value={value || ''} onChange={numberValidator(onChange)} />
   ),
   Date: (value, onChange) => <DateTimeInput fixed={true} value={value} onChange={onChange} />,
-  Object: (value, onChange, wordWrap, syntaxColors) => (
-    <NonPrintableHighlighter value={value} isJson={true} detectNonAlphanumeric={true}>
+  Object: (value, onChange, wordWrap, syntaxColors, options = {}) => (
+    <NonPrintableHighlighter value={value} isJson={true} detectNonAlphanumeric={true} detectRegex={!!options.detectRegex}>
       <JsonEditor
         value={value || ''}
         onChange={onChange}
@@ -69,8 +70,8 @@ const EDITORS = {
       />
     </NonPrintableHighlighter>
   ),
-  Array: (value, onChange, wordWrap, syntaxColors) => (
-    <NonPrintableHighlighter value={value} isJson={true} detectNonAlphanumeric={true}>
+  Array: (value, onChange, wordWrap, syntaxColors, options = {}) => (
+    <NonPrintableHighlighter value={value} isJson={true} detectNonAlphanumeric={true} detectRegex={!!options.detectRegex}>
       <JsonEditor
         value={value || ''}
         onChange={onChange}
@@ -128,6 +129,7 @@ export default class ConfigDialog extends React.Component {
       wordWrap: false,
       error: null,
       syntaxColors: null,
+      detectRegex: false,
     };
     if (props.param.length > 0) {
       let initialValue = props.value;
@@ -144,12 +146,14 @@ export default class ConfigDialog extends React.Component {
         wordWrap: false,
         error: initialError,
         syntaxColors: null,
+        detectRegex: false,
       };
     }
   }
 
   componentDidMount() {
     this.loadSyntaxColors();
+    this.loadDetectRegexSetting();
   }
 
   async loadSyntaxColors() {
@@ -166,6 +170,23 @@ export default class ConfigDialog extends React.Component {
       }
     } catch {
       // Silently fail - use default colors from CSS
+    }
+  }
+
+  async loadDetectRegexSetting() {
+    try {
+      const serverStorage = new ServerConfigStorage(this.context);
+      if (serverStorage.isServerConfigEnabled()) {
+        const settings = await serverStorage.getConfig(
+          CONFIG_KEY,
+          this.context.applicationId
+        );
+        if (settings?.detectRegex !== undefined) {
+          this.setState({ detectRegex: !!settings.detectRegex });
+        }
+      }
+    } catch {
+      // Silently fail - keep default (false)
     }
   }
 
@@ -345,7 +366,8 @@ export default class ConfigDialog extends React.Component {
             this.state.value,
             value => this.setState({ value, error: null }),
             this.state.wordWrap,
-            this.state.syntaxColors
+            this.state.syntaxColors,
+            { detectRegex: this.state.detectRegex }
           )}
         />
 

--- a/src/dashboard/Settings/CloudConfigSettings.react.js
+++ b/src/dashboard/Settings/CloudConfigSettings.react.js
@@ -5,6 +5,7 @@ import Fieldset from 'components/Fieldset/Fieldset.react';
 import Label from 'components/Label/Label.react';
 import React from 'react';
 import TextInput from 'components/TextInput/TextInput.react';
+import Toggle from 'components/Toggle/Toggle.react';
 import Toolbar from 'components/Toolbar/Toolbar.react';
 import Notification from 'dashboard/Data/Browser/Notification.react';
 import ServerConfigStorage from 'lib/ServerConfigStorage';
@@ -35,6 +36,7 @@ export default class CloudConfigSettings extends DashboardView {
     this.state = {
       cloudConfigHistoryLimit: '',
       syntaxColors: { ...DEFAULT_SYNTAX_COLORS },
+      detectRegex: false,
       message: undefined,
       loading: true,
     };
@@ -60,6 +62,9 @@ export default class CloudConfigSettings extends DashboardView {
       if (settings) {
         if (settings.historyLimit !== undefined) {
           this.setState({ cloudConfigHistoryLimit: String(settings.historyLimit) });
+        }
+        if (settings.detectRegex !== undefined) {
+          this.setState({ detectRegex: !!settings.detectRegex });
         }
       }
 
@@ -100,6 +105,16 @@ export default class CloudConfigSettings extends DashboardView {
 
   handleCloudConfigHistoryLimitChange(value) {
     this.setState({ cloudConfigHistoryLimit: value });
+  }
+
+  async handleDetectRegexChange(value) {
+    this.setState({ detectRegex: value });
+    if (await this.saveSettings({ detectRegex: value })) {
+      this.showNote(`Regex validation display ${value ? 'enabled' : 'disabled'}.`);
+    } else {
+      this.setState({ detectRegex: !value });
+      this.showNote('Failed to save setting.', true);
+    }
   }
 
   async saveCloudConfigHistoryLimit() {
@@ -325,6 +340,29 @@ export default class CloudConfigSettings extends DashboardView {
                 disabled={!serverConfigEnabled || this.state.loading}
               />
             </div>
+          </Fieldset>
+          <Fieldset
+            legend="Value Analysis"
+            description="Configure value analysis options for the Cloud Config editor."
+          >
+            <Field
+              labelWidth={62}
+              label={
+                <Label
+                  text="Regex Validation"
+                  description="When enabled, the parameter editor shows whether string values are valid regular expression patterns. Patterns are tested with default, /u (unicode), and /v (unicodeSets) flags."
+                />
+              }
+              input={
+                <Toggle
+                  type={Toggle.Types.YES_NO}
+                  value={this.state.detectRegex}
+                  onChange={this.handleDetectRegexChange.bind(this)}
+                  disabled={!serverConfigEnabled || this.state.loading}
+                  additionalStyles={{ margin: '0px' }}
+                />
+              }
+            />
           </Fieldset>
         </div>
       </div>

--- a/src/dashboard/Settings/CloudConfigSettings.react.js
+++ b/src/dashboard/Settings/CloudConfigSettings.react.js
@@ -36,7 +36,8 @@ export default class CloudConfigSettings extends DashboardView {
     this.state = {
       cloudConfigHistoryLimit: '',
       syntaxColors: { ...DEFAULT_SYNTAX_COLORS },
-      detectRegex: false,
+      detectNonPrintable: true,
+      detectRegex: true,
       message: undefined,
       loading: true,
     };
@@ -62,6 +63,9 @@ export default class CloudConfigSettings extends DashboardView {
       if (settings) {
         if (settings.historyLimit !== undefined) {
           this.setState({ cloudConfigHistoryLimit: String(settings.historyLimit) });
+        }
+        if (settings.detectNonPrintable !== undefined) {
+          this.setState({ detectNonPrintable: !!settings.detectNonPrintable });
         }
         if (settings.detectRegex !== undefined) {
           this.setState({ detectRegex: !!settings.detectRegex });
@@ -107,9 +111,21 @@ export default class CloudConfigSettings extends DashboardView {
     this.setState({ cloudConfigHistoryLimit: value });
   }
 
+  async handleDetectNonPrintableChange(value) {
+    this.setState({ detectNonPrintable: value });
+    // Don't store default value (true) on server
+    if (await this.saveSettings({ detectNonPrintable: value === true ? undefined : value })) {
+      this.showNote(`Non-printable character detection ${value ? 'enabled' : 'disabled'}.`);
+    } else {
+      this.setState({ detectNonPrintable: !value });
+      this.showNote('Failed to save setting.', true);
+    }
+  }
+
   async handleDetectRegexChange(value) {
     this.setState({ detectRegex: value });
-    if (await this.saveSettings({ detectRegex: value })) {
+    // Don't store default value (true) on server
+    if (await this.saveSettings({ detectRegex: value === true ? undefined : value })) {
       this.showNote(`Regex validation display ${value ? 'enabled' : 'disabled'}.`);
     } else {
       this.setState({ detectRegex: !value });
@@ -290,6 +306,47 @@ export default class CloudConfigSettings extends DashboardView {
             />
           </Fieldset>
           <Fieldset
+            legend="Value Analysis"
+            description="Configure value analysis options for the Cloud Config editor."
+          >
+            <Field
+              labelWidth={62}
+              label={
+                <Label
+                  text="Non-Printable Characters"
+                  description="When enabled, the parameter editor highlights non-printable characters such as zero-width spaces and control characters."
+                />
+              }
+              input={
+                <Toggle
+                  type={Toggle.Types.YES_NO}
+                  value={this.state.detectNonPrintable}
+                  onChange={this.handleDetectNonPrintableChange.bind(this)}
+                  disabled={!serverConfigEnabled || this.state.loading}
+                  additionalStyles={{ margin: '0px' }}
+                />
+              }
+            />
+            <Field
+              labelWidth={62}
+              label={
+                <Label
+                  text="Regex Validation"
+                  description="When enabled, the parameter editor shows whether string values are valid regular expression patterns. Patterns are tested with default, /u (unicode), and /v (unicodeSets) flags."
+                />
+              }
+              input={
+                <Toggle
+                  type={Toggle.Types.YES_NO}
+                  value={this.state.detectRegex}
+                  onChange={this.handleDetectRegexChange.bind(this)}
+                  disabled={!serverConfigEnabled || this.state.loading}
+                  additionalStyles={{ margin: '0px' }}
+                />
+              }
+            />
+          </Fieldset>
+          <Fieldset
             legend="Formatting"
             description="Customize JSON syntax highlighting colors for the Cloud Config editor."
           >
@@ -340,29 +397,6 @@ export default class CloudConfigSettings extends DashboardView {
                 disabled={!serverConfigEnabled || this.state.loading}
               />
             </div>
-          </Fieldset>
-          <Fieldset
-            legend="Value Analysis"
-            description="Configure value analysis options for the Cloud Config editor."
-          >
-            <Field
-              labelWidth={62}
-              label={
-                <Label
-                  text="Regex Validation"
-                  description="When enabled, the parameter editor shows whether string values are valid regular expression patterns. Patterns are tested with default, /u (unicode), and /v (unicodeSets) flags."
-                />
-              }
-              input={
-                <Toggle
-                  type={Toggle.Types.YES_NO}
-                  value={this.state.detectRegex}
-                  onChange={this.handleDetectRegexChange.bind(this)}
-                  disabled={!serverConfigEnabled || this.state.loading}
-                  additionalStyles={{ margin: '0px' }}
-                />
-              }
-            />
           </Fieldset>
         </div>
       </div>


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-dashboard/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-dashboard/blob/alpha/LICENSE).

## Issue

Add Regex string validation when editing Cloud Config parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Regex pattern validation in JSON and string editors with summary counts and per-pattern detail panels.
  * Editor options to enable/disable non-printable and regex detection; collapsible validation details for easier inspection.
* **Style**
  * New styles for a validation badge, summary line and expandable details panel.
* **Chores**
  * Added UI controls and persistence for Value Analysis settings (non-printable & regex detection).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->