### PR TITLE
fix: Column resizing mouse cursor in data browser not visible in Safari browser

### DIFF
--- a/src/components/DataBrowserHeader/DataBrowserHeader.scss
+++ b/src/components/DataBrowserHeader/DataBrowserHeader.scss
@@ -15,7 +15,6 @@
   overflow: hidden;
   height: 30px;
   padding: 4px 6px 4px 2px;
-  cursor: pointer;
   border-left: 4px solid transparent;
 }
 

--- a/src/components/DataBrowserHeaderBar/DataBrowserHeaderBar.react.js
+++ b/src/components/DataBrowserHeaderBar/DataBrowserHeaderBar.react.js
@@ -50,7 +50,6 @@ export default class DataBrowserHeaderBar extends React.Component {
       setSelectedObjectId,
       setCurrent,
       stickyLefts,
-      handleLefts,
       freezeIndex,
       showRowNumber,
       rowNumberWidth,
@@ -120,6 +119,11 @@ export default class DataBrowserHeaderBar extends React.Component {
         className += ` ${styles.preventSort} `;
       }
 
+      let handleClassName = styles.handle;
+      if (freezeIndex >= 0 && i === freezeIndex) {
+        handleClassName += ` ${styles.handleFreeze}`;
+      }
+
       elements.push(
         <div
           onClick={onClick}
@@ -136,27 +140,13 @@ export default class DataBrowserHeaderBar extends React.Component {
             index={i}
             moveDataBrowserHeader={this.props.handleDragDrop}
           />
+          <DragHandle
+            key={'handle' + i}
+            className={handleClassName}
+            onDrag={onResize.bind(null, i)}
+            onClick={e => e.stopPropagation()}
+          />
         </div>
-      );
-      const handleStyle = {};
-      if (freezeIndex >= 0 && typeof handleLefts[i] !== 'undefined' && i <= freezeIndex) {
-        handleStyle.position = 'sticky';
-        handleStyle.left = handleLefts[i];
-        handleStyle.zIndex = 11;
-        if (i === freezeIndex) {
-          handleStyle.marginRight = 0;
-          handleStyle.width = 4;
-        } else {
-          handleStyle.background = wrapStyle.background;
-        }
-      }
-      elements.push(
-        <DragHandle
-          key={'handle' + i}
-          className={styles.handle}
-          onDrag={onResize.bind(null, i)}
-          style={handleStyle}
-        />
       );
     });
 

--- a/src/components/DataBrowserHeaderBar/DataBrowserHeaderBar.scss
+++ b/src/components/DataBrowserHeaderBar/DataBrowserHeaderBar.scss
@@ -24,6 +24,7 @@
 }
 
 .wrap {
+  position: relative;
   display: inline-block;
   vertical-align: top;
 }
@@ -71,12 +72,18 @@
 }
 
 .handle {
-  position: relative;
-  display: inline-block;
-  width: 8px;
+  position: absolute;
+  right: -8px;
+  top: 0;
+  width: 16px;
   height: 30px;
-  margin: 0 -4px;
+  z-index: 2;
   cursor: ew-resize;
+}
+
+.handleFreeze {
+  right: -4px;
+  width: 8px;
 }
 
 .pickerPointer {

--- a/src/components/DataBrowserHeaderBar/DataBrowserHeaderBar.scss
+++ b/src/components/DataBrowserHeaderBar/DataBrowserHeaderBar.scss
@@ -24,6 +24,7 @@
   position: relative;
   display: inline-block;
   vertical-align: top;
+  cursor: pointer;
 }
 
 .addColumn {
@@ -76,6 +77,12 @@
   height: 30px;
   z-index: 2;
   cursor: col-resize;
+  background: rgba(255, 255, 255, 0);
+  transition: background 0.15s ease;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.15);
+  }
 }
 
 .handleFreeze {

--- a/src/components/DataBrowserHeaderBar/DataBrowserHeaderBar.scss
+++ b/src/components/DataBrowserHeaderBar/DataBrowserHeaderBar.scss
@@ -18,9 +18,6 @@
   display: block;
   min-width: 100%;
   width: max-content;
-  // to resolve rendering issue with retina displays
-  -webkit-transform: translate3d(0, 0, 0);
-  will-change: transform;
 }
 
 .wrap {
@@ -78,7 +75,7 @@
   width: 16px;
   height: 30px;
   z-index: 2;
-  cursor: ew-resize;
+  cursor: col-resize;
 }
 
 .handleFreeze {

--- a/src/dashboard/Data/Browser/BrowserTable.react.js
+++ b/src/dashboard/Data/Browser/BrowserTable.react.js
@@ -120,7 +120,6 @@ export default class BrowserTable extends React.Component {
     }));
 
     const stickyLefts = [];
-    const handleLefts = [];
     const maxRowNumber =
       this.props.skip + (this.props.data ? this.props.data.length : this.props.limit);
     const rowNumberWidth = this.props.showRowNumber
@@ -130,7 +129,6 @@ export default class BrowserTable extends React.Component {
       let left = 30 + rowNumberWidth;
       headers.forEach((h, i) => {
         stickyLefts[i] = left;
-        handleLefts[i] = left + h.width;
         if (h.visible) {
           left += h.width;
         }
@@ -620,7 +618,6 @@ export default class BrowserTable extends React.Component {
           }
           headers={headers}
           stickyLefts={stickyLefts}
-          handleLefts={handleLefts}
           freezeIndex={this.props.freezeIndex}
           freezeColumns={this.props.freezeColumns}
           unfreezeColumns={this.props.unfreezeColumns}


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-dashboard/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-dashboard/blob/alpha/LICENSE).

## Issue

Column resizing mouse cursor in data browser not visible in Safari browser

## Tasks
<!-- Delete tasks that don't apply. -->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined drag handle positioning and visual styling in the data browser header.
  * Removed pointer cursor effect from header background.
  * Cleaned up rendering optimizations in header bar styling.

* **Refactor**
  * Simplified header drag handle implementation by consolidating styling approach and removing intermediate prop calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->