### PR TITLE
fix: Improve array-of-pointers rendering in data browser

### DIFF
--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -118,32 +118,29 @@ export default class BrowserCell extends Component {
         this.props.value[0].__type === 'Pointer' &&
         typeof this.props.onPointerClick === 'function'
       ) {
-        const array = [];
-        this.props.value.map((v, i) => {
+        const items = this.props.value.map((v, i) => {
           if (typeof v !== 'object' || v.__type !== 'Pointer') {
-            throw new Error('Invalid type found in pointer array');
+            return <li key={`non-pointer-${i}`}><span>{JSON.stringify(v)}</span></li>;
           }
           const object = new Parse.Object(v.className);
           object.id = v.objectId;
-          array.push(
-            <Pill
-              key={i}
-              value={v.objectId}
-              onClick={this.props.onPointerClick.bind(undefined, object)}
-              followClick={true}
-              shrinkablePill
-            />
+          return (
+            <li key={v.objectId || i}>
+              <Pill
+                value={v.objectId}
+                onClick={this.props.onPointerClick.bind(undefined, object)}
+                onCmdClick={this.props.onPointerCmdClick ? this.props.onPointerCmdClick.bind(undefined, object) : undefined}
+                followClick={true}
+                shrinkablePill
+              />
+            </li>
           );
         });
-        content = (
-          <ul className={styles.pointerList}>
-            {array.map((a, i) => (
-              <li key={i}>{a}</li>
-            ))}
-          </ul>
-        );
-        // Set copyableValue to JSON string, not JSX (to avoid infinite render loop)
+        content = <ul className={styles.pointerList}>{items}</ul>;
         this.copyableValue = JSON.stringify(this.props.value);
+        if (this.props.value.length > 1) {
+          classes.push(styles.hasMore);
+        }
       } else {
         this.copyableValue = content = JSON.stringify(this.props.value);
       }

--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -119,7 +119,7 @@ export default class BrowserCell extends Component {
         typeof this.props.onPointerClick === 'function'
       ) {
         const items = this.props.value.map((v, i) => {
-          if (typeof v !== 'object' || v.__type !== 'Pointer') {
+          if (!v || typeof v !== 'object' || v.__type !== 'Pointer') {
             return <li key={`non-pointer-${i}`}><span>{JSON.stringify(v)}</span></li>;
           }
           const object = new Parse.Object(v.className);

--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -125,7 +125,7 @@ export default class BrowserCell extends Component {
           const object = new Parse.Object(v.className);
           object.id = v.objectId;
           return (
-            <li key={v.objectId || i}>
+            <li key={`${v.objectId}-${i}`}>
               <Pill
                 value={v.objectId}
                 onClick={this.props.onPointerClick.bind(undefined, object)}

--- a/src/components/Pill/Pill.react.js
+++ b/src/components/Pill/Pill.react.js
@@ -13,6 +13,7 @@ import Icon from 'components/Icon/Icon.react';
 const Pill = ({
   value,
   onClick,
+  onCmdClick,
   fileDownloadLink,
   followClick = false,
   shrinkablePill = false,
@@ -29,7 +30,7 @@ const Pill = ({
       {value}
     </span>
     {followClick && (
-      <a onClick={e => !e.metaKey && onClick()}>
+      <a onClick={e => { const handler = e.metaKey ? (onCmdClick || onClick) : onClick; if (typeof handler === 'function') { handler(); } }}>
         <Icon name="right-outline" width={20} height={20} fill="#1669a1" />
       </a>
     )}


### PR DESCRIPTION
## Summary
- Fix crash when array contains mixed pointer and non-pointer elements (previously threw `Error: Invalid type found in pointer array`)
- Add Cmd+Click support to open array pointer targets in a new browser tab
- Add `hasMore` scrollbar styling for multi-pointer arrays

Addresses: https://github.com/parse-community/parse-dashboard/issues/275

## Test plan
- [ ] Navigate to a class with an Array field containing Pointers
- [ ] Verify each pointer renders as a clickable pill with its objectId
- [ ] Click the arrow icon on a pointer pill — should navigate to the target class with an objectId filter
- [ ] Cmd+Click the arrow icon — should open the target in a new tab
- [ ] Verify arrays with mixed pointer/non-pointer elements don't crash
- [ ] Verify empty arrays and non-pointer arrays still render as JSON

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Modifier/command-click support on pointer “pills” to open items via modifier-click when available
  * Visual indicator when pointer arrays contain multiple items

* **Bug Fixes**
  * Non-pointer items in pointer arrays now render as formatted JSON text instead of erroring
  * Pointer items consistently render as individual list entries for clearer display
<!-- end of auto-generated comment: release notes by coderabbit.ai -->