### PR TITLE
fix: Date value cannot be pasted into date field in data browser

### DIFF
--- a/src/components/DateTimeEditor/DateTimeEditor.react.js
+++ b/src/components/DateTimeEditor/DateTimeEditor.react.js
@@ -81,9 +81,11 @@ export default class DateTimeEditor extends React.Component {
         text: this.props.value.toISOString(),
       });
     } else {
-      if (this.state.text.endsWith('Z')) {
+      if (this.state.text.endsWith('Z') || this.state.text.endsWith('UTC')) {
+        // Timezone is explicit; the parsed Date is already correct.
         this.setState({ value: date });
       } else {
+        // No timezone indicator; treat input as local time.
         const utc = new Date(
           Date.UTC(
             date.getFullYear(),

--- a/src/components/DateTimeEditor/DateTimeEditor.react.js
+++ b/src/components/DateTimeEditor/DateTimeEditor.react.js
@@ -27,10 +27,6 @@ export default class DateTimeEditor extends React.Component {
     this.editorRef = React.createRef();
   }
 
-  componentWillReceiveProps(props) {
-    this.setState({ value: props.value, text: props.value.toISOString() });
-  }
-
   componentDidMount() {
     document.body.addEventListener('click', this.checkExternalClick);
     document.body.addEventListener('touchend', this.checkExternalClick);

--- a/src/lib/DateUtils.js
+++ b/src/lib/DateUtils.js
@@ -103,7 +103,7 @@ export function monthsFrom(date, delta) {
 }
 
 export function dateStringUTC(date) {
-  return date.toLocaleDateString('en-US', {
+  return date.toLocaleDateString('en-GB', {
     year: 'numeric',
     month: 'short',
     day: 'numeric',

--- a/src/lib/DateUtils.js
+++ b/src/lib/DateUtils.js
@@ -103,25 +103,17 @@ export function monthsFrom(date, delta) {
 }
 
 export function dateStringUTC(date) {
-  let full =
-    String(date.getUTCDate()) +
-    ' ' +
-    shortMonth(date.getUTCMonth()) +
-    ' ' +
-    String(date.getUTCFullYear()) +
-    ' at ';
-  const time = {
-    hours: String(date.getUTCHours()),
-    minutes: String(date.getUTCMinutes()),
-    seconds: String(date.getUTCSeconds()),
-  };
-  for (const k in time) {
-    if (time[k].length < 2) {
-      time[k] = '0' + time[k];
-    }
-  }
-  full += time.hours + ':' + time.minutes + ':' + time.seconds + ' UTC';
-  return full;
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+    second: 'numeric',
+    hour12: false,
+    timeZone: 'UTC',
+    timeZoneName: 'short',
+  });
 }
 
 export function monthDayStringUTC(date) {

--- a/src/lib/DateUtils.js
+++ b/src/lib/DateUtils.js
@@ -103,6 +103,8 @@ export function monthsFrom(date, delta) {
 }
 
 export function dateStringUTC(date) {
+  // Use locale 'en-GB' to maintain the current date time format of "dd MMM yyyy, HH:mm:ss";
+  // when supporting multiple locales in the future, this forced locale should be removed
   return date.toLocaleDateString('en-GB', {
     year: 'numeric',
     month: 'short',


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-dashboard/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-dashboard/blob/alpha/LICENSE).

## Issue

Date value cannot be pasted into date field in data browser.

## Tasks
<!-- Delete tasks that don't apply. -->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timezone handling so inputs with explicit timezone indicators are respected and local times are correctly converted to UTC, preventing misinterpreted timestamps.
  * Prevented unexpected input resets by stopping automatic state overrides from incoming prop changes.

* **Refactor**
  * Simplified internal UTC date formatting for more consistent, zero-padded display across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->