### PR TITLE
feat: Add log pagination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ test_logs
 
 # AI tools
 .claude
+.worktrees

--- a/src/dashboard/Data/Logs/Logs.react.js
+++ b/src/dashboard/Data/Logs/Logs.react.js
@@ -5,6 +5,7 @@
  * This source code is licensed under the license found in the LICENSE file in
  * the root directory of this source tree.
  */
+import Button from 'components/Button/Button.react';
 import CategoryList from 'components/CategoryList/CategoryList.react';
 import DashboardView from 'dashboard/DashboardView.react';
 import EmptyState from 'components/EmptyState/EmptyState.react';
@@ -32,6 +33,8 @@ class Logs extends DashboardView {
     this.state = {
       logs: undefined,
       release: undefined,
+      loading: false,
+      hasMore: false,
     };
   }
 
@@ -47,12 +50,36 @@ class Logs extends DashboardView {
     }
   }
 
-  fetchLogs(app, type) {
+  fetchLogs(app, type, until) {
+    const PAGE_SIZE = 100;
     const typeParam = (type || 'INFO').toUpperCase();
-    app.getLogs(typeParam).then(
-      logs => this.setState({ logs }),
-      () => this.setState({ logs: [] })
+    const options = { size: PAGE_SIZE };
+    if (until) {
+      options.until = until;
+    }
+    this.setState({ loading: true });
+    app.getLogs(typeParam, options).then(
+      newLogs => {
+        this.setState(prevState => ({
+          logs: until && Array.isArray(prevState.logs)
+            ? prevState.logs.concat(newLogs)
+            : newLogs,
+          hasMore: newLogs.length >= PAGE_SIZE,
+          loading: false,
+        }));
+      },
+      () => this.setState({ logs: [], hasMore: false, loading: false })
     );
+  }
+
+  handleLoadMore() {
+    const logs = this.state.logs;
+    if (!logs || logs.length === 0) {
+      return;
+    }
+    const oldestLog = logs[logs.length - 1];
+    const oldestTimestamp = oldestLog.timestamp.iso || oldestLog.timestamp;
+    this.fetchLogs(this.context, this.props.params.type, oldestTimestamp);
   }
 
   // As parse-server doesn't support (yet?) versioning, we are disabling
@@ -115,6 +142,16 @@ class Logs extends DashboardView {
               <LogViewEntry key={timestamp} text={message} timestamp={timestamp} />
             ))}
           </LogView>
+          {this.state.hasMore && (
+            <div className={styles.showMore}>
+              <Button
+                progress={this.state.loading}
+                color="blue"
+                value="Load more logs"
+                onClick={() => this.handleLoadMore()}
+              />
+            </div>
+          )}
         </div>
       );
     }

--- a/src/dashboard/Data/Logs/Logs.react.js
+++ b/src/dashboard/Data/Logs/Logs.react.js
@@ -68,7 +68,11 @@ class Logs extends DashboardView {
           loading: false,
         }));
       },
-      () => this.setState({ logs: [], hasMore: false, loading: false })
+      () => this.setState(prevState => ({
+        logs: prevState.logs || [],
+        hasMore: false,
+        loading: false,
+      }))
     );
   }
 

--- a/src/dashboard/Data/Logs/Logs.react.js
+++ b/src/dashboard/Data/Logs/Logs.react.js
@@ -78,7 +78,7 @@ class Logs extends DashboardView {
 
   handleLoadMore() {
     const logs = this.state.logs;
-    if (!logs || logs.length === 0) {
+    if (!logs || logs.length === 0 || this.state.loading) {
       return;
     }
     const oldestLog = logs[logs.length - 1];

--- a/src/dashboard/Data/Logs/Logs.react.js
+++ b/src/dashboard/Data/Logs/Logs.react.js
@@ -83,7 +83,8 @@ class Logs extends DashboardView {
     }
     const oldestLog = logs[logs.length - 1];
     const oldestTimestamp = oldestLog.timestamp.iso || oldestLog.timestamp;
-    this.fetchLogs(this.context, this.props.params.type, oldestTimestamp);
+    const exclusiveUntil = new Date(new Date(oldestTimestamp).getTime() - 1).toISOString();
+    this.fetchLogs(this.context, this.props.params.type, exclusiveUntil);
   }
 
   // As parse-server doesn't support (yet?) versioning, we are disabling

--- a/src/dashboard/Data/Logs/Logs.react.js
+++ b/src/dashboard/Data/Logs/Logs.react.js
@@ -36,6 +36,7 @@ class Logs extends DashboardView {
       loading: false,
       hasMore: false,
     };
+    this.latestLogsRequestId = 0;
   }
 
   componentDidMount() {
@@ -57,22 +58,47 @@ class Logs extends DashboardView {
     if (until) {
       options.until = until;
     }
+    const requestId = ++this.latestLogsRequestId;
     this.setState({ loading: true });
     app.getLogs(typeParam, options).then(
       newLogs => {
+        if (requestId !== this.latestLogsRequestId) {
+          return;
+        }
+        this.setState(prevState => {
+          let merged;
+          if (until && Array.isArray(prevState.logs)) {
+            const existingKeys = new Set(
+              prevState.logs.map(l => {
+                const ts = l.timestamp.iso || l.timestamp;
+                return `${ts}|${l.message}`;
+              })
+            );
+            const unique = newLogs.filter(l => {
+              const ts = l.timestamp.iso || l.timestamp;
+              return !existingKeys.has(`${ts}|${l.message}`);
+            });
+            merged = prevState.logs.concat(unique);
+          } else {
+            merged = newLogs;
+          }
+          return {
+            logs: merged,
+            hasMore: newLogs.length > 0,
+            loading: false,
+          };
+        });
+      },
+      () => {
+        if (requestId !== this.latestLogsRequestId) {
+          return;
+        }
         this.setState(prevState => ({
-          logs: until && Array.isArray(prevState.logs)
-            ? prevState.logs.concat(newLogs)
-            : newLogs,
-          hasMore: newLogs.length >= PAGE_SIZE,
+          logs: prevState.logs || [],
+          hasMore: false,
           loading: false,
         }));
-      },
-      () => this.setState(prevState => ({
-        logs: prevState.logs || [],
-        hasMore: false,
-        loading: false,
-      }))
+      }
     );
   }
 
@@ -83,8 +109,7 @@ class Logs extends DashboardView {
     }
     const oldestLog = logs[logs.length - 1];
     const oldestTimestamp = oldestLog.timestamp.iso || oldestLog.timestamp;
-    const exclusiveUntil = new Date(new Date(oldestTimestamp).getTime() - 1).toISOString();
-    this.fetchLogs(this.context, this.props.params.type, exclusiveUntil);
+    this.fetchLogs(this.context, this.props.params.type, oldestTimestamp);
   }
 
   // As parse-server doesn't support (yet?) versioning, we are disabling

--- a/src/dashboard/Data/Logs/Logs.scss
+++ b/src/dashboard/Data/Logs/Logs.scss
@@ -25,3 +25,8 @@
   right: 0;
   bottom: 0;
 }
+
+.showMore {
+  padding: 20px;
+  text-align: center;
+}

--- a/src/lib/ParseApp.js
+++ b/src/lib/ParseApp.js
@@ -144,15 +144,24 @@ export default class ParseApp {
 
   /**
    * Fetches scriptlogs from api.parse.com
-   * lines - maximum number of lines to fetch
-   * since - only fetch lines since this Date
+   * level - log level (info or error)
+   * options.from - only fetch logs after this date
+   * options.until - only fetch logs before this date
+   * options.size - maximum number of logs to fetch (default 100)
+   * options.order - sort order (asc or desc)
    */
-  getLogs(level, since) {
-    const path =
-      'scriptlog?level=' +
-      encodeURIComponent(level.toLowerCase()) +
-      '&n=100' +
-      (since ? '&startDate=' + encodeURIComponent(since.getTime()) : '');
+  getLogs(level, { from, until, size = 100, order } = {}) {
+    let path = 'scriptlog?level=' + encodeURIComponent(level.toLowerCase());
+    path += '&size=' + encodeURIComponent(size);
+    if (from) {
+      path += '&from=' + encodeURIComponent(from);
+    }
+    if (until) {
+      path += '&until=' + encodeURIComponent(until);
+    }
+    if (order) {
+      path += '&order=' + encodeURIComponent(order);
+    }
     return this.apiRequest('GET', path, {}, { useMasterKey: true });
   }
 


### PR DESCRIPTION
## Summary
- Add "Load more logs" button to the Logs page for traversing older log entries
- Update `getLogs` API method to support Parse Server's `from`, `until`, `size`, and `order` parameters
- Logs are appended incrementally using timestamp-based cursor pagination

Closes https://github.com/parse-community/parse-dashboard/issues/376

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pagination to the Logs view with a "Load more logs" button and loading state; includes new styling for the control.
* **Enhancements**
  * Log fetching now supports ranged queries, cursor-based paging, ordering, and adjustable page sizes for more efficient retrieval.
* **Chores**
  * Updated ignore rules to include .worktrees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->