### PR TITLE
feat: Add option to block saving Cloud Config parameter if validation fails

### DIFF
--- a/src/components/Dropdown/Dropdown.scss
+++ b/src/components/Dropdown/Dropdown.scss
@@ -27,6 +27,7 @@
   border: 1px solid $blue;
   background: white;
   overflow: auto;
+  overscroll-behavior: none;
 
   button {
     @include buttonReset;

--- a/src/components/MultiSelect/MultiSelect.react.js
+++ b/src/components/MultiSelect/MultiSelect.react.js
@@ -54,6 +54,9 @@ export default class MultiSelect extends React.Component {
   }
 
   toggle() {
+    if (this.props.disabled) {
+      return;
+    }
     this.setPosition();
     this.setState({ open: !this.state.open });
   }
@@ -184,4 +187,5 @@ MultiSelect.propTypes = {
   dense: PropTypes.bool.describe('Mini variant - less height'),
   chips: PropTypes.bool.describe('Display chip for every selected item'),
   formatSelection: PropTypes.func.describe('Custom function to format the display text. Receives array of selected labels.'),
+  disabled: PropTypes.bool.describe('When true, prevents the dropdown from opening.'),
 };

--- a/src/components/MultiSelect/MultiSelect.scss
+++ b/src/components/MultiSelect/MultiSelect.scss
@@ -27,6 +27,7 @@
   border: 1px solid $blue;
   background: white;
   overflow: auto;
+  overscroll-behavior: none;
 
   > *:last-child .option {
     border-bottom: none;

--- a/src/components/NonPrintableHighlighter/NonPrintableHighlighter.react.js
+++ b/src/components/NonPrintableHighlighter/NonPrintableHighlighter.react.js
@@ -654,7 +654,7 @@ export default class NonPrintableHighlighter extends React.Component {
             >
               <span className={styles.regexIcon}>ℛ</span>
               <span className={styles.regexText}>
-                <span className={invalidCount > 0 ? styles.regexLabelInvalid : undefined}>
+                <span className={invalidCount > 0 ? styles.regexSummaryInvalid : undefined}>
                   {isJson
                     ? `${regexResult.results.filter(r => r.isValid).length}/${regexResult.results.length} valid regex pattern${regexResult.results.length > 1 ? 's' : ''}`
                     : (regexResult.results[0].isValid ? 'Valid regex pattern' : 'Invalid regex pattern')

--- a/src/components/NonPrintableHighlighter/NonPrintableHighlighter.scss
+++ b/src/components/NonPrintableHighlighter/NonPrintableHighlighter.scss
@@ -223,3 +223,8 @@
   font-weight: 600;
   color: #d32f2f;
 }
+
+.regexSummaryInvalid {
+  color: #d32f2f;
+  font-weight: 600;
+}

--- a/src/dashboard/Data/Config/Config.react.js
+++ b/src/dashboard/Data/Config/Config.react.js
@@ -61,6 +61,9 @@ class Config extends TableView {
       detectRegex: false,
       nonPrintableBlockSave: [],
       nonPrintableShowOnlyFor: [],
+      detectNonAlphanumeric: false,
+      nonAlphanumericBlockSave: [],
+      nonAlphanumericShowOnlyFor: [],
       regexBlockSave: [],
       regexShowOnlyFor: [],
     };
@@ -106,6 +109,7 @@ class Config extends TableView {
       if (settings) {
         const updates = {
           detectNonPrintable: settings.detectNonPrintable !== undefined ? !!settings.detectNonPrintable : true,
+          detectNonAlphanumeric: settings.detectNonAlphanumeric !== undefined ? !!settings.detectNonAlphanumeric : true,
           detectRegex: settings.detectRegex !== undefined ? !!settings.detectRegex : true,
         };
         if (settings.historyLimit !== undefined) {
@@ -117,6 +121,12 @@ class Config extends TableView {
         if (Array.isArray(settings.nonPrintableShowOnlyFor)) {
           updates.nonPrintableShowOnlyFor = settings.nonPrintableShowOnlyFor;
         }
+        if (Array.isArray(settings.nonAlphanumericBlockSave)) {
+          updates.nonAlphanumericBlockSave = settings.nonAlphanumericBlockSave;
+        }
+        if (Array.isArray(settings.nonAlphanumericShowOnlyFor)) {
+          updates.nonAlphanumericShowOnlyFor = settings.nonAlphanumericShowOnlyFor;
+        }
         if (Array.isArray(settings.regexBlockSave)) {
           updates.regexBlockSave = settings.regexBlockSave;
         }
@@ -125,10 +135,10 @@ class Config extends TableView {
         }
         this.setState(updates);
       } else {
-        this.setState({ detectNonPrintable: true, detectRegex: true });
+        this.setState({ detectNonPrintable: true, detectNonAlphanumeric: true, detectRegex: true });
       }
     } catch {
-      this.setState({ detectNonPrintable: true, detectRegex: true });
+      this.setState({ detectNonPrintable: true, detectNonAlphanumeric: true, detectRegex: true });
     }
   }
 
@@ -222,6 +232,9 @@ class Config extends TableView {
           detectRegex={this.state.detectRegex}
           nonPrintableBlockSave={this.state.nonPrintableBlockSave}
           nonPrintableShowOnlyFor={this.state.nonPrintableShowOnlyFor}
+          detectNonAlphanumeric={this.state.detectNonAlphanumeric}
+          nonAlphanumericBlockSave={this.state.nonAlphanumericBlockSave}
+          nonAlphanumericShowOnlyFor={this.state.nonAlphanumericShowOnlyFor}
           regexBlockSave={this.state.regexBlockSave}
           regexShowOnlyFor={this.state.regexShowOnlyFor}
         />

--- a/src/dashboard/Data/Config/Config.react.js
+++ b/src/dashboard/Data/Config/Config.react.js
@@ -57,6 +57,12 @@ class Config extends TableView {
       removeEntryArrayValue: [],
       serverHistoryLimit: undefined,
       currentParamHistory: null,
+      detectNonPrintable: false,
+      detectRegex: false,
+      nonPrintableBlockSave: [],
+      nonPrintableShowOnlyFor: [],
+      regexBlockSave: [],
+      regexShowOnlyFor: [],
     };
     this.noteTimeout = null;
     this.serverStorage = null;
@@ -98,12 +104,31 @@ class Config extends TableView {
         this.context.applicationId
       );
       if (settings) {
+        const updates = {
+          detectNonPrintable: settings.detectNonPrintable !== undefined ? !!settings.detectNonPrintable : true,
+          detectRegex: settings.detectRegex !== undefined ? !!settings.detectRegex : true,
+        };
         if (settings.historyLimit !== undefined) {
-          this.setState({ serverHistoryLimit: settings.historyLimit });
+          updates.serverHistoryLimit = settings.historyLimit;
         }
+        if (Array.isArray(settings.nonPrintableBlockSave)) {
+          updates.nonPrintableBlockSave = settings.nonPrintableBlockSave;
+        }
+        if (Array.isArray(settings.nonPrintableShowOnlyFor)) {
+          updates.nonPrintableShowOnlyFor = settings.nonPrintableShowOnlyFor;
+        }
+        if (Array.isArray(settings.regexBlockSave)) {
+          updates.regexBlockSave = settings.regexBlockSave;
+        }
+        if (Array.isArray(settings.regexShowOnlyFor)) {
+          updates.regexShowOnlyFor = settings.regexShowOnlyFor;
+        }
+        this.setState(updates);
+      } else {
+        this.setState({ detectNonPrintable: true, detectRegex: true });
       }
     } catch {
-      // Fall back to existing context value
+      this.setState({ detectNonPrintable: true, detectRegex: true });
     }
   }
 
@@ -193,6 +218,12 @@ class Config extends TableView {
           parseServerVersion={this.context.serverInfo?.parseServerVersion}
           loading={this.state.loading}
           configHistory={this.state.currentParamHistory}
+          detectNonPrintable={this.state.detectNonPrintable}
+          detectRegex={this.state.detectRegex}
+          nonPrintableBlockSave={this.state.nonPrintableBlockSave}
+          nonPrintableShowOnlyFor={this.state.nonPrintableShowOnlyFor}
+          regexBlockSave={this.state.regexBlockSave}
+          regexShowOnlyFor={this.state.regexShowOnlyFor}
         />
       );
     } else if (this.state.showDeleteParameterDialog) {

--- a/src/dashboard/Data/Config/ConfigDialog.react.js
+++ b/src/dashboard/Data/Config/ConfigDialog.react.js
@@ -169,6 +169,23 @@ export default class ConfigDialog extends React.Component {
     }
   }
 
+  getEffectiveDetectionFlags() {
+    const isExistingParam = this.props.param && this.props.param.length > 0;
+    let detectNonPrintable = this.props.detectNonPrintable;
+    if (detectNonPrintable && isExistingParam && this.props.nonPrintableShowOnlyFor.length > 0) {
+      detectNonPrintable = this.props.nonPrintableShowOnlyFor.includes(this.props.param);
+    }
+    let detectNonAlphanumeric = this.props.detectNonAlphanumeric;
+    if (detectNonAlphanumeric && isExistingParam && this.props.nonAlphanumericShowOnlyFor.length > 0) {
+      detectNonAlphanumeric = this.props.nonAlphanumericShowOnlyFor.includes(this.props.param);
+    }
+    let detectRegex = this.props.detectRegex;
+    if (detectRegex && isExistingParam && this.props.regexShowOnlyFor.length > 0) {
+      detectRegex = this.props.regexShowOnlyFor.includes(this.props.param);
+    }
+    return { detectNonPrintable, detectNonAlphanumeric, detectRegex };
+  }
+
   valid() {
     if (!this.state.name.match(/^[a-zA-Z_][a-zA-Z0-9_]*$/)) {
       return false;
@@ -236,9 +253,12 @@ export default class ConfigDialog extends React.Component {
       }
     }
 
+    // Compute effective detection flags (respecting show-only-for settings)
+    const { detectNonPrintable, detectNonAlphanumeric, detectRegex } = this.getEffectiveDetectionFlags();
+
     // Block save if non-printable characters detected for this param
     if (
-      this.props.detectNonPrintable &&
+      detectNonPrintable &&
       this.props.param.length > 0 &&
       this.props.nonPrintableBlockSave.includes(this.props.param)
     ) {
@@ -258,7 +278,7 @@ export default class ConfigDialog extends React.Component {
 
     // Block save if non-alphanumeric characters detected for this param
     if (
-      this.props.detectNonAlphanumeric &&
+      detectNonAlphanumeric &&
       this.props.param.length > 0 &&
       this.props.nonAlphanumericBlockSave.includes(this.props.param)
     ) {
@@ -278,7 +298,7 @@ export default class ConfigDialog extends React.Component {
 
     // Block save if regex validation fails for this param
     if (
-      this.props.detectRegex &&
+      detectRegex &&
       this.props.param.length > 0 &&
       this.props.regexBlockSave.includes(this.props.param)
     ) {
@@ -394,19 +414,11 @@ export default class ConfigDialog extends React.Component {
     };
 
     // Determine effective detection flags based on show-only-for settings
-    const isExistingParam = this.props.param && this.props.param.length > 0;
-    let effectiveDetectNonPrintable = this.props.detectNonPrintable;
-    if (effectiveDetectNonPrintable && isExistingParam && this.props.nonPrintableShowOnlyFor.length > 0) {
-      effectiveDetectNonPrintable = this.props.nonPrintableShowOnlyFor.includes(this.props.param);
-    }
-    let effectiveDetectNonAlphanumeric = this.props.detectNonAlphanumeric;
-    if (effectiveDetectNonAlphanumeric && isExistingParam && this.props.nonAlphanumericShowOnlyFor.length > 0) {
-      effectiveDetectNonAlphanumeric = this.props.nonAlphanumericShowOnlyFor.includes(this.props.param);
-    }
-    let effectiveDetectRegex = this.props.detectRegex;
-    if (effectiveDetectRegex && isExistingParam && this.props.regexShowOnlyFor.length > 0) {
-      effectiveDetectRegex = this.props.regexShowOnlyFor.includes(this.props.param);
-    }
+    const {
+      detectNonPrintable: effectiveDetectNonPrintable,
+      detectNonAlphanumeric: effectiveDetectNonAlphanumeric,
+      detectRegex: effectiveDetectRegex,
+    } = this.getEffectiveDetectionFlags();
 
     const dialogContent = (
       <div>

--- a/src/dashboard/Data/Config/ConfigDialog.react.js
+++ b/src/dashboard/Data/Config/ConfigDialog.react.js
@@ -192,7 +192,7 @@ export default class ConfigDialog extends React.Component {
       case 'Object':
         try {
           const obj = JSON.parse(this.state.value);
-          if (!obj || typeof obj !== 'object') {
+          if (!obj || typeof obj !== 'object' || Array.isArray(obj)) {
             return false;
           }
         } catch {

--- a/src/dashboard/Data/Config/ConfigDialog.react.js
+++ b/src/dashboard/Data/Config/ConfigDialog.react.js
@@ -12,7 +12,7 @@ import FileInput from 'components/FileInput/FileInput.react';
 import GeoPointInput from 'components/GeoPointInput/GeoPointInput.react';
 import Label from 'components/Label/Label.react';
 import Modal from 'components/Modal/Modal.react';
-import NonPrintableHighlighter from 'components/NonPrintableHighlighter/NonPrintableHighlighter.react';
+import NonPrintableHighlighter, { hasNonPrintableChars, getNonPrintableCharsFromJson, getRegexValidation, getRegexValidationFromJson } from 'components/NonPrintableHighlighter/NonPrintableHighlighter.react';
 import Option from 'components/Dropdown/Option.react';
 import Parse from 'parse';
 import React from 'react';
@@ -131,6 +131,10 @@ export default class ConfigDialog extends React.Component {
       syntaxColors: null,
       detectNonPrintable: true,
       detectRegex: true,
+      nonPrintableBlockSave: [],
+      nonPrintableShowOnlyFor: [],
+      regexBlockSave: [],
+      regexShowOnlyFor: [],
     };
     if (props.param.length > 0) {
       let initialValue = props.value;
@@ -149,6 +153,10 @@ export default class ConfigDialog extends React.Component {
         syntaxColors: null,
         detectNonPrintable: true,
         detectRegex: true,
+        nonPrintableBlockSave: [],
+        nonPrintableShowOnlyFor: [],
+        regexBlockSave: [],
+        regexShowOnlyFor: [],
       };
     }
   }
@@ -189,6 +197,18 @@ export default class ConfigDialog extends React.Component {
         if (settings?.detectRegex !== undefined) {
           this.setState({ detectRegex: !!settings.detectRegex });
         }
+        if (Array.isArray(settings?.nonPrintableBlockSave)) {
+          this.setState({ nonPrintableBlockSave: settings.nonPrintableBlockSave });
+        }
+        if (Array.isArray(settings?.nonPrintableShowOnlyFor)) {
+          this.setState({ nonPrintableShowOnlyFor: settings.nonPrintableShowOnlyFor });
+        }
+        if (Array.isArray(settings?.regexBlockSave)) {
+          this.setState({ regexBlockSave: settings.regexBlockSave });
+        }
+        if (Array.isArray(settings?.regexShowOnlyFor)) {
+          this.setState({ regexShowOnlyFor: settings.regexShowOnlyFor });
+        }
       }
     } catch {
       // Silently fail - keep defaults (true)
@@ -201,32 +221,41 @@ export default class ConfigDialog extends React.Component {
     }
     switch (this.state.type) {
       case 'String':
-        return !!this.state.value;
+        if (!this.state.value) {
+          return false;
+        }
+        break;
       case 'Number':
-        return !isNaN(parseFloat(this.state.value));
+        if (isNaN(parseFloat(this.state.value))) {
+          return false;
+        }
+        break;
       case 'Date':
-        return !isNaN(new Date(this.state.value));
+        if (isNaN(new Date(this.state.value))) {
+          return false;
+        }
+        break;
       case 'Object':
         try {
           const obj = JSON.parse(this.state.value);
-          if (obj && typeof obj === 'object') {
-            return true;
+          if (!obj || typeof obj !== 'object') {
+            return false;
           }
-          return false;
         } catch {
           return false;
         }
+        break;
       case 'Array':
         try {
           const obj = JSON.parse(this.state.value);
-          if (obj && Array.isArray(obj)) {
-            return true;
+          if (!obj || !Array.isArray(obj)) {
+            return false;
           }
-          return false;
         } catch {
           return false;
         }
-      case 'GeoPoint':
+        break;
+      case 'GeoPoint': {
         const val = this.state.value;
         if (!val || typeof val !== 'object') {
           return false;
@@ -242,14 +271,58 @@ export default class ConfigDialog extends React.Component {
         ) {
           return false;
         }
-        return true;
-      case 'File':
+        break;
+      }
+      case 'File': {
         const fileVal = this.state.value;
-        if (fileVal && fileVal.url()) {
-          return true;
+        if (!fileVal || !fileVal.url()) {
+          return false;
         }
-        return false;
+        break;
+      }
     }
+
+    // Block save if non-printable characters detected for this param
+    if (
+      this.state.detectNonPrintable &&
+      this.props.param.length > 0 &&
+      this.state.nonPrintableBlockSave.includes(this.props.param)
+    ) {
+      const value = this.state.value;
+      if (value && typeof value === 'string') {
+        if (this.state.type === 'Object' || this.state.type === 'Array') {
+          if (getNonPrintableCharsFromJson(value).totalCount > 0) {
+            return false;
+          }
+        } else if (this.state.type === 'String') {
+          if (hasNonPrintableChars(value)) {
+            return false;
+          }
+        }
+      }
+    }
+
+    // Block save if regex validation fails for this param
+    if (
+      this.state.detectRegex &&
+      this.props.param.length > 0 &&
+      this.state.regexBlockSave.includes(this.props.param)
+    ) {
+      const value = this.state.value;
+      if (value && typeof value === 'string') {
+        if (this.state.type === 'Object' || this.state.type === 'Array') {
+          const result = getRegexValidationFromJson(value);
+          if (result.results.some(r => !r.isValid)) {
+            return false;
+          }
+        } else if (this.state.type === 'String') {
+          if (!getRegexValidation(value).isValid) {
+            return false;
+          }
+        }
+      }
+    }
+
     return true;
   }
 
@@ -346,6 +419,17 @@ export default class ConfigDialog extends React.Component {
       this.setState({ selectedIndex: index, value });
     };
 
+    // Determine effective detection flags based on show-only-for settings
+    const isExistingParam = this.props.param && this.props.param.length > 0;
+    let effectiveDetectNonPrintable = this.state.detectNonPrintable;
+    if (effectiveDetectNonPrintable && isExistingParam && this.state.nonPrintableShowOnlyFor.length > 0) {
+      effectiveDetectNonPrintable = this.state.nonPrintableShowOnlyFor.includes(this.props.param);
+    }
+    let effectiveDetectRegex = this.state.detectRegex;
+    if (effectiveDetectRegex && isExistingParam && this.state.regexShowOnlyFor.length > 0) {
+      effectiveDetectRegex = this.state.regexShowOnlyFor.includes(this.props.param);
+    }
+
     const dialogContent = (
       <div>
         <Field
@@ -372,7 +456,7 @@ export default class ConfigDialog extends React.Component {
             value => this.setState({ value, error: null }),
             this.state.wordWrap,
             this.state.syntaxColors,
-            { detectNonPrintable: this.state.detectNonPrintable, detectRegex: this.state.detectRegex }
+            { detectNonPrintable: effectiveDetectNonPrintable, detectRegex: effectiveDetectRegex }
           )}
         />
 

--- a/src/dashboard/Data/Config/ConfigDialog.react.js
+++ b/src/dashboard/Data/Config/ConfigDialog.react.js
@@ -12,7 +12,7 @@ import FileInput from 'components/FileInput/FileInput.react';
 import GeoPointInput from 'components/GeoPointInput/GeoPointInput.react';
 import Label from 'components/Label/Label.react';
 import Modal from 'components/Modal/Modal.react';
-import NonPrintableHighlighter, { hasNonPrintableChars, getNonPrintableCharsFromJson, getRegexValidation, getRegexValidationFromJson } from 'components/NonPrintableHighlighter/NonPrintableHighlighter.react';
+import NonPrintableHighlighter, { hasNonPrintableChars, getNonPrintableCharsFromJson, hasNonAlphanumericChars, getNonAlphanumericCharsFromJson, getRegexValidation, getRegexValidationFromJson } from 'components/NonPrintableHighlighter/NonPrintableHighlighter.react';
 import Option from 'components/Dropdown/Option.react';
 import Parse from 'parse';
 import React from 'react';
@@ -50,7 +50,7 @@ const EDITORS = {
     <Toggle type={Toggle.Types.TRUE_FALSE} value={!!value} onChange={onChange} />
   ),
   String: (value, onChange, wordWrap, syntaxColors, options = {}) => (
-    <NonPrintableHighlighter value={value} detectNonPrintable={!!options.detectNonPrintable} detectNonAlphanumeric={!!options.detectNonPrintable} detectRegex={!!options.detectRegex}>
+    <NonPrintableHighlighter value={value} detectNonPrintable={!!options.detectNonPrintable} detectNonAlphanumeric={!!options.detectNonAlphanumeric} detectRegex={!!options.detectRegex}>
       <TextInput multiline={true} value={value || ''} onChange={onChange} />
     </NonPrintableHighlighter>
   ),
@@ -59,7 +59,7 @@ const EDITORS = {
   ),
   Date: (value, onChange) => <DateTimeInput fixed={true} value={value} onChange={onChange} />,
   Object: (value, onChange, wordWrap, syntaxColors, options = {}) => (
-    <NonPrintableHighlighter value={value} isJson={true} detectNonPrintable={!!options.detectNonPrintable} detectNonAlphanumeric={!!options.detectNonPrintable} detectRegex={!!options.detectRegex}>
+    <NonPrintableHighlighter value={value} isJson={true} detectNonPrintable={!!options.detectNonPrintable} detectNonAlphanumeric={!!options.detectNonAlphanumeric} detectRegex={!!options.detectRegex}>
       <JsonEditor
         value={value || ''}
         onChange={onChange}
@@ -70,7 +70,7 @@ const EDITORS = {
     </NonPrintableHighlighter>
   ),
   Array: (value, onChange, wordWrap, syntaxColors, options = {}) => (
-    <NonPrintableHighlighter value={value} isJson={true} detectNonPrintable={!!options.detectNonPrintable} detectNonAlphanumeric={!!options.detectNonPrintable} detectRegex={!!options.detectRegex}>
+    <NonPrintableHighlighter value={value} isJson={true} detectNonPrintable={!!options.detectNonPrintable} detectNonAlphanumeric={!!options.detectNonAlphanumeric} detectRegex={!!options.detectRegex}>
       <JsonEditor
         value={value || ''}
         onChange={onChange}
@@ -256,6 +256,26 @@ export default class ConfigDialog extends React.Component {
       }
     }
 
+    // Block save if non-alphanumeric characters detected for this param
+    if (
+      this.props.detectNonAlphanumeric &&
+      this.props.param.length > 0 &&
+      this.props.nonAlphanumericBlockSave.includes(this.props.param)
+    ) {
+      const value = this.state.value;
+      if (value && typeof value === 'string') {
+        if (this.state.type === 'Object' || this.state.type === 'Array') {
+          if (getNonAlphanumericCharsFromJson(value).totalCount > 0) {
+            return false;
+          }
+        } else if (this.state.type === 'String') {
+          if (hasNonAlphanumericChars(value)) {
+            return false;
+          }
+        }
+      }
+    }
+
     // Block save if regex validation fails for this param
     if (
       this.props.detectRegex &&
@@ -379,6 +399,10 @@ export default class ConfigDialog extends React.Component {
     if (effectiveDetectNonPrintable && isExistingParam && this.props.nonPrintableShowOnlyFor.length > 0) {
       effectiveDetectNonPrintable = this.props.nonPrintableShowOnlyFor.includes(this.props.param);
     }
+    let effectiveDetectNonAlphanumeric = this.props.detectNonAlphanumeric;
+    if (effectiveDetectNonAlphanumeric && isExistingParam && this.props.nonAlphanumericShowOnlyFor.length > 0) {
+      effectiveDetectNonAlphanumeric = this.props.nonAlphanumericShowOnlyFor.includes(this.props.param);
+    }
     let effectiveDetectRegex = this.props.detectRegex;
     if (effectiveDetectRegex && isExistingParam && this.props.regexShowOnlyFor.length > 0) {
       effectiveDetectRegex = this.props.regexShowOnlyFor.includes(this.props.param);
@@ -410,7 +434,7 @@ export default class ConfigDialog extends React.Component {
             value => this.setState({ value, error: null }),
             this.state.wordWrap,
             this.state.syntaxColors,
-            { detectNonPrintable: effectiveDetectNonPrintable, detectRegex: effectiveDetectRegex }
+            { detectNonPrintable: effectiveDetectNonPrintable, detectNonAlphanumeric: effectiveDetectNonAlphanumeric, detectRegex: effectiveDetectRegex }
           )}
         />
 

--- a/src/dashboard/Data/Config/ConfigDialog.react.js
+++ b/src/dashboard/Data/Config/ConfigDialog.react.js
@@ -28,7 +28,6 @@ import LoaderContainer from 'components/LoaderContainer/LoaderContainer.react';
 import ServerConfigStorage from 'lib/ServerConfigStorage';
 import { CurrentApp } from 'context/currentApp';
 
-const CONFIG_KEY = 'config.settings';
 const FORMATTING_CONFIG_KEY = 'config.formatting.syntax';
 
 const PARAM_TYPES = ['Boolean', 'String', 'Number', 'Date', 'Object', 'Array', 'GeoPoint', 'File'];
@@ -51,7 +50,7 @@ const EDITORS = {
     <Toggle type={Toggle.Types.TRUE_FALSE} value={!!value} onChange={onChange} />
   ),
   String: (value, onChange, wordWrap, syntaxColors, options = {}) => (
-    <NonPrintableHighlighter value={value} detectNonPrintable={!!options.detectNonPrintable} detectNonAlphanumeric={true} detectRegex={!!options.detectRegex}>
+    <NonPrintableHighlighter value={value} detectNonPrintable={!!options.detectNonPrintable} detectNonAlphanumeric={!!options.detectNonPrintable} detectRegex={!!options.detectRegex}>
       <TextInput multiline={true} value={value || ''} onChange={onChange} />
     </NonPrintableHighlighter>
   ),
@@ -60,7 +59,7 @@ const EDITORS = {
   ),
   Date: (value, onChange) => <DateTimeInput fixed={true} value={value} onChange={onChange} />,
   Object: (value, onChange, wordWrap, syntaxColors, options = {}) => (
-    <NonPrintableHighlighter value={value} isJson={true} detectNonPrintable={!!options.detectNonPrintable} detectNonAlphanumeric={true} detectRegex={!!options.detectRegex}>
+    <NonPrintableHighlighter value={value} isJson={true} detectNonPrintable={!!options.detectNonPrintable} detectNonAlphanumeric={!!options.detectNonPrintable} detectRegex={!!options.detectRegex}>
       <JsonEditor
         value={value || ''}
         onChange={onChange}
@@ -71,7 +70,7 @@ const EDITORS = {
     </NonPrintableHighlighter>
   ),
   Array: (value, onChange, wordWrap, syntaxColors, options = {}) => (
-    <NonPrintableHighlighter value={value} isJson={true} detectNonPrintable={!!options.detectNonPrintable} detectNonAlphanumeric={true} detectRegex={!!options.detectRegex}>
+    <NonPrintableHighlighter value={value} isJson={true} detectNonPrintable={!!options.detectNonPrintable} detectNonAlphanumeric={!!options.detectNonPrintable} detectRegex={!!options.detectRegex}>
       <JsonEditor
         value={value || ''}
         onChange={onChange}
@@ -129,12 +128,6 @@ export default class ConfigDialog extends React.Component {
       wordWrap: false,
       error: null,
       syntaxColors: null,
-      detectNonPrintable: true,
-      detectRegex: true,
-      nonPrintableBlockSave: [],
-      nonPrintableShowOnlyFor: [],
-      regexBlockSave: [],
-      regexShowOnlyFor: [],
     };
     if (props.param.length > 0) {
       let initialValue = props.value;
@@ -151,19 +144,12 @@ export default class ConfigDialog extends React.Component {
         wordWrap: false,
         error: initialError,
         syntaxColors: null,
-        detectNonPrintable: true,
-        detectRegex: true,
-        nonPrintableBlockSave: [],
-        nonPrintableShowOnlyFor: [],
-        regexBlockSave: [],
-        regexShowOnlyFor: [],
       };
     }
   }
 
   componentDidMount() {
     this.loadSyntaxColors();
-    this.loadValueAnalysisSettings();
   }
 
   async loadSyntaxColors() {
@@ -180,38 +166,6 @@ export default class ConfigDialog extends React.Component {
       }
     } catch {
       // Silently fail - use default colors from CSS
-    }
-  }
-
-  async loadValueAnalysisSettings() {
-    try {
-      const serverStorage = new ServerConfigStorage(this.context);
-      if (serverStorage.isServerConfigEnabled()) {
-        const settings = await serverStorage.getConfig(
-          CONFIG_KEY,
-          this.context.applicationId
-        );
-        if (settings?.detectNonPrintable !== undefined) {
-          this.setState({ detectNonPrintable: !!settings.detectNonPrintable });
-        }
-        if (settings?.detectRegex !== undefined) {
-          this.setState({ detectRegex: !!settings.detectRegex });
-        }
-        if (Array.isArray(settings?.nonPrintableBlockSave)) {
-          this.setState({ nonPrintableBlockSave: settings.nonPrintableBlockSave });
-        }
-        if (Array.isArray(settings?.nonPrintableShowOnlyFor)) {
-          this.setState({ nonPrintableShowOnlyFor: settings.nonPrintableShowOnlyFor });
-        }
-        if (Array.isArray(settings?.regexBlockSave)) {
-          this.setState({ regexBlockSave: settings.regexBlockSave });
-        }
-        if (Array.isArray(settings?.regexShowOnlyFor)) {
-          this.setState({ regexShowOnlyFor: settings.regexShowOnlyFor });
-        }
-      }
-    } catch {
-      // Silently fail - keep defaults (true)
     }
   }
 
@@ -284,9 +238,9 @@ export default class ConfigDialog extends React.Component {
 
     // Block save if non-printable characters detected for this param
     if (
-      this.state.detectNonPrintable &&
+      this.props.detectNonPrintable &&
       this.props.param.length > 0 &&
-      this.state.nonPrintableBlockSave.includes(this.props.param)
+      this.props.nonPrintableBlockSave.includes(this.props.param)
     ) {
       const value = this.state.value;
       if (value && typeof value === 'string') {
@@ -304,9 +258,9 @@ export default class ConfigDialog extends React.Component {
 
     // Block save if regex validation fails for this param
     if (
-      this.state.detectRegex &&
+      this.props.detectRegex &&
       this.props.param.length > 0 &&
-      this.state.regexBlockSave.includes(this.props.param)
+      this.props.regexBlockSave.includes(this.props.param)
     ) {
       const value = this.state.value;
       if (value && typeof value === 'string') {
@@ -421,13 +375,13 @@ export default class ConfigDialog extends React.Component {
 
     // Determine effective detection flags based on show-only-for settings
     const isExistingParam = this.props.param && this.props.param.length > 0;
-    let effectiveDetectNonPrintable = this.state.detectNonPrintable;
-    if (effectiveDetectNonPrintable && isExistingParam && this.state.nonPrintableShowOnlyFor.length > 0) {
-      effectiveDetectNonPrintable = this.state.nonPrintableShowOnlyFor.includes(this.props.param);
+    let effectiveDetectNonPrintable = this.props.detectNonPrintable;
+    if (effectiveDetectNonPrintable && isExistingParam && this.props.nonPrintableShowOnlyFor.length > 0) {
+      effectiveDetectNonPrintable = this.props.nonPrintableShowOnlyFor.includes(this.props.param);
     }
-    let effectiveDetectRegex = this.state.detectRegex;
-    if (effectiveDetectRegex && isExistingParam && this.state.regexShowOnlyFor.length > 0) {
-      effectiveDetectRegex = this.state.regexShowOnlyFor.includes(this.props.param);
+    let effectiveDetectRegex = this.props.detectRegex;
+    if (effectiveDetectRegex && isExistingParam && this.props.regexShowOnlyFor.length > 0) {
+      effectiveDetectRegex = this.props.regexShowOnlyFor.includes(this.props.param);
     }
 
     const dialogContent = (

--- a/src/dashboard/Settings/CloudConfigSettings.react.js
+++ b/src/dashboard/Settings/CloudConfigSettings.react.js
@@ -44,6 +44,9 @@ export default class CloudConfigSettings extends DashboardView {
       configParamNames: [],
       nonPrintableBlockSave: [],
       nonPrintableShowOnlyFor: [],
+      detectNonAlphanumeric: true,
+      nonAlphanumericBlockSave: [],
+      nonAlphanumericShowOnlyFor: [],
       regexBlockSave: [],
       regexShowOnlyFor: [],
       message: undefined,
@@ -84,6 +87,15 @@ export default class CloudConfigSettings extends DashboardView {
         if (Array.isArray(settings.nonPrintableShowOnlyFor)) {
           this.setState({ nonPrintableShowOnlyFor: settings.nonPrintableShowOnlyFor });
         }
+        if (settings.detectNonAlphanumeric !== undefined) {
+          this.setState({ detectNonAlphanumeric: !!settings.detectNonAlphanumeric });
+        }
+        if (Array.isArray(settings.nonAlphanumericBlockSave)) {
+          this.setState({ nonAlphanumericBlockSave: settings.nonAlphanumericBlockSave });
+        }
+        if (Array.isArray(settings.nonAlphanumericShowOnlyFor)) {
+          this.setState({ nonAlphanumericShowOnlyFor: settings.nonAlphanumericShowOnlyFor });
+        }
         if (Array.isArray(settings.regexBlockSave)) {
           this.setState({ regexBlockSave: settings.regexBlockSave });
         }
@@ -117,7 +129,24 @@ export default class CloudConfigSettings extends DashboardView {
       this.context.setParseKeys();
       const result = await Parse._request('GET', 'config', {}, { useMasterKey: true });
       if (result && result.params) {
-        this.setState({ configParamNames: Object.keys(result.params).sort() });
+        // Only include params of types that support value analysis (String, Object, Array)
+        const names = Object.entries(result.params)
+          .filter(([, value]) => {
+            if (typeof value === 'string') {
+              return true;
+            }
+            if (typeof value === 'object' && value !== null) {
+              // Exclude Date, GeoPoint, File
+              if (value.__type === 'Date' || value.__type === 'GeoPoint' || value.__type === 'File') {
+                return false;
+              }
+              return true; // Object or Array
+            }
+            return false;
+          })
+          .map(([name]) => name)
+          .sort();
+        this.setState({ configParamNames: names });
       }
     } catch {
       // Silently fail - dropdowns will be empty
@@ -186,6 +215,38 @@ export default class CloudConfigSettings extends DashboardView {
       this.showNote('Non-printable show-only parameters updated.');
     } else {
       this.setState({ nonPrintableShowOnlyFor: previous });
+      this.showNote('Failed to save setting.', true);
+    }
+  }
+
+  async handleDetectNonAlphanumericChange(value) {
+    this.setState({ detectNonAlphanumeric: value });
+    if (await this.saveSettings({ detectNonAlphanumeric: value === true ? undefined : value })) {
+      this.showNote(`Non-alphanumeric character detection ${value ? 'enabled' : 'disabled'}.`);
+    } else {
+      this.setState({ detectNonAlphanumeric: !value });
+      this.showNote('Failed to save setting.', true);
+    }
+  }
+
+  async handleNonAlphanumericBlockSaveChange(value) {
+    const previous = this.state.nonAlphanumericBlockSave;
+    this.setState({ nonAlphanumericBlockSave: value });
+    if (await this.saveSettings({ nonAlphanumericBlockSave: value.length > 0 ? value : undefined })) {
+      this.showNote('Non-alphanumeric block-save parameters updated.');
+    } else {
+      this.setState({ nonAlphanumericBlockSave: previous });
+      this.showNote('Failed to save setting.', true);
+    }
+  }
+
+  async handleNonAlphanumericShowOnlyForChange(value) {
+    const previous = this.state.nonAlphanumericShowOnlyFor;
+    this.setState({ nonAlphanumericShowOnlyFor: value });
+    if (await this.saveSettings({ nonAlphanumericShowOnlyFor: value.length > 0 ? value : undefined })) {
+      this.showNote('Non-alphanumeric show-only parameters updated.');
+    } else {
+      this.setState({ nonAlphanumericShowOnlyFor: previous });
       this.showNote('Failed to save setting.', true);
     }
   }
@@ -430,8 +491,24 @@ export default class CloudConfigSettings extends DashboardView {
                   labelWidth={62}
                   label={
                     <Label
+                      text="Show Info Box"
+                      description="Show the info box for selected parameters, or for all if none are selected."
+                    />
+                  }
+                  input={this.renderParamMultiSelect(
+                    this.state.nonPrintableShowOnlyFor,
+                    this.handleNonPrintableShowOnlyForChange.bind(this),
+                    'All parameters',
+                    !serverConfigEnabled || this.state.loading
+                  )}
+                />
+                <Field
+                  labelWidth={62}
+                  className={styles.sectionSeparator}
+                  label={
+                    <Label
                       text="Block Save"
-                      description="Select parameters for which the Save button should be disabled when non-printable characters are detected."
+                      description="Select parameters for which the Save button should be disabled if validation fails."
                     />
                   }
                   input={this.renderParamMultiSelect(
@@ -441,19 +518,56 @@ export default class CloudConfigSettings extends DashboardView {
                     !serverConfigEnabled || this.state.loading
                   )}
                 />
+              </>
+            )}
+            <Field
+              labelWidth={62}
+              label={
+                <Label
+                  text="Non-Alphanumeric Characters"
+                  description="When enabled, the parameter editor highlights non-alphanumeric characters such as special symbols, punctuation, and whitespace."
+                />
+              }
+              input={
+                <Toggle
+                  type={Toggle.Types.YES_NO}
+                  value={this.state.detectNonAlphanumeric}
+                  onChange={this.handleDetectNonAlphanumericChange.bind(this)}
+                  disabled={!serverConfigEnabled || this.state.loading}
+                  additionalStyles={{ margin: '0px' }}
+                />
+              }
+            />
+            {this.state.detectNonAlphanumeric && (
+              <>
+                <Field
+                  labelWidth={62}
+                  label={
+                    <Label
+                      text="Show Info Box"
+                      description="Show the info box for selected parameters, or for all if none are selected."
+                    />
+                  }
+                  input={this.renderParamMultiSelect(
+                    this.state.nonAlphanumericShowOnlyFor,
+                    this.handleNonAlphanumericShowOnlyForChange.bind(this),
+                    'All parameters',
+                    !serverConfigEnabled || this.state.loading
+                  )}
+                />
                 <Field
                   labelWidth={62}
                   className={styles.sectionSeparator}
                   label={
                     <Label
-                      text="Show Only For"
-                      description="Limit the non-printable character info box to only the selected parameters. When none are selected, the info box shows for all parameters."
+                      text="Block Save"
+                      description="Select parameters for which the Save button should be disabled if validation fails."
                     />
                   }
                   input={this.renderParamMultiSelect(
-                    this.state.nonPrintableShowOnlyFor,
-                    this.handleNonPrintableShowOnlyForChange.bind(this),
-                    'All parameters',
+                    this.state.nonAlphanumericBlockSave,
+                    this.handleNonAlphanumericBlockSaveChange.bind(this),
+                    'No parameter',
                     !serverConfigEnabled || this.state.loading
                   )}
                 />
@@ -483,14 +597,14 @@ export default class CloudConfigSettings extends DashboardView {
                   labelWidth={62}
                   label={
                     <Label
-                      text="Block Save"
-                      description="Select parameters for which the Save button should be disabled when invalid regex patterns are detected."
+                      text="Show Info Box"
+                      description="Show the info box for selected parameters, or for all if none are selected."
                     />
                   }
                   input={this.renderParamMultiSelect(
-                    this.state.regexBlockSave,
-                    this.handleRegexBlockSaveChange.bind(this),
-                    'No parameter',
+                    this.state.regexShowOnlyFor,
+                    this.handleRegexShowOnlyForChange.bind(this),
+                    'All parameters',
                     !serverConfigEnabled || this.state.loading
                   )}
                 />
@@ -498,14 +612,14 @@ export default class CloudConfigSettings extends DashboardView {
                   labelWidth={62}
                   label={
                     <Label
-                      text="Show Only For"
-                      description="Limit the regex validation info box to only the selected parameters. When none are selected, the info box shows for all parameters."
+                      text="Block Save"
+                      description="Select parameters for which the Save button should be disabled if validation fails."
                     />
                   }
                   input={this.renderParamMultiSelect(
-                    this.state.regexShowOnlyFor,
-                    this.handleRegexShowOnlyForChange.bind(this),
-                    'All parameters',
+                    this.state.regexBlockSave,
+                    this.handleRegexBlockSaveChange.bind(this),
+                    'No parameter',
                     !serverConfigEnabled || this.state.loading
                   )}
                 />

--- a/src/dashboard/Settings/CloudConfigSettings.react.js
+++ b/src/dashboard/Settings/CloudConfigSettings.react.js
@@ -209,13 +209,14 @@ export default class CloudConfigSettings extends DashboardView {
   }
 
   async handleNonPrintableShowOnlyForChange(value) {
-    const previous = this.state.nonPrintableShowOnlyFor;
+    const previousShowOnlyFor = this.state.nonPrintableShowOnlyFor;
+    const previousBlockSave = this.state.nonPrintableBlockSave;
     this.setState({ nonPrintableShowOnlyFor: value });
     // Remove block-save entries that are no longer in the show-info-box list
     const blockSaveUpdates = {};
     if (value.length > 0) {
-      const filtered = this.state.nonPrintableBlockSave.filter(name => value.includes(name));
-      if (filtered.length !== this.state.nonPrintableBlockSave.length) {
+      const filtered = previousBlockSave.filter(name => value.includes(name));
+      if (filtered.length !== previousBlockSave.length) {
         this.setState({ nonPrintableBlockSave: filtered });
         blockSaveUpdates.nonPrintableBlockSave = filtered.length > 0 ? filtered : undefined;
       }
@@ -223,7 +224,7 @@ export default class CloudConfigSettings extends DashboardView {
     if (await this.saveSettings({ nonPrintableShowOnlyFor: value.length > 0 ? value : undefined, ...blockSaveUpdates })) {
       this.showNote('Non-printable show-only parameters updated.');
     } else {
-      this.setState({ nonPrintableShowOnlyFor: previous });
+      this.setState({ nonPrintableShowOnlyFor: previousShowOnlyFor, nonPrintableBlockSave: previousBlockSave });
       this.showNote('Failed to save setting.', true);
     }
   }
@@ -250,13 +251,14 @@ export default class CloudConfigSettings extends DashboardView {
   }
 
   async handleNonAlphanumericShowOnlyForChange(value) {
-    const previous = this.state.nonAlphanumericShowOnlyFor;
+    const previousShowOnlyFor = this.state.nonAlphanumericShowOnlyFor;
+    const previousBlockSave = this.state.nonAlphanumericBlockSave;
     this.setState({ nonAlphanumericShowOnlyFor: value });
     // Remove block-save entries that are no longer in the show-info-box list
     const blockSaveUpdates = {};
     if (value.length > 0) {
-      const filtered = this.state.nonAlphanumericBlockSave.filter(name => value.includes(name));
-      if (filtered.length !== this.state.nonAlphanumericBlockSave.length) {
+      const filtered = previousBlockSave.filter(name => value.includes(name));
+      if (filtered.length !== previousBlockSave.length) {
         this.setState({ nonAlphanumericBlockSave: filtered });
         blockSaveUpdates.nonAlphanumericBlockSave = filtered.length > 0 ? filtered : undefined;
       }
@@ -264,7 +266,7 @@ export default class CloudConfigSettings extends DashboardView {
     if (await this.saveSettings({ nonAlphanumericShowOnlyFor: value.length > 0 ? value : undefined, ...blockSaveUpdates })) {
       this.showNote('Non-alphanumeric show-only parameters updated.');
     } else {
-      this.setState({ nonAlphanumericShowOnlyFor: previous });
+      this.setState({ nonAlphanumericShowOnlyFor: previousShowOnlyFor, nonAlphanumericBlockSave: previousBlockSave });
       this.showNote('Failed to save setting.', true);
     }
   }
@@ -281,13 +283,14 @@ export default class CloudConfigSettings extends DashboardView {
   }
 
   async handleRegexShowOnlyForChange(value) {
-    const previous = this.state.regexShowOnlyFor;
+    const previousShowOnlyFor = this.state.regexShowOnlyFor;
+    const previousBlockSave = this.state.regexBlockSave;
     this.setState({ regexShowOnlyFor: value });
     // Remove block-save entries that are no longer in the show-info-box list
     const blockSaveUpdates = {};
     if (value.length > 0) {
-      const filtered = this.state.regexBlockSave.filter(name => value.includes(name));
-      if (filtered.length !== this.state.regexBlockSave.length) {
+      const filtered = previousBlockSave.filter(name => value.includes(name));
+      if (filtered.length !== previousBlockSave.length) {
         this.setState({ regexBlockSave: filtered });
         blockSaveUpdates.regexBlockSave = filtered.length > 0 ? filtered : undefined;
       }
@@ -295,7 +298,7 @@ export default class CloudConfigSettings extends DashboardView {
     if (await this.saveSettings({ regexShowOnlyFor: value.length > 0 ? value : undefined, ...blockSaveUpdates })) {
       this.showNote('Regex show-only parameters updated.');
     } else {
-      this.setState({ regexShowOnlyFor: previous });
+      this.setState({ regexShowOnlyFor: previousShowOnlyFor, regexBlockSave: previousBlockSave });
       this.showNote('Failed to save setting.', true);
     }
   }

--- a/src/dashboard/Settings/CloudConfigSettings.react.js
+++ b/src/dashboard/Settings/CloudConfigSettings.react.js
@@ -433,7 +433,7 @@ export default class CloudConfigSettings extends DashboardView {
     const allNames = paramNames || this.state.configParamNames;
     return (
       <div style={{ width: '100%', background: '#f6fafb' }}>
-        {this.renderParamMultiSelect(value, onChange, placeholder, disabled, paramNames)}
+        {this.renderParamMultiSelect(value, onChange, placeholder, disabled, allNames)}
         <div style={{ display: 'flex', justifyContent: 'center', gap: '8px', marginTop: '8px', paddingBottom: '8px' }}>
           <Button
             value="Select all"

--- a/src/dashboard/Settings/CloudConfigSettings.react.js
+++ b/src/dashboard/Settings/CloudConfigSettings.react.js
@@ -458,6 +458,7 @@ export default class CloudConfigSettings extends DashboardView {
         value={value}
         onChange={onChange}
         placeHolder={placeholder}
+        disabled={disabled}
         formatSelection={sel => `${sel.length} parameter${sel.length !== 1 ? 's' : ''} selected`}
       >
         {names.map(name => (

--- a/src/dashboard/Settings/CloudConfigSettings.react.js
+++ b/src/dashboard/Settings/CloudConfigSettings.react.js
@@ -426,6 +426,27 @@ export default class CloudConfigSettings extends DashboardView {
     }, 3500);
   }
 
+  renderParamMultiSelectWithButtons(value, onChange, placeholder, disabled, paramNames) {
+    const allNames = paramNames || this.state.configParamNames;
+    return (
+      <div style={{ width: '100%', background: '#f6fafb' }}>
+        {this.renderParamMultiSelect(value, onChange, placeholder, disabled, paramNames)}
+        <div style={{ display: 'flex', justifyContent: 'center', gap: '8px', marginTop: '8px', paddingBottom: '8px' }}>
+          <Button
+            value="Select all"
+            disabled={disabled || value.length === allNames.length}
+            onClick={() => onChange([...allNames])}
+          />
+          <Button
+            value="Unselect all"
+            disabled={disabled || value.length === 0}
+            onClick={() => onChange([])}
+          />
+        </div>
+      </div>
+    );
+  }
+
   renderParamMultiSelect(value, onChange, placeholder, disabled, paramNames) {
     const names = paramNames || this.state.configParamNames;
     return (
@@ -523,7 +544,7 @@ export default class CloudConfigSettings extends DashboardView {
                       description="Show the info box for selected parameters, or for all if none are selected."
                     />
                   }
-                  input={this.renderParamMultiSelect(
+                  input={this.renderParamMultiSelectWithButtons(
                     this.state.nonPrintableShowOnlyFor,
                     this.handleNonPrintableShowOnlyForChange.bind(this),
                     'All parameters',
@@ -539,7 +560,7 @@ export default class CloudConfigSettings extends DashboardView {
                       description="Select parameters for which the Save button should be disabled if validation fails."
                     />
                   }
-                  input={this.renderParamMultiSelect(
+                  input={this.renderParamMultiSelectWithButtons(
                     this.state.nonPrintableBlockSave,
                     this.handleNonPrintableBlockSaveChange.bind(this),
                     'No parameter',
@@ -577,7 +598,7 @@ export default class CloudConfigSettings extends DashboardView {
                       description="Show the info box for selected parameters, or for all if none are selected."
                     />
                   }
-                  input={this.renderParamMultiSelect(
+                  input={this.renderParamMultiSelectWithButtons(
                     this.state.nonAlphanumericShowOnlyFor,
                     this.handleNonAlphanumericShowOnlyForChange.bind(this),
                     'All parameters',
@@ -593,7 +614,7 @@ export default class CloudConfigSettings extends DashboardView {
                       description="Select parameters for which the Save button should be disabled if validation fails."
                     />
                   }
-                  input={this.renderParamMultiSelect(
+                  input={this.renderParamMultiSelectWithButtons(
                     this.state.nonAlphanumericBlockSave,
                     this.handleNonAlphanumericBlockSaveChange.bind(this),
                     'No parameter',
@@ -631,7 +652,7 @@ export default class CloudConfigSettings extends DashboardView {
                       description="Show the info box for selected parameters, or for all if none are selected."
                     />
                   }
-                  input={this.renderParamMultiSelect(
+                  input={this.renderParamMultiSelectWithButtons(
                     this.state.regexShowOnlyFor,
                     this.handleRegexShowOnlyForChange.bind(this),
                     'All parameters',
@@ -646,7 +667,7 @@ export default class CloudConfigSettings extends DashboardView {
                       description="Select parameters for which the Save button should be disabled if validation fails."
                     />
                   }
-                  input={this.renderParamMultiSelect(
+                  input={this.renderParamMultiSelectWithButtons(
                     this.state.regexBlockSave,
                     this.handleRegexBlockSaveChange.bind(this),
                     'No parameter',

--- a/src/dashboard/Settings/CloudConfigSettings.react.js
+++ b/src/dashboard/Settings/CloudConfigSettings.react.js
@@ -664,6 +664,7 @@ export default class CloudConfigSettings extends DashboardView {
                 />
                 <Field
                   labelWidth={62}
+                  className={styles.sectionSeparator}
                   label={
                     <Label
                       text="Block Save"

--- a/src/dashboard/Settings/CloudConfigSettings.react.js
+++ b/src/dashboard/Settings/CloudConfigSettings.react.js
@@ -3,6 +3,9 @@ import DashboardView from 'dashboard/DashboardView.react';
 import Field from 'components/Field/Field.react';
 import Fieldset from 'components/Fieldset/Fieldset.react';
 import Label from 'components/Label/Label.react';
+import MultiSelect from 'components/MultiSelect/MultiSelect.react';
+import MultiSelectOption from 'components/MultiSelect/MultiSelectOption.react';
+import Parse from 'parse';
 import React from 'react';
 import TextInput from 'components/TextInput/TextInput.react';
 import Toggle from 'components/Toggle/Toggle.react';
@@ -38,6 +41,11 @@ export default class CloudConfigSettings extends DashboardView {
       syntaxColors: { ...DEFAULT_SYNTAX_COLORS },
       detectNonPrintable: true,
       detectRegex: true,
+      configParamNames: [],
+      nonPrintableBlockSave: [],
+      nonPrintableShowOnlyFor: [],
+      regexBlockSave: [],
+      regexShowOnlyFor: [],
       message: undefined,
       loading: true,
     };
@@ -70,7 +78,22 @@ export default class CloudConfigSettings extends DashboardView {
         if (settings.detectRegex !== undefined) {
           this.setState({ detectRegex: !!settings.detectRegex });
         }
+        if (Array.isArray(settings.nonPrintableBlockSave)) {
+          this.setState({ nonPrintableBlockSave: settings.nonPrintableBlockSave });
+        }
+        if (Array.isArray(settings.nonPrintableShowOnlyFor)) {
+          this.setState({ nonPrintableShowOnlyFor: settings.nonPrintableShowOnlyFor });
+        }
+        if (Array.isArray(settings.regexBlockSave)) {
+          this.setState({ regexBlockSave: settings.regexBlockSave });
+        }
+        if (Array.isArray(settings.regexShowOnlyFor)) {
+          this.setState({ regexShowOnlyFor: settings.regexShowOnlyFor });
+        }
       }
+
+      // Fetch Cloud Config parameter names for multi-select dropdowns
+      await this.loadConfigParamNames();
 
       // Load formatting settings
       const formattingSettings = await this.serverStorage.getConfig(
@@ -86,6 +109,18 @@ export default class CloudConfigSettings extends DashboardView {
       this.showNote('Failed to load Cloud Config settings.', true);
     } finally {
       this.setState({ loading: false });
+    }
+  }
+
+  async loadConfigParamNames() {
+    try {
+      this.context.setParseKeys();
+      const result = await Parse._request('GET', 'config', {}, { useMasterKey: true });
+      if (result && result.params) {
+        this.setState({ configParamNames: Object.keys(result.params).sort() });
+      }
+    } catch {
+      // Silently fail - dropdowns will be empty
     }
   }
 
@@ -129,6 +164,50 @@ export default class CloudConfigSettings extends DashboardView {
       this.showNote(`Regex validation display ${value ? 'enabled' : 'disabled'}.`);
     } else {
       this.setState({ detectRegex: !value });
+      this.showNote('Failed to save setting.', true);
+    }
+  }
+
+  async handleNonPrintableBlockSaveChange(value) {
+    const previous = this.state.nonPrintableBlockSave;
+    this.setState({ nonPrintableBlockSave: value });
+    if (await this.saveSettings({ nonPrintableBlockSave: value.length > 0 ? value : undefined })) {
+      this.showNote('Non-printable block-save parameters updated.');
+    } else {
+      this.setState({ nonPrintableBlockSave: previous });
+      this.showNote('Failed to save setting.', true);
+    }
+  }
+
+  async handleNonPrintableShowOnlyForChange(value) {
+    const previous = this.state.nonPrintableShowOnlyFor;
+    this.setState({ nonPrintableShowOnlyFor: value });
+    if (await this.saveSettings({ nonPrintableShowOnlyFor: value.length > 0 ? value : undefined })) {
+      this.showNote('Non-printable show-only parameters updated.');
+    } else {
+      this.setState({ nonPrintableShowOnlyFor: previous });
+      this.showNote('Failed to save setting.', true);
+    }
+  }
+
+  async handleRegexBlockSaveChange(value) {
+    const previous = this.state.regexBlockSave;
+    this.setState({ regexBlockSave: value });
+    if (await this.saveSettings({ regexBlockSave: value.length > 0 ? value : undefined })) {
+      this.showNote('Regex block-save parameters updated.');
+    } else {
+      this.setState({ regexBlockSave: previous });
+      this.showNote('Failed to save setting.', true);
+    }
+  }
+
+  async handleRegexShowOnlyForChange(value) {
+    const previous = this.state.regexShowOnlyFor;
+    this.setState({ regexShowOnlyFor: value });
+    if (await this.saveSettings({ regexShowOnlyFor: value.length > 0 ? value : undefined })) {
+      this.showNote('Regex show-only parameters updated.');
+    } else {
+      this.setState({ regexShowOnlyFor: previous });
       this.showNote('Failed to save setting.', true);
     }
   }
@@ -259,6 +338,24 @@ export default class CloudConfigSettings extends DashboardView {
     }, 3500);
   }
 
+  renderParamMultiSelect(value, onChange, placeholder, disabled) {
+    return (
+      <MultiSelect
+        fixed={true}
+        value={value}
+        onChange={onChange}
+        placeHolder={placeholder}
+        formatSelection={sel => `${sel.length} parameter${sel.length !== 1 ? 's' : ''} selected`}
+      >
+        {this.state.configParamNames.map(name => (
+          <MultiSelectOption key={name} value={name} disabled={disabled}>
+            {name}
+          </MultiSelectOption>
+        ))}
+      </MultiSelect>
+    );
+  }
+
   renderContent() {
     const message = this.state.message;
     const serverConfigEnabled = this.serverStorage && this.serverStorage.isServerConfigEnabled();
@@ -327,6 +424,41 @@ export default class CloudConfigSettings extends DashboardView {
                 />
               }
             />
+            {this.state.detectNonPrintable && (
+              <>
+                <Field
+                  labelWidth={62}
+                  label={
+                    <Label
+                      text="Block Save"
+                      description="Select parameters for which the Save button should be disabled when non-printable characters are detected."
+                    />
+                  }
+                  input={this.renderParamMultiSelect(
+                    this.state.nonPrintableBlockSave,
+                    this.handleNonPrintableBlockSaveChange.bind(this),
+                    'No parameter',
+                    !serverConfigEnabled || this.state.loading
+                  )}
+                />
+                <Field
+                  labelWidth={62}
+                  className={styles.sectionSeparator}
+                  label={
+                    <Label
+                      text="Show Only For"
+                      description="Limit the non-printable character info box to only the selected parameters. When none are selected, the info box shows for all parameters."
+                    />
+                  }
+                  input={this.renderParamMultiSelect(
+                    this.state.nonPrintableShowOnlyFor,
+                    this.handleNonPrintableShowOnlyForChange.bind(this),
+                    'All parameters',
+                    !serverConfigEnabled || this.state.loading
+                  )}
+                />
+              </>
+            )}
             <Field
               labelWidth={62}
               label={
@@ -345,6 +477,40 @@ export default class CloudConfigSettings extends DashboardView {
                 />
               }
             />
+            {this.state.detectRegex && (
+              <>
+                <Field
+                  labelWidth={62}
+                  label={
+                    <Label
+                      text="Block Save"
+                      description="Select parameters for which the Save button should be disabled when invalid regex patterns are detected."
+                    />
+                  }
+                  input={this.renderParamMultiSelect(
+                    this.state.regexBlockSave,
+                    this.handleRegexBlockSaveChange.bind(this),
+                    'No parameter',
+                    !serverConfigEnabled || this.state.loading
+                  )}
+                />
+                <Field
+                  labelWidth={62}
+                  label={
+                    <Label
+                      text="Show Only For"
+                      description="Limit the regex validation info box to only the selected parameters. When none are selected, the info box shows for all parameters."
+                    />
+                  }
+                  input={this.renderParamMultiSelect(
+                    this.state.regexShowOnlyFor,
+                    this.handleRegexShowOnlyForChange.bind(this),
+                    'All parameters',
+                    !serverConfigEnabled || this.state.loading
+                  )}
+                />
+              </>
+            )}
           </Fieldset>
           <Fieldset
             legend="Formatting"
@@ -358,10 +524,11 @@ export default class CloudConfigSettings extends DashboardView {
               null: 'Null',
               punctuation: 'Punctuation (brackets, commas)',
               operator: 'Operator (colons)',
-            }).map(([tokenType, label]) => (
+            }).map(([tokenType, label], index, array) => (
               <Field
                 key={tokenType}
                 labelWidth={62}
+                className={index === array.length - 1 ? styles.lastField : undefined}
                 label={
                   <Label
                     text={label}

--- a/src/dashboard/Settings/CloudConfigSettings.react.js
+++ b/src/dashboard/Settings/CloudConfigSettings.react.js
@@ -211,7 +211,16 @@ export default class CloudConfigSettings extends DashboardView {
   async handleNonPrintableShowOnlyForChange(value) {
     const previous = this.state.nonPrintableShowOnlyFor;
     this.setState({ nonPrintableShowOnlyFor: value });
-    if (await this.saveSettings({ nonPrintableShowOnlyFor: value.length > 0 ? value : undefined })) {
+    // Remove block-save entries that are no longer in the show-info-box list
+    const blockSaveUpdates = {};
+    if (value.length > 0) {
+      const filtered = this.state.nonPrintableBlockSave.filter(name => value.includes(name));
+      if (filtered.length !== this.state.nonPrintableBlockSave.length) {
+        this.setState({ nonPrintableBlockSave: filtered });
+        blockSaveUpdates.nonPrintableBlockSave = filtered.length > 0 ? filtered : undefined;
+      }
+    }
+    if (await this.saveSettings({ nonPrintableShowOnlyFor: value.length > 0 ? value : undefined, ...blockSaveUpdates })) {
       this.showNote('Non-printable show-only parameters updated.');
     } else {
       this.setState({ nonPrintableShowOnlyFor: previous });
@@ -243,7 +252,16 @@ export default class CloudConfigSettings extends DashboardView {
   async handleNonAlphanumericShowOnlyForChange(value) {
     const previous = this.state.nonAlphanumericShowOnlyFor;
     this.setState({ nonAlphanumericShowOnlyFor: value });
-    if (await this.saveSettings({ nonAlphanumericShowOnlyFor: value.length > 0 ? value : undefined })) {
+    // Remove block-save entries that are no longer in the show-info-box list
+    const blockSaveUpdates = {};
+    if (value.length > 0) {
+      const filtered = this.state.nonAlphanumericBlockSave.filter(name => value.includes(name));
+      if (filtered.length !== this.state.nonAlphanumericBlockSave.length) {
+        this.setState({ nonAlphanumericBlockSave: filtered });
+        blockSaveUpdates.nonAlphanumericBlockSave = filtered.length > 0 ? filtered : undefined;
+      }
+    }
+    if (await this.saveSettings({ nonAlphanumericShowOnlyFor: value.length > 0 ? value : undefined, ...blockSaveUpdates })) {
       this.showNote('Non-alphanumeric show-only parameters updated.');
     } else {
       this.setState({ nonAlphanumericShowOnlyFor: previous });
@@ -265,7 +283,16 @@ export default class CloudConfigSettings extends DashboardView {
   async handleRegexShowOnlyForChange(value) {
     const previous = this.state.regexShowOnlyFor;
     this.setState({ regexShowOnlyFor: value });
-    if (await this.saveSettings({ regexShowOnlyFor: value.length > 0 ? value : undefined })) {
+    // Remove block-save entries that are no longer in the show-info-box list
+    const blockSaveUpdates = {};
+    if (value.length > 0) {
+      const filtered = this.state.regexBlockSave.filter(name => value.includes(name));
+      if (filtered.length !== this.state.regexBlockSave.length) {
+        this.setState({ regexBlockSave: filtered });
+        blockSaveUpdates.regexBlockSave = filtered.length > 0 ? filtered : undefined;
+      }
+    }
+    if (await this.saveSettings({ regexShowOnlyFor: value.length > 0 ? value : undefined, ...blockSaveUpdates })) {
       this.showNote('Regex show-only parameters updated.');
     } else {
       this.setState({ regexShowOnlyFor: previous });
@@ -399,7 +426,8 @@ export default class CloudConfigSettings extends DashboardView {
     }, 3500);
   }
 
-  renderParamMultiSelect(value, onChange, placeholder, disabled) {
+  renderParamMultiSelect(value, onChange, placeholder, disabled, paramNames) {
+    const names = paramNames || this.state.configParamNames;
     return (
       <MultiSelect
         fixed={true}
@@ -408,7 +436,7 @@ export default class CloudConfigSettings extends DashboardView {
         placeHolder={placeholder}
         formatSelection={sel => `${sel.length} parameter${sel.length !== 1 ? 's' : ''} selected`}
       >
-        {this.state.configParamNames.map(name => (
+        {names.map(name => (
           <MultiSelectOption key={name} value={name} disabled={disabled}>
             {name}
           </MultiSelectOption>
@@ -515,7 +543,8 @@ export default class CloudConfigSettings extends DashboardView {
                     this.state.nonPrintableBlockSave,
                     this.handleNonPrintableBlockSaveChange.bind(this),
                     'No parameter',
-                    !serverConfigEnabled || this.state.loading
+                    !serverConfigEnabled || this.state.loading,
+                    this.state.nonPrintableShowOnlyFor.length > 0 ? this.state.nonPrintableShowOnlyFor : undefined
                   )}
                 />
               </>
@@ -568,7 +597,8 @@ export default class CloudConfigSettings extends DashboardView {
                     this.state.nonAlphanumericBlockSave,
                     this.handleNonAlphanumericBlockSaveChange.bind(this),
                     'No parameter',
-                    !serverConfigEnabled || this.state.loading
+                    !serverConfigEnabled || this.state.loading,
+                    this.state.nonAlphanumericShowOnlyFor.length > 0 ? this.state.nonAlphanumericShowOnlyFor : undefined
                   )}
                 />
               </>
@@ -620,7 +650,8 @@ export default class CloudConfigSettings extends DashboardView {
                     this.state.regexBlockSave,
                     this.handleRegexBlockSaveChange.bind(this),
                     'No parameter',
-                    !serverConfigEnabled || this.state.loading
+                    !serverConfigEnabled || this.state.loading,
+                    this.state.regexShowOnlyFor.length > 0 ? this.state.regexShowOnlyFor : undefined
                   )}
                 />
               </>

--- a/src/dashboard/Settings/Settings.scss
+++ b/src/dashboard/Settings/Settings.scss
@@ -22,3 +22,14 @@
     height: auto !important;
   }
 }
+
+.sectionSeparator {
+  border-bottom-width: 1px;
+  margin-bottom: 20px;
+}
+
+.lastField {
+  border-bottom-width: 1px;
+  border-bottom-left-radius: 5px;
+  border-bottom-right-radius: 5px;
+}


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-dashboard/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-dashboard/blob/alpha/LICENSE).

## Issue

Add option to block saving Cloud Config parameter if validation fails.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Granular detection and management for non‑printable, non‑alphanumeric, and regex issues with per‑parameter show‑only and block‑save controls.
  * Multi‑select parameter selection with dynamic parameter name loading for targeting rules.
  * Pre‑save validations now block saves/creates when enabled detections fail.

* **Behavior**
  * Detection flags respect show‑only lists so checks only apply where configured.

* **Style**
  * Updated validation label styling, new section/field styles, and improved dropdown/multiselect scroll behavior.
* **Chores**
  * MultiSelect now respects a disabled state and will not open when disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->