### PR TITLE
fix: Security removal dependency svg-prep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -97,7 +97,6 @@
         "semantic-release": "25.0.3",
         "semver": "7.7.4",
         "style-loader": "3.3.1",
-        "svg-prep": "1.0.4",
         "typescript": "5.9.3",
         "webpack": "5.105.1",
         "webpack-cli": "6.0.1",
@@ -28255,12 +28254,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
-    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -30080,28 +30073,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/svg-prep": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/svg-prep/-/svg-prep-1.0.4.tgz",
-      "integrity": "sha512-RT9dKj+l9yRsrQIZhdWqIftN0E4agtnPCn8pFJm9yM9bEWrNJhtUjG2g2AA/K+9pa4gh/CRFMXIPtcHOviQE2w==",
-      "dev": true,
-      "dependencies": {
-        "commander": "^2.8.1",
-        "xml2js": "^0.4.12"
-      },
-      "bin": {
-        "svg-prep": "bin/index.js"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/svg-prep/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
     },
     "node_modules/symbol-observable": {
       "version": "1.2.0",
@@ -32146,28 +32117,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-      "dev": true,
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
       }
     },
     "node_modules/xmlchars": {

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
     "semantic-release": "25.0.3",
     "semver": "7.7.4",
     "style-loader": "3.3.1",
-    "svg-prep": "1.0.4",
     "typescript": "5.9.3",
     "webpack": "5.105.1",
     "webpack-cli": "6.0.1",

--- a/webpack/plugins/svg-prep.js
+++ b/webpack/plugins/svg-prep.js
@@ -9,9 +9,51 @@
 
 const fs = require('fs');
 const path = require('path');
-const SvgPrep = require('svg-prep');
 const { Compilation, sources } = require('webpack');
 const { RawSource } = sources;
+
+/**
+ * Builds an SVG sprite from individual SVG files. Each SVG becomes a
+ * <symbol> element identified by its filename (without extension).
+ */
+function buildSvgSprite(files) {
+  const symbols = files.map(file => {
+    const name = path.basename(file, '.svg');
+    const svg = fs.readFileSync(file, 'utf-8');
+
+    // Extract viewBox from the root <svg> element
+    const viewBoxMatch = svg.match(/viewBox="([^"]*)"/);
+    const viewBox = viewBoxMatch ? viewBoxMatch[1] : '0 0 100 100';
+
+    // Extract inner content between <svg ...> and </svg>
+    const innerMatch = svg.match(/<svg[^>]*>([\s\S]*)<\/svg>/);
+    const inner = innerMatch ? innerMatch[1] : '';
+
+    // Strip <style>, <defs>, <title>, <desc> elements and their content
+    // Remove id, fill, class, style, stroke attributes
+    const cleaned = inner
+      .replace(/<style[\s\S]*?<\/style>/gi, '')
+      .replace(/<defs[\s\S]*?<\/defs>/gi, '')
+      .replace(/<title[\s\S]*?<\/title>/gi, '')
+      .replace(/<desc[\s\S]*?<\/desc>/gi, '')
+      .replace(/<!--[\s\S]*?-->/g, '')
+      .replace(/\s+id="[^"]*"/g, '')
+      .replace(/\s+fill="[^"]*"/g, '')
+      .replace(/\s+class="[^"]*"/g, '')
+      .replace(/\s+style="[^"]*"/g, '')
+      .replace(/\s+stroke="[^"]*"/g, '')
+      .replace(/\s+stroke-[a-z]+="[^"]*"/g, '');
+
+    return `  <symbol id="${name}" viewBox="${viewBox}">\n    ${cleaned.trim()}\n  </symbol>`;
+  });
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>',
+    '<svg id="sprites" xmlns="http://www.w3.org/2000/svg" style="display:none">',
+    symbols.join('\n'),
+    '</svg>',
+  ].join('\n');
+}
 
 function SvgPrepPlugin(options) {
   this.options = {};
@@ -33,17 +75,16 @@ SvgPrepPlugin.prototype.apply = function (compiler) {
       },
       async () => {
         if (!this.options.source) {
-          return Promise.resolve();
+          return;
         }
 
-        // TODO: Keep track of file hashes, so we can avoid recompiling when none have changed
         const files = fs
           .readdirSync(this.options.source)
           .filter(name => name.endsWith('.svg'))
+          .sort()
           .map(name => path.join(this.options.source, name));
 
-        const sprited = await SvgPrep(files).filter({ removeIds: true, noFill: true }).output();
-
+        const sprited = buildSvgSprite(files);
         compilation.emitAsset(this.options.output, new RawSource(sprited));
       }
     );

--- a/webpack/plugins/svg-prep.js
+++ b/webpack/plugins/svg-prep.js
@@ -29,20 +29,25 @@ function buildSvgSprite(files) {
     const innerMatch = svg.match(/<svg[^>]*>([\s\S]*)<\/svg>/);
     const inner = innerMatch ? innerMatch[1] : '';
 
-    // Strip <style>, <defs>, <title>, <desc> elements and their content
-    // Remove id, fill, class, style, stroke attributes
+    // Strip elements that are unnecessary or potential XSS vectors
+    // Remove attributes that interfere with sprite styling or pose security risks
     const cleaned = inner
       .replace(/<style[\s\S]*?<\/style>/gi, '')
       .replace(/<defs[\s\S]*?<\/defs>/gi, '')
       .replace(/<title[\s\S]*?<\/title>/gi, '')
       .replace(/<desc[\s\S]*?<\/desc>/gi, '')
+      .replace(/<script[\s\S]*?<\/script>/gi, '')
       .replace(/<!--[\s\S]*?-->/g, '')
       .replace(/\s+id="[^"]*"/g, '')
       .replace(/\s+fill="[^"]*"/g, '')
       .replace(/\s+class="[^"]*"/g, '')
       .replace(/\s+style="[^"]*"/g, '')
       .replace(/\s+stroke="[^"]*"/g, '')
-      .replace(/\s+stroke-[a-z]+="[^"]*"/g, '');
+      .replace(/\s+stroke-[a-z]+="[^"]*"/g, '')
+      .replace(/\s+on[a-zA-Z]+="[^"]*"/g, '')
+      .replace(/\s+on[a-zA-Z]+='[^']*'/g, '')
+      .replace(/\s+href="[^"]*"/g, '')
+      .replace(/\s+xlink:href="[^"]*"/g, '');
 
     return `  <symbol id="${name}" viewBox="${viewBox}">\n    ${cleaned.trim()}\n  </symbol>`;
   });


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-dashboard/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-dashboard/blob/alpha/LICENSE).

## Issue

Security removal dependency svg-prep

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed a development-only SVG preprocessing tool from the build setup.
  * Inlined and simplified SVG sprite generation within the build pipeline, including deterministic file ordering and an early-exit when no sources are configured.
  * Consolidated build dependencies to streamline local development and build maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->