### PR TITLE
fix: Context menu submenu offset incorrect for last item

### DIFF
--- a/src/components/ContextMenu/ContextMenu.react.js
+++ b/src/components/ContextMenu/ContextMenu.react.js
@@ -7,7 +7,7 @@
  */
 
 import PropTypes from 'lib/PropTypes';
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useLayoutEffect, useRef } from 'react';
 import styles from 'components/ContextMenu/ContextMenu.scss';
 
 const getPositionToFitVisibleScreen = (ref, offset = 0) => {
@@ -65,7 +65,7 @@ const MenuSection = ({ level, items, path, setPath, hide, hoveredItemOffset }) =
   const basePosition = useRef(null);
   const initialParentScrollTop = useRef(0);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     // Use the actual pixel offset of the hovered item instead of index-based calculation
     const newPosition = getPositionToFitVisibleScreen(sectionRef, hoveredItemOffset);
     if (newPosition) {
@@ -110,7 +110,11 @@ const MenuSection = ({ level, items, path, setPath, hide, hoveredItemOffset }) =
       opacity: 1,
       position: 'absolute',
     }
-    : {};
+    : {
+      opacity: 0,
+      position: 'absolute',
+      pointerEvents: 'none',
+    };
 
   return (
     <ul ref={sectionRef} className={styles.category} style={style}>
@@ -119,8 +123,12 @@ const MenuSection = ({ level, items, path, setPath, hide, hoveredItemOffset }) =
           const newPath = path.slice(0, level + 1);
           newPath.push(index);
           // Get the actual pixel offset of the hovered item relative to its parent
+          // Using getBoundingClientRect for accuracy regardless of offsetParent chain
           const itemElement = event.currentTarget;
-          const itemOffset = itemElement.offsetTop;
+          const parentElement = itemElement.closest('ul');
+          const itemRect = itemElement.getBoundingClientRect();
+          const parentRect = parentElement.getBoundingClientRect();
+          const itemOffset = itemRect.top - parentRect.top + parentElement.scrollTop;
           setPath(newPath, itemOffset);
         };
 

--- a/src/components/ContextMenu/ContextMenu.react.js
+++ b/src/components/ContextMenu/ContextMenu.react.js
@@ -126,6 +126,10 @@ const MenuSection = ({ level, items, path, setPath, hide, hoveredItemOffset }) =
           // Using getBoundingClientRect for accuracy regardless of offsetParent chain
           const itemElement = event.currentTarget;
           const parentElement = itemElement.closest('ul');
+          if (!parentElement) {
+            setPath(newPath, 0);
+            return;
+          }
           const itemRect = itemElement.getBoundingClientRect();
           const parentRect = parentElement.getBoundingClientRect();
           const itemOffset = itemRect.top - parentRect.top + parentElement.scrollTop;

--- a/src/components/ContextMenu/ContextMenu.react.js
+++ b/src/components/ContextMenu/ContextMenu.react.js
@@ -36,18 +36,37 @@ const getPositionToFitVisibleScreen = (ref, offset = 0) => {
     const xRight = prevElBox.right - elBox.left;
     const xLeft = prevElBox.left - elBox.left - elBox.width;
 
-    // Align submenu vertically with the hovered item in the parent menu
-    // offset is the actual pixel position of the hovered item (via offsetTop)
-    // Subtract parent's scrollTop to account for scrolled position
+    // Align the submenu's first item with the hovered item in the parent menu.
+    // offset is the actual pixel position of the hovered item (via getBoundingClientRect);
+    // subtract the parent's scrollTop to account for a scrolled parent menu.
     const adjustedOffset = offset - prevEl.scrollTop;
-    let proposedTop = prevElBox.top + adjustedOffset;
+    const itemTop = prevElBox.top + adjustedOffset;
+    const spaceBelow = lowerLimit - itemTop;
+    const spaceAbove = itemTop - upperLimit;
 
-    // Clamp to screen bounds
-    proposedTop = Math.max(upperLimit, Math.min(proposedTop, lowerLimit - menuHeight));
+    // Decide where the submenu opens so it stays adjacent to the hovered item
+    // instead of jumping to the top of the screen when it doesn't fit below.
+    let top;
+    let maxHeight = null;
+    if (menuHeight <= spaceBelow) {
+      // Fits below: open downward with the first item aligned to the hovered item.
+      top = itemTop;
+    } else if (spaceBelow >= spaceAbove) {
+      // Not enough room below, but more room below than above: keep the first
+      // item aligned to the cursor and let the submenu scroll.
+      top = itemTop;
+      maxHeight = spaceBelow;
+    } else {
+      // More room above: open upward, anchored to the hovered item, so the
+      // submenu stays next to the cursor. Scroll if it is taller than the space.
+      maxHeight = Math.min(menuHeight, spaceAbove);
+      top = itemTop - maxHeight;
+    }
 
     return {
       x: showOnRight ? xRight : xLeft,
-      y: proposedTop - elBox.top,
+      y: top - elBox.top,
+      maxHeight,
     };
   }
 
@@ -105,7 +124,7 @@ const MenuSection = ({ level, items, path, setPath, hide, hoveredItemOffset }) =
   const style = position
     ? {
       transform: `translate(${position.x}px, ${position.y}px)`,
-      maxHeight: '80vh',
+      maxHeight: position.maxHeight != null ? `${position.maxHeight}px` : '80vh',
       overflowY: 'auto',
       opacity: 1,
       position: 'absolute',


### PR DESCRIPTION
Closes https://github.com/parse-community/parse-dashboard/issues/2635

## Summary
- Use `useLayoutEffect` instead of `useEffect` for submenu position calculation to prevent flash at wrong position before repositioning
- Set explicit `opacity: 0` initial style when position hasn't been calculated yet
- Replace `offsetTop` with `getBoundingClientRect` for more robust offset measurement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate submenu positioning for context menus when hovering over items.
  * Improved visual stability during menu open/scroll interactions, preventing flicker and misplacement.
  * Submenus now render offscreen/invisible until correctly positioned, reducing layout jumps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->