### PR TITLE
fix: Edit icon does not disappear when hovering out of saved filter name in data browser sidebar

### DIFF
--- a/src/components/CategoryList/CategoryList.react.js
+++ b/src/components/CategoryList/CategoryList.react.js
@@ -20,6 +20,8 @@ export default class CategoryList extends React.Component {
     this.listWrapperRef = React.createRef();
     this.state = {
       openClasses: [],
+      hoveredFilter: null,
+      hoveredClass: null,
     };
   }
 
@@ -170,7 +172,11 @@ export default class CategoryList extends React.Component {
           const link = generatePath(this.context, (this.props.linkPrefix || '') + (c.link || id));
           return (
             <div key={id}>
-              <div className={styles.link}>
+              <div
+                className={styles.link}
+                onMouseEnter={() => this.setState({ hoveredClass: id })}
+                onMouseLeave={() => this.setState({ hoveredClass: null })}
+              >
                 <Link
                   title={c.name}
                   to={{ pathname: link }}
@@ -194,6 +200,7 @@ export default class CategoryList extends React.Component {
                 {c.onEdit && (
                   <a
                     className={styles.edit}
+                    style={{ opacity: this.state.hoveredClass === id ? 1 : 0 }}
                     onClick={e => {
                       e.preventDefault();
                       c.onEdit();
@@ -221,8 +228,14 @@ export default class CategoryList extends React.Component {
                   const url = id
                     ? `${this.props.linkPrefix}${c.name}?filters=${encodeURIComponent(filter)}&filterId=${id}`
                     : `${this.props.linkPrefix}${c.name}?filters=${encodeURIComponent(filter)}`;
+                  const filterKey = `${c.name}-${index}`;
                   return (
-                    <div key={index} className={styles.childLink}>
+                    <div
+                      key={index}
+                      className={styles.childLink}
+                      onMouseEnter={() => this.setState({ hoveredFilter: filterKey })}
+                      onMouseLeave={() => this.setState({ hoveredFilter: null })}
+                    >
                       <Link
                         className={selectedFilter === index ? styles.active : ''}
                         onClick={e => {
@@ -236,6 +249,7 @@ export default class CategoryList extends React.Component {
                       {this.props.onEditFilter && (
                         <a
                           className={styles.editFilter}
+                          style={{ opacity: this.state.hoveredFilter === filterKey ? 1 : 0 }}
                           onClick={e => {
                             e.preventDefault();
                             this.props.onEditFilter(c.name, filterData);

--- a/src/components/CategoryList/CategoryList.scss
+++ b/src/components/CategoryList/CategoryList.scss
@@ -100,8 +100,6 @@
     align-items: flex-start;
     padding-top: 2px;
     cursor: pointer;
-    opacity: 0;
-    transition: opacity 0.2s ease;
     svg {
       fill: #8fb9cf;
     }
@@ -110,10 +108,6 @@
         fill: white;
       }
     }
-  }
-  
-  &:hover .edit {
-    opacity: 1;
   }
 }
 
@@ -138,8 +132,6 @@
     align-items: flex-start;
     padding-top: 2px;
     cursor: pointer;
-    opacity: 0;
-    transition: opacity 0.2s ease;
     svg {
       fill: #8fb9cf;
     }
@@ -148,9 +140,5 @@
         fill: white;
       }
     }
-  }
-  
-  &:hover .editFilter {
-    opacity: 1;
   }
 }


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-dashboard/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-dashboard/blob/alpha/LICENSE).

## Issue

Edit icon does not disappear on hoover out of saved filter name in data browser sidebar

## Tasks
<!-- Delete tasks that don't apply. -->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Edit controls for categories and filters now display dynamically with enhanced hover interactions, improving accessibility when managing these items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->