### PR TITLE
feat: Modernize UI with design tokens and theming

### DIFF
--- a/src/components/AggregationPanel/AggregationPanel.js
+++ b/src/components/AggregationPanel/AggregationPanel.js
@@ -223,7 +223,7 @@ const AggregationPanel = ({
                       onClick={handleReload}
                       className={styles.reloadButton}
                     >
-                      <Icon name="refresh-solid" width={20} height={20} fill="#169cee" />
+                      <Icon name="refresh-solid" width={20} height={20} fill="var(--color-accent-blue)" />
                     </button>
                   </div>
                 )}
@@ -268,7 +268,7 @@ const AggregationPanel = ({
                 onClick={handleReload}
                 className={styles.reloadButton}
               >
-                <Icon name="refresh-outline" width={20} height={20} fill="#169cee" />
+                <Icon name="refresh-outline" width={20} height={20} fill="var(--color-accent-blue)" />
               </button>
             </div>
           )}

--- a/src/components/AggregationPanel/AggregationPanel.scss
+++ b/src/components/AggregationPanel/AggregationPanel.scss
@@ -1,212 +1,227 @@
 @import 'stylesheets/globals.scss';
 
 .heading {
-    font-size: 14px;
-    margin-top: 0;
-    padding: 8px;
-    padding-left: 10px;
-    background-color: $blue;
-    color: $white;
+  @include HeadingFont;
+  font-size: var(--text-base);
+  margin-top: 0;
+  padding: var(--space-2);
+  padding-left: var(--space-3);
+  background-color: var(--color-accent-blue);
+  color: var(--color-text-on-dark);
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
 }
 
 .segmentItems {
-    font-size: 14px;
-    padding: 10px;
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-  }
+  @include UIFont;
+  font-size: var(--text-base);
+  padding: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
 
 .keyValue {
-    font-size: 14px;
-    display: flex;
-    gap: 10px;
-    align-items: center;
+  font-size: var(--text-base);
+  display: flex;
+  gap: var(--space-3);
+  align-items: center;
 
-    .copyIcon {
-        display: none;
-        cursor: pointer;
-        margin-left: 4px;
-        color: inherit;
-        opacity: 0.6;
-    }
+  .copyIcon {
+    display: none;
+    cursor: pointer;
+    margin-left: var(--space-1);
+    color: inherit;
+    opacity: 0.6;
+    transition: opacity var(--transition-fast);
 
-    &:hover .copyIcon {
-        display: inline-block;
+    &:hover {
+      opacity: 1;
     }
+  }
+
+  &:hover .copyIcon {
+    display: inline-block;
+  }
 }
 
 .video {
-    width: 100%;
-    height: 100%;
+  width: 100%;
+  height: 100%;
 }
 
 .image {
-    width: 100%;
-    height: 100%;
+  width: 100%;
+  height: 100%;
 }
 
 .audio {
-    width: 100%;
+  width: 100%;
 }
 
 .segmentItems table,
 .segmentItems th,
 .segmentItems td {
-    font-size: 14px;
-    border: 1px solid #ddd;
+  font-size: var(--text-base);
+  border: 1px solid var(--color-border-primary);
 }
 
 .segmentItems th,
 .segmentItems td {
-    padding: 4px;
-    text-align: left;
+  padding: var(--space-1);
+  text-align: left;
 }
 
 .buttonContainer {
-    display: flex;
-    justify-content: center;
-    align-items: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .button {
-    width: auto;
-    max-width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    cursor: pointer;
-    margin-bottom: 15px;
-    background-color: $blue;
-    padding: 3px 13px;
-    border: none;
-    color: $white;
-    line-height: 28px;
-    outline: 0;
-    text-decoration: none;
-    text-align: center;
-    border-radius: 5px;
-    font-size: 14px;
+  @include UIFont;
+  width: auto;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
+  margin-bottom: var(--space-4);
+  background-color: var(--color-accent-blue);
+  padding: var(--space-1) var(--space-3);
+  border: none;
+  color: var(--color-text-on-dark);
+  line-height: 28px;
+  outline: 0;
+  text-decoration: none;
+  text-align: center;
+  border-radius: var(--radius-md);
+  font-size: var(--text-base);
+  transition: background-color var(--transition-fast);
 
-    &:hover,
-    &:focus {
-        background-color: $darkBlue;
-    }
+  &:hover,
+  &:focus {
+    background-color: var(--color-accent-blue-hover);
+  }
 }
 
 .loading {
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    text-align: center;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
 }
 
 .center {
-    position: absolute;
-    text-align: center;
-    top: 50%;
-    left: 50%;
-    @include transform(translate(-50%, -50%));
+  position: absolute;
+  text-align: center;
+  top: 50%;
+  left: 50%;
+  @include transform(translate(-50%, -50%));
 }
 
 .nestedPanel {
-    margin-right: -10px;
-    transition: all 0.3s ease;
+  margin-right: -10px;
+  transition: all 0.3s ease;
 }
 
 .nestedPanelHeader {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 8px;
-    border-left: 1px solid transparent; 
-    background-color: $blue;
-    color: $white;
-    cursor: pointer;
-    padding-right: 4px;
-    
-    &.expanded {                         
-      border-left-color: #e3e3ea;
-    }
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  border-left: 1px solid transparent;
+  background-color: var(--color-accent-blue);
+  color: var(--color-text-on-dark);
+  cursor: pointer;
+  padding-right: var(--space-1);
+  transition: border-color var(--transition-fast);
+
+  &.expanded {
+    border-left-color: var(--color-border-primary);
   }
+}
 
 .expandButton {
-    display: inline;
-    padding: 8px;
-    font-weight: 500;
+  @include UIFont;
+  display: inline;
+  padding: var(--space-2);
+  font-weight: var(--font-weight-medium);
 
-    &.expanded {
-        font-weight: 600;
-    }
+  &.expanded {
+    font-weight: var(--font-weight-semibold);
+  }
 }
 
 .refreshButton {
-    background: none;
-    border: none;
-    padding: 4px;
-    cursor: pointer;
-    color: #666;
-    font-size: 16px;
+  background: none;
+  border: none;
+  padding: var(--space-1);
+  cursor: pointer;
+  color: var(--color-text-secondary);
+  font-size: var(--text-lg);
+  transition: color var(--transition-fast);
 
-    &:hover {
-        color: #333;
-    }
+  &:hover {
+    color: var(--color-text-primary);
+  }
 
-    &:disabled {
-        color: #ccc;
-        cursor: not-allowed;
-    }
+  &:disabled {
+    color: var(--color-text-tertiary);
+    cursor: not-allowed;
+  }
 }
 
 .nestedPanelContent {
-    padding: 0  0 8px 0;
+  padding: 0 0 var(--space-2) 0;
 }
 
 .loader {
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 }
 
 .reloadControls {
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    margin-top: 6px;
-    animation: fadeIn 0.5s ease-in;
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: var(--space-2);
+  animation: fadeIn 0.5s ease-in;
 }
 
 .elapsedTimer {
-    color: #999;
-    font-size: 12px;
+  color: var(--color-text-tertiary);
+  font-size: var(--text-xs);
 }
 
 .reloadButton {
-    background: none;
-    border: none;
-    padding: 8px 12px;
-    cursor: pointer;
-    color: $blue;
-    font-size: 13px;
-    margin-top: 10px;
+  @include UIFont;
+  background: none;
+  border: none;
+  padding: var(--space-2) var(--space-3);
+  cursor: pointer;
+  color: var(--color-accent-blue);
+  font-size: var(--text-sm);
+  margin-top: var(--space-3);
+  transition: color var(--transition-fast);
 
-    &:hover {
-        color: $darkBlue;
-    }
+  &:hover {
+    color: var(--color-accent-blue-hover);
+  }
 }
 
 @keyframes fadeIn {
-    from { opacity: 0; }
-    to { opacity: 1; }
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
 
 .segmentContainer {
-    border-left: 1px solid #e3e3ea;
-    border-bottom: 1px solid #e3e3ea;
-    margin-bottom: 16px;
-  }
+  border-left: 1px solid var(--color-border-primary);
+  border-bottom: 1px solid var(--color-border-primary);
+  margin-bottom: var(--space-4);
+}

--- a/src/components/AppBadge/AppBadge.scss
+++ b/src/components/AppBadge/AppBadge.scss
@@ -8,16 +8,16 @@
 @import 'stylesheets/globals.scss';
 
 .badge {
-  @include DosisFont;
+  @include HeadingFont;
   display: inline-block;
   height: 26px;
   line-height: 26px;
   vertical-align: middle;
   text-align: center;
-  border: 1px solid #768C97;
-  color: #768C97;
-  border-radius: 5px;
-  font-size: 10px;
+  border: 1px solid var(--color-text-on-dark-muted);
+  color: var(--color-text-on-dark-muted);
+  border-radius: var(--radius-md);
+  font-size: var(--text-xs);
   letter-spacing: 4px;
   width: 60px;
   padding-left: 3px;
@@ -25,6 +25,6 @@
 }
 
 .prod {
-  color: #00dc7c;
-  border-color: #00dc7c;
+  color: var(--color-accent-green);
+  border-color: var(--color-accent-green);
 }

--- a/src/components/Autocomplete/Autocomplete.scss
+++ b/src/components/Autocomplete/Autocomplete.scss
@@ -5,24 +5,24 @@
  * This source code is licensed under the license found in the LICENSE file in
  * the root directory of this source tree.
  */
- @import "stylesheets/globals.scss";
+@import 'stylesheets/globals.scss';
 
 .field {
   width: 100%;
   height: 56px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   position: relative;
-  transition: 0.3s background-color ease-in-out, 0.3s box-shadow ease-in-out;
+  transition: background-color var(--transition-fast), box-shadow var(--transition-fast);
 }
 
-.field.dropdown input{
-  border-radius: 5px 5px 0px 0px;
+.field.dropdown input {
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
 }
 
 .field.active input + label {
   opacity: 1;
   font-size: 0.5em;
-  color: #0e69a1;
+  color: var(--color-accent-blue);
 }
 
 .field.locked {
@@ -31,33 +31,37 @@
 
 .field input {
   height: 40px;
-
-  border: 1px solid $mainTextColor;
-  border-radius: 5px;
-  font-size: 14px;
+  border: 1px solid var(--color-border-primary);
+  border-radius: var(--radius-md);
+  font-size: var(--text-base);
   outline: none;
   vertical-align: top;
   line-height: normal;
   position: relative;
   font-weight: 400;
-  transition: 0.3s background-color ease-in-out, 0.3s box-shadow ease-in-out,
-    0.1s padding ease-in-out;
+  transition: background-color var(--transition-fast), box-shadow var(--transition-fast),
+    padding 0.1s ease-in-out;
   -webkit-appearance: none;
+
+  &:focus {
+    border-color: var(--color-border-focus);
+    box-shadow: 0 0 0 2px var(--color-accent-blue-light);
+  }
 }
 
 .field input + label {
   position: absolute;
   top: 6px;
   left: 26px;
-  font-family: "Gotham SSm A", "Gotham SSm B", sans-serif;
-  font-size: 14px;
-  font-weight: 600;
+  @include UIFont;
+  font-size: var(--text-base);
+  font-weight: var(--font-weight-semibold);
   line-height: 24px;
   opacity: 0;
   pointer-events: none;
-  transition: 0.1s all ease-in-out;
+  transition: all 0.1s ease-in-out;
 }
 
 .field input + label.error {
-  color: #ec392f;
+  color: var(--color-accent-red);
 }

--- a/src/components/BooleanEditor/BooleanEditor.scss
+++ b/src/components/BooleanEditor/BooleanEditor.scss
@@ -5,12 +5,14 @@
  * This source code is licensed under the license found in the LICENSE file in
  * the root directory of this source tree.
  */
+@import 'stylesheets/globals.scss';
+
 .editor {
-  background: white;
+  background: var(--color-bg-elevated);
   white-space: nowrap;
-  box-shadow: 0 1px 4px rgba(0,0,0,0.4);
+  box-shadow: var(--shadow-md);
 
   > *:first-child {
-    margin: 6px 0;
+    margin: var(--space-2) 0;
   }
 }

--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -725,7 +725,7 @@ export default class BrowserCell extends Component {
       style.left = this.props.stickyLeft;
       style.zIndex = 1;
       style.background = this.props.rowBackground;
-      style.borderBottom = '1px solid #e3e3ea';
+      style.borderBottom = '1px solid var(--color-border-secondary)';
     }
 
     return (

--- a/src/components/BrowserCell/BrowserCell.scss
+++ b/src/components/BrowserCell/BrowserCell.scss
@@ -10,15 +10,15 @@
   overflow: hidden;
   text-overflow: ellipsis;
   cursor: default;
-  color: #0E69A1;
+  color: var(--color-cell-text);
   height: 30px;
   line-height: 20px;
-  padding: 5px;
-  border-right: 1px solid #e3e3ea;
+  padding: var(--data-cell-padding);
+  border-right: 1px solid var(--color-cell-border);
 }
 
 .empty {
-  color: #7D929F;
+  color: var(--color-text-tertiary);
 }
 
 .current {
@@ -28,7 +28,7 @@
     position: absolute;
     pointer-events: none;
     content: '';
-    border: 2px solid #555572;
+    border: 2px solid var(--color-text-primary);
     top: 0;
     left: 0;
     right: 0;
@@ -43,7 +43,7 @@
     position: absolute;
     pointer-events: none;
     content: '';
-    border-left: 2px solid #555572;
+    border-left: 2px solid var(--color-text-primary);
     top: 0;
     left: 0;
     right: 0;
@@ -58,7 +58,7 @@
     position: absolute;
     pointer-events: none;
     content: '';
-    border-right: 2px solid #555572;
+    border-right: 2px solid var(--color-text-primary);
     top: 0;
     left: 0;
     right: 0;
@@ -73,7 +73,7 @@
     position: absolute;
     pointer-events: none;
     content: '';
-    border-top: 2px solid #555572;
+    border-top: 2px solid var(--color-text-primary);
     top: 0;
     left: 0;
     right: 0;
@@ -88,7 +88,7 @@
     position: absolute;
     pointer-events: none;
     content: '';
-    border-bottom: 2px solid #555572;
+    border-bottom: 2px solid var(--color-text-primary);
     top: 0;
     left: 0;
     right: 0;
@@ -97,7 +97,7 @@
 }
 
 .selected {
-  background-color: #e3effd;
+  background-color: var(--color-accent-blue-light);
 }
 
 .pointerList {
@@ -154,7 +154,7 @@
     position: absolute;
     pointer-events: none;
     content: '';
-    border: 2px solid #ff395e;
+    border: 2px solid var(--color-accent-red);
     top: 0;
     left: 0;
     right: 0;
@@ -163,7 +163,7 @@
 }
 
 .readonly {
-  color: #04263bd1;
+  color: var(--color-text-secondary);
 }
 
 .action {

--- a/src/components/BrowserFilter/BrowserFilter.react.js
+++ b/src/components/BrowserFilter/BrowserFilter.react.js
@@ -857,7 +857,6 @@ export default class BrowserFilter extends React.Component {
               {this.state.confirmDelete && (
                 <div className={styles.footer}>
                   <Button
-                    color="white"
                     value="Cancel"
                     width="120px"
                     onClick={() => this.setState({ confirmDelete: false })}
@@ -885,15 +884,14 @@ export default class BrowserFilter extends React.Component {
                           name="up-solid"
                           width={20}
                           height={20}
-                          fill="white"
+                          fill="var(--color-text-secondary)"
                         />
                       </span>
                       <div
                         style={{
                           width: '1px',
                           height: '20px',
-                          backgroundColor: '#ffffff',
-                          opacity: 0.3,
+                          backgroundColor: 'var(--color-border-primary)',
                           alignSelf: 'center'
                         }}
                       />
@@ -909,7 +907,7 @@ export default class BrowserFilter extends React.Component {
                           name="check"
                           width={20}
                           height={20}
-                          fill={this.state.name && (this.state.name !== this.state.originalFilterName || this.hasFilterContentChanged()) && !this.isFilterNameExists(this.state.name) ? '#00db7c' : 'white'}
+                          fill={this.state.name && (this.state.name !== this.state.originalFilterName || this.hasFilterContentChanged()) && !this.isFilterNameExists(this.state.name) ? 'var(--color-accent-green)' : 'var(--color-text-tertiary)'}
                         />
                       </span>
                       {this.isCurrentFilterSaved() && (
@@ -922,7 +920,7 @@ export default class BrowserFilter extends React.Component {
                               name="clone-icon"
                               width={20}
                               height={20}
-                              fill="white"
+                              fill="var(--color-text-secondary)"
                             />
                           </span>
                           <span
@@ -933,7 +931,7 @@ export default class BrowserFilter extends React.Component {
                               name="trash-solid"
                               width={20}
                               height={20}
-                              fill="white"
+                              fill="var(--color-accent-red)"
                             />
                           </span>
                         </>
@@ -951,11 +949,10 @@ export default class BrowserFilter extends React.Component {
                             name="down-solid"
                             width={20}
                             height={20}
-                            fill="white"
+                            fill="var(--color-text-secondary)"
                           />
                         </span>
                         <Button
-                          color="white"
                           value="Clear"
                           disabled={this.state.filters.size === 0}
                           width="120px"
@@ -966,14 +963,12 @@ export default class BrowserFilter extends React.Component {
                   </div>
                   <div className={styles.btnFlex}>
                     <Button
-                      color="white"
                       value="Add"
                       disabled={Object.keys(available).length === 0}
                       width="120px"
                       onClick={() => this.addRow()}
                     />
                     <Button
-                      color="white"
                       primary={true}
                       value="Apply"
                       width="120px"

--- a/src/components/BrowserFilter/BrowserFilter.scss
+++ b/src/components/BrowserFilter/BrowserFilter.scss
@@ -12,74 +12,87 @@
 }
 
 .entry {
-  height: 30px;
-  padding: 8px;
+  display: inline-flex;
+  align-items: center;
+  padding: var(--space-1) var(--space-2);
 
   svg {
-    fill: #66637A;
+    fill: var(--color-text-on-dark-muted);
   }
 
   &:hover svg {
-    fill: white;
+    fill: var(--color-text-on-dark);
   }
 
   &.disabled {
     cursor: not-allowed;
-    color: #66637A;
+    color: rgba(255, 255, 255, 0.3);
+    opacity: 0.5;
 
     &:hover svg {
-      fill: #66637A;
+      fill: rgba(255, 255, 255, 0.3);
     }
   }
 }
 
 .entry.active {
-  background: $blue;
-  border-radius: 5px;
+  background: var(--color-accent-blue);
+  border-radius: var(--radius-sm);
 
   svg {
-    fill: white;
+    fill: var(--color-text-on-dark);
   }
 }
 
-.active .title, .active .body {
-  background: $blue;
+.active .title {
+  background: var(--color-accent-blue);
+}
+
+.active .body {
+  background: var(--color-bg-elevated);
 }
 
 .title {
-  background: #797691;
-  padding: 8px;
-  border-radius: 5px 5px 0 0;
+  display: inline-flex;
+  align-items: center;
+  background: rgba(255, 255, 255, 0.1);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
 
   svg {
-    fill: white;
+    fill: var(--color-text-on-dark);
   }
 }
 
 .entry, .title {
-  @include NotoSansFont;
-  position: relative;
-  bottom: -4px;
-  font-size: 14px;
-  color: #ffffff;
+  @include UIFont;
+  font-size: var(--text-sm);
+  color: var(--color-text-on-dark-muted);
   cursor: pointer;
+  border-radius: var(--radius-md);
+  transition: background var(--transition-fast), color var(--transition-fast);
 
   svg {
-    vertical-align: top;
-    margin-right: 6px;
+    vertical-align: middle;
+    margin-right: var(--space-1);
   }
 
   span {
     display: inline-block;
-    vertical-align: top;
+    vertical-align: middle;
     height: 14px;
     line-height: 14px;
+  }
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.1);
+    color: var(--color-text-on-dark);
   }
 }
 
 .objectPickerContent {
   .entry svg {
-    fill: rgba(0, 0, 0, 0.3);
+    fill: var(--color-text-tertiary);
   }
 }
 
@@ -91,18 +104,22 @@
   overflow: hidden;
   top: 30px;
   right: 0;
-  border-radius: 5px 0 5px 5px;
-  background: #797691;
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border-secondary);
+  box-shadow: var(--shadow-overlay);
   width: 685px;
-  font-size: 14px;
+  font-size: var(--text-base);
 }
 
 .footer {
-  background: rgba(0,0,0,0.2);
-  padding: 11px 16px;
+  background: var(--color-bg-tertiary);
+  padding: var(--space-3) var(--space-4);
   text-align: center;
   display: flex;
   justify-content: space-between;
+  border-top: 1px solid var(--color-border-secondary);
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
   > button {
     margin-right: 10px;
 
@@ -113,7 +130,7 @@
 }
 
 .row {
-  padding: 8px 15px;
+  padding: var(--space-2) 15px;
 
   > * {
     margin-right: 10px;
@@ -127,26 +144,31 @@
     @include MonospaceFont;
     height: 30px;
     width: 140px;
-    background: #343445;
-    border: none;
+    background: var(--color-bg-secondary);
+    border: 1px solid var(--color-border-primary);
     outline: none;
-    border-radius: 5px;
+    border-radius: var(--radius-md);
     vertical-align: top;
-    padding: 0 8px;
-    color: white;
-    font-size: 14px;
+    padding: 0 var(--space-2);
+    color: var(--color-text-primary);
+    font-size: var(--text-base);
+
+    &:focus {
+      border-color: var(--color-border-focus);
+      box-shadow: 0 0 0 1px var(--color-border-focus);
+    }
   }
 }
 
 .active .row input {
-  background: #0E69A1;
+  border-color: var(--color-accent-blue);
 }
 
 .remove {
   @include buttonReset;
   display: inline-block;
   height: 14px;
-  margin: 8px;
+  margin: var(--space-2);
 }
 
 .date {
@@ -161,7 +183,7 @@
 
 .btnFlex{
   display: flex;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .iconButton {
@@ -170,8 +192,8 @@
   align-items: center;
   justify-content: center;
   opacity: 0.7;
-  transition: opacity 0.2s ease;
-  
+  transition: opacity var(--transition-fast);
+
   &:hover {
     opacity: 1;
   }
@@ -183,7 +205,7 @@
   align-items: center;
   justify-content: center;
   opacity: 0.3;
-  
+
   &:hover {
     opacity: 0.3;
   }

--- a/src/components/BrowserFilter/FilterRow.react.js
+++ b/src/components/BrowserFilter/FilterRow.react.js
@@ -75,17 +75,17 @@ const RegexOptionsButton = ({ modifiers, onChangeModifiers }) => {
       <div
         ref={dropdownRef}
         style={{
-          background: '#1e1e2e',
-          border: '1px solid #66637A',
-          borderRadius: '5px',
+          background: 'var(--color-bg-elevated)',
+          border: '1px solid var(--color-border-secondary)',
+          borderRadius: 'var(--radius-lg)',
           padding: '8px',
           minWidth: '150px',
-          color: 'white',
+          color: 'var(--color-text-primary)',
           fontSize: '14px',
-          boxShadow: '0 4px 6px rgba(0, 0, 0, 0.3)'
+          boxShadow: 'var(--shadow-overlay)'
         }}
       >
-        <div style={{ marginBottom: '4px', fontWeight: 'bold', paddingBottom: '4px', borderBottom: '1px solid rgba(255,255,255,0.2)' }}>
+        <div style={{ marginBottom: '4px', fontWeight: 'bold', paddingBottom: '4px', borderBottom: '1px solid var(--color-border-secondary)' }}>
           Regex Options
         </div>
         <label
@@ -163,7 +163,7 @@ const RegexOptionsButton = ({ modifiers, onChangeModifiers }) => {
         }}
         title="Regex options"
       >
-        <Icon name="gear-solid" width={14} height={14} fill="rgba(0,0,0,0.4)" />
+        <Icon name="gear-solid" width={14} height={14} fill="var(--color-text-tertiary)" />
       </button>
       {optionsDropdown}
     </>
@@ -252,7 +252,7 @@ function compareValue(
       return (
         <ChromeDropdown
           width="140"
-          color={active ? 'blue' : 'purple'}
+          color={active ? 'blue' : undefined}
           value={value ? 'True' : 'False'}
           options={['True', 'False']}
           onChange={val => onChangeCompareTo(val === 'True')}
@@ -342,15 +342,16 @@ const FilterRow = ({
           maxHeight: '360px',
           overflowY: 'auto',
           fontSize: '14px',
-          background: '#343445',
-          borderBottomLeftRadius: '5px',
-          borderBottomRightRadius: '5px',
-          color: 'white',
+          background: 'var(--color-bg-elevated)',
+          border: '1px solid var(--color-border-secondary)',
+          borderRadius: '0 0 var(--radius-md) var(--radius-md)',
+          color: 'var(--color-text-primary)',
           cursor: 'pointer',
+          boxShadow: 'var(--shadow-md)',
         }}
         suggestionsItemStyle={{
-          background: '#343445',
-          color: 'white',
+          background: 'var(--color-bg-elevated)',
+          color: 'var(--color-text-primary)',
           height: '30px',
           lineHeight: '30px',
           borderBottom: '0px',
@@ -377,15 +378,16 @@ const FilterRow = ({
           maxHeight: '360px',
           overflowY: 'auto',
           fontSize: '14px',
-          background: '#343445',
-          borderBottomLeftRadius: '5px',
-          borderBottomRightRadius: '5px',
-          color: 'white',
+          background: 'var(--color-bg-elevated)',
+          border: '1px solid var(--color-border-secondary)',
+          borderRadius: '0 0 var(--radius-md) var(--radius-md)',
+          color: 'var(--color-text-primary)',
           cursor: 'pointer',
+          boxShadow: 'var(--shadow-md)',
         }}
         suggestionsItemStyle={{
-          background: '#343445',
-          color: 'white',
+          background: 'var(--color-bg-elevated)',
+          color: 'var(--color-text-primary)',
           height: '30px',
           lineHeight: '30px',
           borderBottom: '0px',
@@ -405,7 +407,7 @@ const FilterRow = ({
       />
       <div style={{ flex: 1 }}>
         <ChromeDropdown
-          color={active ? 'blue' : 'purple'}
+          color={active ? 'blue' : undefined}
           value={Constraints[currentConstraint].name}
           options={constraints.map(c => Constraints[c].name)}
           onChange={c => onChangeConstraint(constraintLookup[c], compareTo)}
@@ -424,7 +426,7 @@ const FilterRow = ({
         onChangeModifiers
       )}
       <button type="button" className={styles.remove} onClick={onDeleteRow}>
-        <Icon name="minus-solid" width={14} height={14} fill="rgba(0,0,0,0.4)" />
+        <Icon name="minus-solid" width={14} height={14} fill="var(--color-text-tertiary)" />
       </button>
     </div>
   );

--- a/src/components/BrowserMenu/BrowserMenu.scss
+++ b/src/components/BrowserMenu/BrowserMenu.scss
@@ -16,6 +16,7 @@
 }
 
 // Make submenu entries stretch to full width within menu bodies
+// Override dark-toolbar colors with light-bg colors when inside dropdown
 .body, .subMenuBody, .subMenuBodyLeft {
   > .wrap {
     display: block;
@@ -24,146 +25,215 @@
       display: flex;
       align-items: center;
       justify-content: space-between;
-      padding: 4px 14px;
+      padding: var(--space-1) var(--space-3);
       white-space: nowrap;
+      color: var(--color-text-primary);
+
+      svg {
+        fill: var(--color-text-tertiary);
+      }
+
+      &:hover {
+        background: var(--color-interactive-hover);
+        color: var(--color-text-primary);
+
+        svg {
+          fill: var(--color-text-primary);
+        }
+      }
+
+      &.disabled {
+        color: var(--color-text-tertiary);
+
+        &:hover svg {
+          fill: var(--color-text-tertiary);
+        }
+      }
+
+      &.active {
+        background: var(--color-accent-blue-light);
+        color: var(--color-accent-blue);
+
+        svg {
+          fill: var(--color-accent-blue);
+        }
+      }
+    }
+  }
+
+  // Title inside dropdown body also needs light colors
+  .title {
+    color: var(--color-text-primary);
+
+    svg {
+      fill: var(--color-text-secondary);
+    }
+
+    &:hover {
+      background: var(--color-interactive-hover);
+      color: var(--color-text-primary);
+
+      svg {
+        fill: var(--color-text-primary);
+      }
     }
   }
 }
 
 .entry {
-  height: 30px;
-  padding: 8px;
+  display: inline-flex;
+  align-items: center;
+  padding: var(--space-1) var(--space-2);
 
   svg {
-    fill: #66637A;
+    fill: var(--color-text-on-dark-muted);
+    transition: fill var(--transition-fast);
   }
 
   &:hover {
     svg {
-      fill: white;
+      fill: var(--color-text-on-dark);
     }
   }
 
   &.disabled {
     cursor: not-allowed;
-    color: #66637A;
+    color: var(--color-text-on-dark-muted);
+    opacity: 0.4;
 
     &:hover svg {
-      fill: #66637A;
+      fill: var(--color-text-on-dark-muted);
     }
   }
 
   &.active {
-    background: $orange;
-    border-radius: 5px;
+    background: var(--color-accent-orange);
+    border-radius: var(--radius-md);
 
     svg {
-      fill: white;
+      fill: var(--color-text-on-dark);
     }
   }
 }
 
 .title {
-  background: #797592;
-  padding: 8px;
-  border-radius: 5px 5px 0 0;
+  display: inline-flex;
+  align-items: center;
+  background: var(--color-interactive-hover);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
 
   svg {
-    fill: white;
+    fill: var(--color-text-secondary);
   }
 
   &.active {
-    background: $orange;
-    border-radius: 5px;
+    background: var(--color-accent-orange);
+    border-radius: var(--radius-md);
+
+    svg {
+      fill: var(--color-text-on-dark);
+    }
   }
 }
 
 .entry, .title {
-  @include NotoSansFont;
-  position: relative;
-  bottom: -4px;
-  font-size: 14px;
-  color: #ffffff;
+  @include UIFont;
+  font-size: var(--text-sm);
+  color: var(--color-text-on-dark-muted);
   cursor: pointer;
+  border-radius: var(--radius-md);
+  transition: background var(--transition-fast), color var(--transition-fast);
 
   svg {
-    vertical-align: top;
-    margin-right: 4px;
+    vertical-align: middle;
+    margin-right: var(--space-1);
+    fill: var(--color-text-on-dark-muted);
   }
 
   span {
-    vertical-align: top;
+    vertical-align: middle;
     height: 14px;
     line-height: 14px;
+  }
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.1);
+    color: var(--color-text-on-dark);
+
+    svg {
+      fill: var(--color-text-on-dark);
+    }
   }
 }
 
 .body {
   position: absolute;
-  top: 30px;
+  top: 34px;
   right: 0;
-  border-radius: 5px 0 5px 5px;
-  background: #797592;
-  padding: 8px 0;
-  font-size: 14px;
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-elevated);
+  padding: var(--space-1) 0;
+  font-size: var(--text-sm);
+  box-shadow: var(--shadow-overlay);
+  border: 1px solid var(--color-border-secondary);
+  z-index: 10;
 }
-
 
 .subMenuBody {
   position: absolute;
   top: 0;
-  border-radius: 0 5px 5px 5px;
-  background: #797592;
-  padding: 8px 0;
-  font-size: 14px;
-  border: 1px solid rgba(0, 0, 0, 0.1);
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-elevated);
+  padding: var(--space-1) 0;
+  font-size: var(--text-sm);
+  border: 1px solid var(--color-border-secondary);
+  box-shadow: var(--shadow-lg);
+  z-index: 11;
 }
 
 .subMenuBodyLeft {
   position: absolute;
   top: 0;
-  border-radius: 5px 0 5px 5px;
-  background: #797592;
-  padding: 8px 0;
-  font-size: 14px;
-  border: 1px solid rgba(0, 0, 0, 0.1);
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-elevated);
+  padding: var(--space-1) 0;
+  font-size: var(--text-sm);
+  border: 1px solid var(--color-border-secondary);
+  box-shadow: var(--shadow-lg);
+  z-index: 11;
 }
 
 .submenuArrow {
-  margin-left: 12px;
+  margin-left: var(--space-3);
   flex-shrink: 0;
   font-size: 18px;
   line-height: 1;
-  color: rgba(255, 255, 255, 0.5);
+  color: var(--color-text-tertiary);
 
   &::after {
-    content: '›';
+    content: '\203A';
   }
 }
 
 .entry:hover .submenuArrow {
-  color: white;
+  color: var(--color-text-primary);
 }
 
 .item {
   position: relative;
-  padding: 4px 14px;
+  padding: var(--space-1) var(--space-3);
   white-space: nowrap;
   cursor: pointer;
-  color: white;
+  color: var(--color-text-primary);
+  transition: background var(--transition-fast);
 
   &:hover {
-    background: $blue;
-
-    .submenuArrow {
-      border-left-color: white;
-    }
+    background: var(--color-interactive-hover);
   }
 
   &.disabled {
-    color: rgba(0,0,0,0.2);
+    color: var(--color-text-tertiary);
     cursor: not-allowed;
 
     &:hover {
@@ -173,7 +243,7 @@
 }
 
 .separator {
-  background: rgba(0,0,0,0.1);
+  background: var(--color-border-secondary);
   height: 1px;
-  margin: 4px 0;
+  margin: var(--space-1) 0;
 }

--- a/src/components/BrowserRow/BrowserRow.react.js
+++ b/src/components/BrowserRow/BrowserRow.react.js
@@ -74,7 +74,7 @@ export default class BrowserRow extends Component {
     } else if (obj.className === '_User' && obj.get('authData') !== undefined) {
       requiredCols = ['authData'];
     }
-    const rowBackground = row % 2 ? '#F4F5F7' : '#fdfafb';
+    const rowBackground = row % 2 ? 'var(--color-bg-secondary)' : 'var(--color-bg-primary)';
     const rowStyle = { minWidth: rowWidth };
     return (
       <div className={styles.tableRow} style={rowStyle} onMouseOver={() => onMouseOverRow(obj.id)}>
@@ -87,7 +87,7 @@ export default class BrowserRow extends Component {
             left: 0,
             zIndex: 1,
             background: rowBackground,
-            borderBottom: '1px solid #e3e3ea',
+            borderBottom: '1px solid var(--color-border-secondary)',
           }}
         >
           <input
@@ -105,7 +105,7 @@ export default class BrowserRow extends Component {
               left: 30,
               zIndex: 1,
               background: rowBackground,
-              borderBottom: '1px solid #e3e3ea',
+              borderBottom: '1px solid var(--color-border-secondary)',
               width: rowNumberWidth,
             }}
           >

--- a/src/components/Button/Button.react.js
+++ b/src/components/Button/Button.react.js
@@ -74,7 +74,7 @@ Button.propTypes = {
     'Determines whether a button can be clicked. Disabled buttons will ' +
       'appear grayed out, and will not fire onClick events.'
   ),
-  color: PropTypes.oneOf(['blue', 'green', 'red', 'white']).describe('The color of the button.'),
+  color: PropTypes.oneOf(['blue', 'green', 'red', 'white', 'ghost']).describe('The color of the button.'),
   onClick: PropTypes.func.describe('A function to be called when the button is clicked.'),
   value: PropTypes.string.isRequired.describe(
     'The content of the button. This can be any renderable content.'

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -8,95 +8,125 @@
 @import 'stylesheets/globals.scss';
 
 .button {
-  @include DosisFont;
-  @include buttonReset($bg: none, $border: 1px solid $blue, $padding: 0 16px);
+  @include UIFont;
+  @include buttonReset($bg: var(--btn-bg), $border: var(--btn-border), $padding: 0 16px);
   display: inline-block;
-  height: 30px;
-  line-height: 28px;
+  height: 36px;
+  line-height: 36px;
   outline: 0;
   text-decoration: none;
   text-align: center;
-  border-radius: 5px;
-  font-size: 14px;
-
-  color: $blue;
+  border-radius: var(--btn-radius);
+  font-size: var(--text-base);
+  font-weight: var(--font-weight-medium);
+  color: var(--btn-color);
+  transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast), box-shadow var(--transition-fast);
 
   &:hover, &:focus {
-    background-color: $blue;
-    color: white;
+    background: var(--btn-hover-bg);
+    color: var(--btn-hover-color);
+    border-color: var(--color-border-primary);
   }
 }
 
 .primary {
-  background-color: $blue;
-  color: $white;
+  background: var(--btn-primary-bg);
+  color: var(--btn-primary-color);
+  border: var(--btn-primary-border);
 
   &:hover, &:focus {
-    background-color: $darkBlue;
+    background: var(--btn-primary-hover-bg);
+    border-color: var(--btn-primary-hover-bg);
+    color: var(--btn-primary-color);
   }
 }
 
 .green {
-  color: $green;
-  border-color: $green;
+  color: var(--color-accent-green);
+  background: var(--color-accent-green-light);
+  border-color: transparent;
 
   &:hover, &:focus {
-    background-color: $lightGreen;
+    background: var(--color-accent-green);
+    color: var(--color-text-on-dark);
+    border-color: transparent;
   }
 
   &.primary {
-    background-color: $green;
-    color: $white;
+    background: var(--color-accent-green);
+    color: var(--color-text-on-dark);
+    border-color: transparent;
 
     &:hover, &:focus {
-      background-color: $darkGreen;
+      background: var(--color-accent-green);
+      filter: brightness(0.9);
     }
   }
 }
 
 .red {
-  color: $red;
-  border-color: $red;
+  color: var(--color-accent-red);
+  background: var(--color-accent-red-light);
+  border-color: transparent;
 
   &:hover, &:focus {
-    background-color: $lightRed;
+    background: var(--color-accent-red);
+    color: var(--color-text-on-dark);
+    border-color: transparent;
   }
 
   &.primary {
-    background-color: $red;
-    color: $white;
+    background: var(--color-accent-red);
+    color: var(--color-text-on-dark);
+    border-color: transparent;
 
     &:hover, &:focus {
-      background-color: $darkRed;
+      background: var(--color-accent-red);
+      filter: brightness(0.9);
     }
   }
 }
 
-.white {
-  color: $white;
-  border-color: $white;
-  line-height: 28px;
+// Ghost: transparent bg, subtle hover — for Cancel / tertiary actions
+.ghost {
+  color: var(--color-text-secondary);
+  background: transparent;
+  border-color: transparent;
 
   &:hover, &:focus {
-    background-color: $white;
-    color: $blue;
+    background: var(--color-interactive-hover);
+    color: var(--color-text-primary);
+    border-color: transparent;
+  }
+}
+
+.white {
+  color: var(--color-text-on-dark);
+  border-color: rgba(255, 255, 255, 0.3);
+  background: rgba(255, 255, 255, 0.1);
+
+  &:hover, &:focus {
+    background: rgba(255, 255, 255, 0.2);
+    color: var(--color-text-on-dark);
+    border-color: rgba(255, 255, 255, 0.4);
   }
 
   &.primary {
-    background-color: $white;
-    color: $blue;
+    background: var(--color-text-on-dark);
+    color: var(--color-accent-blue);
+    border-color: transparent;
 
     &:hover, &:focus {
-      background-color: $blue;
-      border-color: $blue;
-      color: white;
+      background: rgba(255, 255, 255, 0.9);
+      border-color: transparent;
+      color: var(--color-accent-blue);
     }
   }
 
   &.disabled {
-    background-color: transparent;
-    border-color: white;
-    opacity: 0.2;
+    background: transparent;
+    border-color: rgba(255, 255, 255, 0.15);
+    opacity: 0.3;
   }
 }
 
@@ -109,14 +139,15 @@
 }
 
 .disabled, .disabled.primary {
-  background-color: #e0e0ea;
-  border-color: #e0e0ea;
-  color: white;
+  background: var(--color-bg-tertiary);
+  border-color: transparent;
+  color: var(--color-text-tertiary);
   cursor: default;
-  &:hover{
-    background-color: #e0e0ea;
-    border-color: #e0e0ea;
-    color: white;
+
+  &:hover {
+    background: var(--color-bg-tertiary);
+    border-color: transparent;
+    color: var(--color-text-tertiary);
   }
 }
 
@@ -128,4 +159,3 @@
     background-position: 150% 0;
   }
 }
-

--- a/src/components/Calendar/Calendar.scss
+++ b/src/components/Calendar/Calendar.scss
@@ -8,24 +8,25 @@
 @import 'stylesheets/globals.scss';
 
 .calendar {
-  background: white;
-  color: $blue;
+  background: var(--color-bg-elevated);
+  color: var(--color-accent-blue);
   width: 182px;
   height: auto;
 }
 
 .month {
-  margin-bottom: 10px;
+  margin-bottom: var(--space-3);
 
   button {
-    @include buttonReset($border: 1px solid $blue);
+    @include buttonReset($border: 1px solid var(--color-accent-blue));
     position: relative;
     display: inline-block;
     width: 14px;
     height: 14px;
-    border-radius: 100%;
+    border-radius: var(--radius-full);
     opacity: 0.5;
-    margin: 0 6px;
+    margin: 0 var(--space-2);
+    transition: opacity var(--transition-fast);
 
     &:hover {
       opacity: 1;
@@ -37,7 +38,7 @@
       &:before {
         content: '';
         position: absolute;
-        @include arrow('left', 8px, 4px, $blue);
+        @include arrow('left', 8px, 4px, var(--color-accent-blue));
         top: 2px;
         left: 4px;
       }
@@ -45,7 +46,7 @@
       &:after {
         content: '';
         position: absolute;
-        @include arrow('left', 8px, 4px, white);
+        @include arrow('left', 8px, 4px, var(--color-bg-elevated));
         top: 2px;
         left: 5px;
       }
@@ -57,7 +58,7 @@
       &:before {
         content: '';
         position: absolute;
-        @include arrow('right', 8px, 4px, $blue);
+        @include arrow('right', 8px, 4px, var(--color-accent-blue));
         top: 2px;
         left: 4px;
       }
@@ -65,7 +66,7 @@
       &:after {
         content: '';
         position: absolute;
-        @include arrow('right', 8px, 4px, white);
+        @include arrow('right', 8px, 4px, var(--color-bg-elevated));
         top: 2px;
         left: 3px;
       }
@@ -73,22 +74,22 @@
   }
 
   div {
-    font-size: 14px;
+    font-size: var(--text-base);
     text-align: center;
   }
 }
 
 .weekdays {
   opacity: 0.5;
-  font-size: 12px;
-  margin-bottom: 8px;
+  font-size: var(--text-xs);
+  margin-bottom: var(--space-2);
 
   span {
     display: inline-block;
     width: 26px;
     height: 13px;
     line-height: 13px;
-    font-size: 13px;
+    font-size: var(--text-sm);
     text-align: center;
   }
 }
@@ -101,34 +102,44 @@
     width: 26px;
     height: 20px;
     line-height: 20px;
-    font-size: 12px;
+    font-size: var(--text-xs);
     text-align: center;
     margin: 0;
-    color: $blue;
+    color: var(--color-accent-blue);
+    border-radius: var(--radius-sm);
+    transition: background var(--transition-fast), color var(--transition-fast);
+
+    &:hover {
+      background: var(--color-interactive-hover);
+    }
   }
 
   .selected {
-    color: white;
-    background: $darkBlue;
+    color: var(--color-text-on-dark);
+    background: var(--color-accent-blue-hover);
+
+    &:hover {
+      background: var(--color-accent-blue);
+    }
   }
 }
 
 .shadeBefore {
   a {
-    background: #efeff1;
+    background: var(--color-bg-tertiary);
   }
 
   .selected {
-    background: $darkBlue;
+    background: var(--color-accent-blue-hover);
   }
 
   .selected ~ button {
-    background: white;
+    background: var(--color-bg-elevated);
   }
 }
 
 .shadeAfter {
   .selected ~ button {
-    background: #efeff1;
+    background: var(--color-bg-tertiary);
   }
 }

--- a/src/components/CascadingView/CascadingView.scss
+++ b/src/components/CascadingView/CascadingView.scss
@@ -7,7 +7,7 @@
  */
 @import 'stylesheets/globals.scss';
 
-$arrowColor: #343445;
+$arrowColor: var(--color-accent-purple);
 
 .cascadingView, .contentContainer {
   position: relative;
@@ -29,6 +29,11 @@ $arrowColor: #343445;
 
 .arrow {
   @include buttonReset;
+  transition: opacity var(--transition-fast);
+
+  &:hover {
+    opacity: 0.8;
+  }
 }
 
 .expanded {
@@ -43,11 +48,11 @@ $arrowColor: #343445;
 
 .childrenContainer {
   position: relative;
-  padding: 15px 0px 15px 18px;
-  background-color: $inputBackgroundColor;
+  padding: var(--space-4) 0 var(--space-4) var(--space-4);
+  background-color: var(--color-bg-tertiary);
 
   .children {
-    border-left: 1px solid rgba(52, 52, 69, 0.2);
-    padding-left: 14px;
+    border-left: 1px solid var(--color-border-secondary);
+    padding-left: var(--space-3);
   }
 }

--- a/src/components/CategoryList/CategoryList.react.js
+++ b/src/components/CategoryList/CategoryList.react.js
@@ -17,7 +17,6 @@ export default class CategoryList extends React.Component {
   static contextType = CurrentApp;
   constructor() {
     super();
-    this.listWrapperRef = React.createRef();
     this.state = {
       openClasses: [],
       hoveredFilter: null,
@@ -26,14 +25,7 @@ export default class CategoryList extends React.Component {
   }
 
   componentDidMount() {
-    const listWrapper = this.listWrapperRef.current;
-    if (listWrapper) {
-      this.highlight = document.createElement('div');
-      this.highlight.className = styles.highlight;
-      listWrapper.appendChild(this.highlight);
-      this._autoExpandForSelectedFilter();
-      this._updateHighlight();
-    }
+    this._autoExpandForSelectedFilter();
   }
 
   componentDidUpdate(prevProps) {
@@ -41,13 +33,6 @@ export default class CategoryList extends React.Component {
     // OR if categories changed (e.g., filters finished loading asynchronously)
     if (prevProps.params !== this.props.params || prevProps.categories !== this.props.categories) {
       this._autoExpandForSelectedFilter();
-    }
-    this._updateHighlight();
-  }
-
-  componentWillUnmount() {
-    if (this.highlight) {
-      this.highlight.parentNode.removeChild(this.highlight);
     }
   }
 
@@ -98,40 +83,6 @@ export default class CategoryList extends React.Component {
     }
   }
 
-  _updateHighlight() {
-    if (this.highlight) {
-      let height = 0;
-      for (let i = 0; i < this.props.categories.length; i++) {
-        const c = this.props.categories[i];
-        const id = c.id || c.name;
-        if (id === this.props.current) {
-          if (this.state.openClasses.includes(id)) {
-            const query = new URLSearchParams(this.props.params);
-            if (query.has('filters')) {
-              const queryFilter = query.get('filters');
-              const filterId = query.get('filterId');
-              const matchIndex = this._findMatchingFilterIndex(c.filters, queryFilter, filterId);
-              if (matchIndex !== -1) {
-                height += (matchIndex + 1) * 20;
-              }
-            }
-          }
-          this.highlight.style.display = 'block';
-          this.highlight.style.top = height + 'px';
-          return;
-        }
-        if (id === 'classSeparator') {
-          height += 13;
-        } else if (this.state.openClasses.includes(id)) {
-          height = height + 20 * (c.filters.length + 1);
-        } else {
-          height += 20;
-        }
-      }
-      this.highlight.style.display = 'none';
-    }
-  }
-
   toggleDropdown(e, id) {
     e.preventDefault();
     const openClasses = [...this.state.openClasses];
@@ -149,11 +100,14 @@ export default class CategoryList extends React.Component {
       return null;
     }
     return (
-      <div ref={this.listWrapperRef} className={styles.class_list}>
+      <div className={styles.class_list}>
         {this.props.categories.map(c => {
           const id = c.id || c.name;
           if (c.type === 'separator') {
             return <hr key={id} className={styles.separator} />;
+          }
+          if (c.type === 'sectionHeader') {
+            return <div key={id} className={styles.sectionHeader}>{c.name}</div>;
           }
           const count = c.count;
           let className = id === this.props.current ? styles.active : '';

--- a/src/components/CategoryList/CategoryList.scss
+++ b/src/components/CategoryList/CategoryList.scss
@@ -10,29 +10,32 @@
 .class_list {
   position: relative;
   margin-bottom: 5px;
-  border-left: 1px solid #3e87b2;
+  margin-left: 8px;
 
   a {
     display: block;
-    padding-left: 12px;
-    height: 20px;
-    line-height: 20px;
-    color: #8fb9cf;
-    font-size: 12px;
+    padding-left: 8px;
+    height: 24px;
+    line-height: 24px;
+    color: var(--color-text-on-dark-muted);
+    font-size: var(--text-sm);
+    border-radius: var(--radius-md);
+    transition: color var(--transition-fast);
 
     &.active {
-      color: white;
+      color: var(--color-text-on-dark);
+      font-weight: var(--font-weight-medium);
     }
 
-    &:hover{
-      color: white;
+    &:hover {
+      color: var(--color-text-on-dark);
     }
 
     span {
       display: block;
 
       &:first-of-type {
-        @include DosisFont;
+        @include UIFont;
         float: right;
         width: 50px;
         text-align: right;
@@ -47,17 +50,26 @@
   }
 }
 
-.highlight {
-  position: absolute;
-  width: 1px;
-  height: 20px;
-  background: white;
-  transition: top 0.2s cubic-bezier(1, 0, 0, 1);
+
+.sectionHeader {
+  @include UIFont;
+  font-size: 10px;
+  font-weight: var(--font-weight-medium);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--color-text-on-dark-muted);
+  padding: 12px 8px 4px;
+  line-height: 1;
+  opacity: 0.6;
+
+  &:first-child {
+    padding-top: 4px;
+  }
 }
 
 .separator {
   margin: 6px 0 6px 12px;
-  background-color: #3e87b2;
+  background-color: rgba(255, 255, 255, 0.1);
   border: 0;
   height: 1px;
 }
@@ -74,26 +86,40 @@
   margin-right: 20px;
   padding-left: 0px !important;
   &:after {
-    @include arrow('down', 10px, 7px, #8fb9cf);
+    @include arrow('down', 10px, 7px, var(--color-text-on-dark-muted));
     content: '';
     margin-left: 6px;
   }
 }
 .link {
   display: flex;
+  align-items: center;
+  border-radius: var(--radius-md);
+  transition: background var(--transition-fast);
+
+  &:has(a.active) {
+    background: rgba(255, 255, 255, 0.08);
+  }
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.04);
+  }
+
   a {
     &:first-of-type {
       flex-grow: 1
     }
   }
   .count {
-    @include DosisFont;
-    color: #8fb9cf;
-    font-size: 12px;
+    @include UIFont;
+    color: var(--color-text-on-dark-muted);
+    font-size: 11px;
     margin-left: auto;
     margin-right: 4px;
     min-width: 20px;
     text-align: right;
+    opacity: 0.6;
+    line-height: 24px;
   }
   .edit {
     display: flex;
@@ -101,11 +127,11 @@
     padding-top: 2px;
     cursor: pointer;
     svg {
-      fill: #8fb9cf;
+      fill: var(--color-text-on-dark-muted);
     }
     &:hover {
       svg {
-        fill: white;
+        fill: var(--color-text-on-dark);
       }
     }
   }
@@ -123,7 +149,7 @@
       text-align: left !important;
       margin-left: 14px;
       margin-right: 0px !important;
-      font-family: Dosis, "Helvetica Neue", Helvetica, Arial, sans-serif;
+      @include UIFont;
       flex-grow: 1;
     }
   }
@@ -133,11 +159,11 @@
     padding-top: 2px;
     cursor: pointer;
     svg {
-      fill: #8fb9cf;
+      fill: var(--color-text-on-dark-muted);
     }
     &:hover {
       svg {
-        fill: white;
+        fill: var(--color-text-on-dark);
       }
     }
   }

--- a/src/components/Chart/Chart.scss
+++ b/src/components/Chart/Chart.scss
@@ -9,7 +9,7 @@
 
 .chart {
   position: relative;
-  background: white;
+  background: var(--color-bg-primary);
   padding: 0 0 40px 40px;
 }
 
@@ -23,25 +23,25 @@
 
 .label {
   position: absolute;
-  right: 10px;
-  font-size: 10px;
+  right: var(--space-2);
+  font-size: var(--text-xs);
   margin-top: -6px;
+  color: var(--color-text-secondary);
 }
 
 .tick {
   @include transform(translateX(-50%));
   position: absolute;
   bottom: 14px;
-  font-size: 10px;
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
 }
 
 .grow {
   @include transform(scale(1));
-  transition: transform 0.2s ease-out;
-  -webkit-transition: -webkit-transform 0.2s ease-out;
+  transition: transform var(--transition-fast);
 
   transform-origin: 50% 50%;
-  -webkit-transform-origin: 50% 50%;
 
   &:hover {
     @include transform(scale(2));
@@ -55,10 +55,11 @@
 .popup {
   @include transform(translateY(-50%));
   position: absolute;
-  border-radius: 5px;
-  border: 1px solid $blue;
-  background: white;
-  padding: 8px 8px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-accent-blue);
+  background: var(--color-bg-elevated);
+  box-shadow: var(--shadow-md);
+  padding: var(--space-2);
   text-align: center;
   min-width: 140px;
 }
@@ -76,7 +77,7 @@
   }
 
   &:after {
-    @include arrow('right', 12px, 8px, white);
+    @include arrow('right', 12px, 8px, var(--color-bg-elevated));
     content: '';
     position: absolute;
     right: -7px;
@@ -98,7 +99,7 @@
   }
 
   &:after {
-    @include arrow('left', 12px, 8px, white);
+    @include arrow('left', 12px, 8px, var(--color-bg-elevated));
     content: '';
     position: absolute;
     left: -7px;
@@ -109,10 +110,13 @@
 
 .popupTime {
   white-space: nowrap;
-  font-size: 10px;
-  margin-bottom: 4px;
+  font-size: var(--text-xs);
+  margin-bottom: var(--space-1);
+  color: var(--color-text-secondary);
 }
 
 .popupValue {
-  font-size: 12px;
+  font-size: var(--text-xs);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-primary);
 }

--- a/src/components/Checkbox/Checkbox.react.js
+++ b/src/components/Checkbox/Checkbox.react.js
@@ -18,7 +18,7 @@ const Checkbox = ({ label, checked, indeterminate, onChange }) => {
   }
   let inner = null;
   if (checked) {
-    inner = <Icon width={12} height={12} name="check" fill="#169cee" />;
+    inner = <Icon width={12} height={12} name="check" fill="var(--color-accent-blue)" />;
   } else if (indeterminate) {
     inner = <span className={styles.minus} />;
   }

--- a/src/components/Checkbox/Checkbox.scss
+++ b/src/components/Checkbox/Checkbox.scss
@@ -15,14 +15,16 @@
 }
 
 .checkbox {
-  display: inline-block;
-  height: 20px;
-  width: 20px;
-  padding: 3px;
-  border-radius: 4px;
-  background: white;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 18px;
+  width: 18px;
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-primary);
   vertical-align: middle;
-  border: 1px solid $mainTextColor;
+  border: 1px solid var(--color-border-primary);
+  transition: border-color var(--transition-fast), background var(--transition-fast);
 
   svg {
     vertical-align: top;
@@ -31,27 +33,27 @@
 
 .minus {
   display: block;
-  width: 12px;
-  height: 4px;
-  background: $blue;
-  margin-top: 4px;
-  border-radius: 2px;
+  width: 10px;
+  height: 2px;
+  background: var(--color-bg-primary);
+  border-radius: 1px;
 }
 
 .label {
-  @include DosisFont;
-  color: $mainTextColor;
-  font-size: 14px;
+  @include UIFont;
+  color: var(--color-text-secondary);
+  font-size: var(--text-base);
   vertical-align: middle;
   margin-right: 6px;
 }
 
 .checked, .indeterminate {
   .checkbox {
-    border-color: $blue;
+    background: var(--color-accent-blue);
+    border-color: var(--color-accent-blue);
   }
 
   .label {
-    color: $blue;
+    color: var(--color-text-primary);
   }
 }

--- a/src/components/Chip/Chip.scss
+++ b/src/components/Chip/Chip.scss
@@ -9,22 +9,28 @@
 .chip {
   display: inline-flex;
   flex-direction: row;
-  background-color: #d5e5f2;
-  border: none;
+  background-color: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border-secondary);
   cursor: pointer;
-  height: 32px;
+  height: 28px;
   outline: none;
-  padding: 4px;
-  margin: 4px;
-  font-size: 14px;
-  color: #0e69a1;
-  font-family: "Open Sans", sans-serif;
+  padding: 2px;
+  margin: 3px;
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  font-family: var(--font-sans);
   white-space: nowrap;
   align-items: center;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   vertical-align: middle;
   text-decoration: none;
   justify-content: center;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+
+  &:hover {
+    background-color: var(--color-interactive-hover);
+    border-color: var(--color-border-primary);
+  }
 }
 
 .content {
@@ -39,20 +45,18 @@
 
 .chip {
   svg {
-    color: #999999;
+    color: var(--color-text-tertiary);
     cursor: pointer;
-    height: auto;
-    margin: 20px 6px 0 -8px;
+    margin: 0 4px 0 -4px;
     fill: currentColor;
-    width: 1em;
-    height: 1em;
+    width: 14px;
+    height: 14px;
     display: inline-block;
-    font-size: 16px;
-    transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+    transition: color var(--transition-fast);
     user-select: none;
     flex-shrink: 0;
   }
   svg:hover {
-    color: red;
+    color: var(--color-accent-red);
   }
 }

--- a/src/components/ChromeDatePicker/ChromeDatePicker.react.js
+++ b/src/components/ChromeDatePicker/ChromeDatePicker.react.js
@@ -74,7 +74,7 @@ export default class ChromeDatePicker extends React.Component {
             </div>
             <div className={styles.chrome} onClick={this.close.bind(this)}>
               <span>{`${monthDayStringUTC(this.props.value)}`}</span>
-              <Icon width={18} height={18} name="calendar-solid" fill="#169CEE" />
+              <Icon width={18} height={18} name="calendar-solid" fill="var(--color-accent-blue)" />
             </div>
           </div>
         </Popover>
@@ -83,7 +83,7 @@ export default class ChromeDatePicker extends React.Component {
       content = (
         <div className={styles.chrome}>
           <span>{`${monthDayStringUTC(this.props.value)}`}</span>
-          <Icon width={18} height={18} name="calendar-solid" fill="#169CEE" />
+          <Icon width={18} height={18} name="calendar-solid" fill="var(--color-accent-blue)" />
         </div>
       );
     }

--- a/src/components/ChromeDatePicker/ChromeDatePicker.scss
+++ b/src/components/ChromeDatePicker/ChromeDatePicker.scss
@@ -19,12 +19,13 @@ $pickerHeight: 30px;
   display: inline-block;
   white-space: nowrap;
   cursor: pointer;
-  font-size: 14px;
+  font-size: var(--text-base);
   height: $pickerHeight;
-  border: 1px solid $blue;
-  border-radius: 5px;
-  padding: 6px 12px;
-  color: $blue;
+  border: 1px solid var(--color-accent-blue);
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-3);
+  color: var(--color-accent-blue);
+  transition: background-color var(--transition-fast), color var(--transition-fast);
 
   span {
     display: inline-block;
@@ -33,28 +34,33 @@ $pickerHeight: 30px;
 
   svg {
     vertical-align: top;
-    margin-left: 10px;
+    margin-left: var(--space-2);
+  }
+
+  &:hover {
+    background: var(--color-accent-blue-light);
   }
 }
 
 .open .chrome {
   position: relative;
-  background: white;
+  background: var(--color-bg-elevated);
   border-top: none;
   padding-top: 7px;
-  border-radius: 0 0 5px 5px;
+  border-radius: 0 0 var(--radius-md) var(--radius-md);
 }
 
 .calendar {
   position: absolute;
-  background: white;
-  border: 1px solid $blue;
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-accent-blue);
+  box-shadow: var(--shadow-overlay);
   bottom: 29px;
   left: 0;
   width: 204px;
   height: 192px;
-  padding: 10px;
-  border-radius: 5px 5px 5px 0;
+  padding: var(--space-2);
+  border-radius: var(--radius-md) var(--radius-md) var(--radius-md) 0;
 }
 
 .right {
@@ -66,6 +72,6 @@ $pickerHeight: 30px;
   .calendar {
     left: auto;
     right: 0;
-    border-radius: 5px 5px 0 5px;
+    border-radius: var(--radius-md) var(--radius-md) 0 var(--radius-md);
   }
 }

--- a/src/components/ChromeDropdown/ChromeDropdown.scss
+++ b/src/components/ChromeDropdown/ChromeDropdown.scss
@@ -6,24 +6,33 @@
  * the root directory of this source tree.
  */
 @import 'stylesheets/globals.scss';
-       
+
 .dropdown {
   display: inline-block;
   vertical-align: top;
   height: 30px;
   text-align: left;
   white-space: nowrap;
-  font-size: 14px;
+  font-size: var(--text-base);
 }
 
 .current, .menu {
-  background: $purple;
-  border-radius: 5px;
-  color: white;
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border-secondary);
+  border-radius: var(--radius-md);
+  color: var(--color-text-primary);
   cursor: pointer;
+  transition: var(--transition-fast);
 
   &.blue {
-    background: $darkBlue;
+    background: var(--color-accent-blue);
+    border-color: var(--color-accent-blue);
+    color: var(--color-text-on-dark);
+
+    &:hover {
+      background: var(--color-accent-blue-hover);
+      border-color: var(--color-accent-blue-hover);
+    }
   }
 }
 
@@ -31,34 +40,43 @@
   position: relative;
   height: 30px;
   line-height: 30px;
-  padding: 0 30px 0 10px;
+  padding: 0 30px 0 var(--space-3);
 
   div {
     overflow-x: hidden;
     text-overflow: ellipsis;
   }
 
+  &:hover {
+    border-color: var(--color-border-focus);
+  }
+
   &:after {
-    @include arrow('down', 12px, 8px, rgba(255,255,255,0.3));
+    @include arrow('down', 12px, 8px, var(--color-text-tertiary));
     position: absolute;
     content: '';
     top: 12px;
-    right: 10px;
+    right: var(--space-3);
   }
 }
 
 .menu {
   max-height: 360px;
   overflow-y: auto;
-  font-size: 14px;
+  font-size: var(--text-base);
+  box-shadow: var(--shadow-md);
+  padding: var(--space-1) 0;
 
   div {
     height: 30px;
     line-height: 30px;
-    padding: 0 10px;
+    padding: 0 var(--space-3);
+    border-radius: var(--radius-sm);
+    margin: 0 var(--space-1);
+    transition: var(--transition-fast);
 
     &:hover {
-      background: rgba(255, 255, 255, 0.1);
+      background: var(--color-interactive-hover);
     }
   }
 }

--- a/src/components/CodeSnippet/CodeSnippet.css
+++ b/src/components/CodeSnippet/CodeSnippet.css
@@ -6,46 +6,29 @@
  * the root directory of this source tree.
  */
 /**
- * prism.js default theme for JavaScript, CSS and HTML
- * Based on dabblet (http://dabblet.com)
- * @author Lea Verou
+ * Code snippet theme — uses CSS custom properties for theme support
  */
 
 code[class*="language-"],
 pre[class*="language-"] {
-  color: #555572;
-  font-family: 'Source Code Pro', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
-  font-size: 13px;
+  color: var(--color-text-primary);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
   direction: ltr;
   text-align: left;
   white-space: pre;
   word-spacing: normal;
   word-break: normal;
   word-wrap: normal;
-  line-height: 22px;
-  -moz-tab-size: 4;
-  -o-tab-size: 4;
+  line-height: 1.6;
   tab-size: 4;
-  -webkit-hyphens: none;
-  -moz-hyphens: none;
-  -ms-hyphens: none;
   hyphens: none;
 }
 
-pre[class*="language-"]::-moz-selection,
-pre[class*="language-"]::-moz-selection,
-code[class*="language-"]::-moz-selection,
-code[class*="language-"]::-moz-selection {
-  text-shadow: none;
-  background: #b3d4fc;
-}
-
 pre[class*="language-"]::selection,
-pre[class*="language-"]::selection,
-code[class*="language-"]::selection,
 code[class*="language-"]::selection {
   text-shadow: none;
-  background: #b3d4fc;
+  background: var(--color-accent-blue-light);
 }
 
 @media print {
@@ -55,37 +38,34 @@ code[class*="language-"]::selection {
   }
 }
 
-
 /* Code blocks */
-
 pre[class*="language-"] {
-  padding: 1em;
-  margin: .5em 0;
+  padding: var(--space-4);
+  margin: 0;
   overflow: auto;
+  border-radius: var(--radius-md);
 }
 
 :not(pre) > code[class*="language-"],
 pre[class*="language-"] {
-  background: #FDFAFB;
+  background: var(--color-bg-secondary);
 }
 
-
 /* Inline code */
-
 :not(pre) > code[class*="language-"] {
-  padding: .1em;
-  border-radius: .3em;
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
 }
 
 .token.comment,
 .token.prolog,
 .token.doctype,
 .token.cdata {
-  color: #a3a3c2;
+  color: var(--color-text-tertiary);
 }
 
 .token.punctuation {
-  color: #555572;
+  color: var(--color-text-secondary);
 }
 
 .namespace {
@@ -99,7 +79,7 @@ pre[class*="language-"] {
 .token.constant,
 .token.symbol,
 .token.deleted {
-  color: #FF395E;
+  color: var(--color-accent-red);
 }
 
 .token.selector,
@@ -108,7 +88,7 @@ pre[class*="language-"] {
 .token.char,
 .token.builtin,
 .token.inserted {
-  color: #00D275;
+  color: var(--color-accent-green);
 }
 
 .token.operator,
@@ -116,28 +96,28 @@ pre[class*="language-"] {
 .token.url,
 .language-css .token.string,
 .style .token.string {
-  color: #555572;
+  color: var(--color-text-secondary);
 }
 
 .token.atrule,
 .token.attr-value,
 .token.keyword {
-  color: #169CEE;
+  color: var(--color-accent-blue);
 }
 
 .token.function {
-  color: #FF395E;
+  color: var(--color-accent-red);
 }
 
 .token.regex,
 .token.important,
 .token.variable {
-  color: #F45530;
+  color: var(--color-accent-orange);
 }
 
 .token.important,
 .token.bold {
-  font-weight: bold;
+  font-weight: var(--font-weight-semibold);
 }
 
 .token.italic {
@@ -153,13 +133,13 @@ pre.line-numbers {
   padding-left: 3.5em;
   counter-reset: linenumber;
   padding-top: 0px;
-  padding-bottom: 20px;
+  padding-bottom: var(--space-5);
 }
 
 pre.line-numbers:before {
   display: block;
   content: '';
-  background: #66637A;
+  background: var(--color-bg-tertiary);
   height: 100%;
   width: 33px;
   position: absolute;
@@ -178,12 +158,8 @@ pre.line-numbers > code {
   font-size: 100%;
   left: -3.8em;
   width: 3em;
-  /* works for line-numbers below 1000 lines */
   padding-top: 10px;
   margin-bottom: 100px;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
 }
 
@@ -195,10 +171,10 @@ pre.line-numbers > code {
 
 .line-numbers-rows > span:before {
   content: counter(linenumber);
-  color: #343445;
+  color: var(--color-text-tertiary);
   display: block;
-  font-size: 10px;
-  font-family: 'Dosis';
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
   padding-right: 0;
   text-align: center;
 }

--- a/src/components/ColumnsConfiguration/ColumnConfigurationItem.react.js
+++ b/src/components/ColumnsConfiguration/ColumnConfigurationItem.react.js
@@ -29,7 +29,7 @@ export default ({ name, handleColumnDragDrop, index, onChangeVisible, visible })
         style={{
           opacity: isDragging ? 0.5 : 1,
           cursor: isDragging ? 'grabbing' : null,
-          backgroundColor: isOver && canDrop ? '#208aec' : null,
+          backgroundColor: isOver && canDrop ? 'var(--color-accent-blue-light)' : null,
         }}
         onClick={() => onChangeVisible(!visible)}
       >
@@ -38,14 +38,14 @@ export default ({ name, handleColumnDragDrop, index, onChangeVisible, visible })
             name={visible ? 'visibility' : 'visibility_off'}
             width={18}
             height={18}
-            fill={visible ? 'white' : 'rgba(0,0,0,0.4)'}
+            fill={visible ? 'var(--color-accent-blue)' : 'var(--color-text-tertiary)'}
           />
         </div>
         <div className={styles.columnConfigItemName} title={name}>
           {name}
         </div>
         <div className={[styles.icon, styles.columnIcon].join(' ')}>
-          <Icon name="drag-indicator" width={14} height={14} fill="white" />
+          <Icon name="drag-indicator" width={14} height={14} fill="var(--color-text-tertiary)" />
         </div>
       </section>
     )

--- a/src/components/ColumnsConfiguration/ColumnConfigurationItem.scss
+++ b/src/components/ColumnsConfiguration/ColumnConfigurationItem.scss
@@ -1,8 +1,26 @@
+/*
+ * Copyright (c) 2016-present, Parse, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+@import 'stylesheets/globals.scss';
+
 .columnConfigItem {
-  padding: 8px 10px;
+  padding: var(--space-2) var(--space-2);
   display: flex;
-  border-radius: 5px;
+  border-radius: var(--radius-md);
   cursor: grab;
+  transition: background-color var(--transition-fast);
+
+  &:hover {
+    background-color: var(--color-interactive-hover);
+  }
+
+  &:active {
+    cursor: grabbing;
+  }
 }
 
 .icon {
@@ -14,12 +32,18 @@
 .visibilityIcon {
   cursor: pointer;
   width: 30px;
+  transition: opacity var(--transition-fast);
+
+  &:hover {
+    opacity: 0.7;
+  }
 }
 
 .columnConfigItemName {
   text-overflow: ellipsis;
   overflow: hidden;
   line-height: 24px;
+  color: var(--color-text-primary);
 }
 
 .columnIcon {

--- a/src/components/ColumnsConfiguration/ColumnsConfiguration.react.js
+++ b/src/components/ColumnsConfiguration/ColumnsConfiguration.react.js
@@ -150,9 +150,9 @@ export default class ColumnsConfiguration extends React.Component {
                 </DndProvider>
               </div>
               <div className={styles.footer}>
-                <Button color="white" value="Hide all" onClick={this.hideAll.bind(this)} />
-                <Button color="white" value="Show all" onClick={this.showAll.bind(this)} />
-                <Button color="white" value="Auto-sort" onClick={this.autoSort.bind(this)} />
+                <Button value="Hide all" onClick={this.hideAll.bind(this)} />
+                <Button value="Show all" onClick={this.showAll.bind(this)} />
+                <Button value="Auto-sort" onClick={this.autoSort.bind(this)} />
               </div>
             </div>
           </div>

--- a/src/components/ColumnsConfiguration/ColumnsConfiguration.scss
+++ b/src/components/ColumnsConfiguration/ColumnsConfiguration.scss
@@ -1,44 +1,65 @@
 @import 'stylesheets/globals.scss';
 
 .entry {
-  display: inline-block;
-  height: 14px;
-  padding: 0 8px;
+  display: inline-flex;
+  align-items: center;
+  padding: var(--space-1) var(--space-2);
 
   svg {
-    fill: #66637A;
+    fill: var(--color-text-on-dark-muted);
   }
 
   &:hover svg {
-    fill: white;
+    fill: var(--color-text-on-dark);
   }
 
   &.disabled {
     cursor: not-allowed;
-    color: #66637A;
+    color: rgba(255, 255, 255, 0.3);
+    opacity: 0.5;
 
     &:hover svg {
-      fill: #66637A;
+      fill: rgba(255, 255, 255, 0.3);
     }
   }
 }
 
 .title {
-  margin-top: -4px;
-  background: #797691;
+  background: rgba(255, 255, 255, 0.1);
   padding: 4px 8px;
-  border-radius: 5px 5px 0 0;
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
 
   svg {
-    fill: white;
+    fill: var(--color-text-on-dark);
+  }
+}
+
+// When title is inside the popover dropdown, use light-bg styling
+.popover {
+  .title {
+    background: var(--color-bg-tertiary);
+    color: var(--color-text-primary);
+    padding: var(--space-2) var(--space-3);
+    border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+    font-weight: var(--font-weight-semibold);
+
+    svg {
+      fill: var(--color-text-secondary);
+    }
+
+    &:hover {
+      color: var(--color-text-primary);
+      background: var(--color-bg-tertiary);
+    }
   }
 }
 
 .entry, .title {
-  @include NotoSansFont;
-  font-size: 14px;
-  color: #ffffff;
+  @include UIFont;
+  font-size: var(--text-sm);
+  color: var(--color-text-on-dark-muted);
   cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
 
   svg {
     vertical-align: middle;
@@ -49,23 +70,29 @@
     vertical-align: middle;
     line-height: 14px;
   }
+
+  &:hover {
+    color: var(--color-text-on-dark);
+  }
 }
 
 .objectPickerContent {
   .entry svg {
-    fill: rgba(0, 0, 0, 0.3);
+    fill: var(--color-text-tertiary);
   }
 }
 
 .body {
-  color: white;
+  color: var(--color-text-primary);
   position: absolute;
   top: 22px;
   right: 0;
-  border-radius: 5px 0 5px 5px;
-  background: #797691;
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border-secondary);
+  box-shadow: var(--shadow-overlay);
   width: 320px;
-  font-size: 14px;
+  font-size: var(--text-sm);
 
   .columnConfigContainer {
     max-height: calc(100vh - 180px);
@@ -75,10 +102,12 @@
 }
 
 .footer {
-  background: rgba(0,0,0,0.2);
-  padding: 15px 20px;
+  background: var(--color-bg-tertiary);
+  padding: var(--space-3) var(--space-4);
   display: flex;
   justify-content: space-between;
+  border-top: 1px solid var(--color-border-secondary);
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
 
   > a {
     margin-right: 10px;

--- a/src/components/ContextMenu/ContextMenu.scss
+++ b/src/components/ContextMenu/ContextMenu.scss
@@ -1,43 +1,57 @@
+/*
+ * Copyright (c) 2016-present, Parse, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
 @import 'stylesheets/globals.scss';
 
 .menu {
 	position: absolute;
-	font-size: 14px;
+	font-size: var(--text-sm);
 
 	ul {
-		background: $purple;
-		@include animation('fade-in .2s linear');
+		background: var(--color-bg-elevated);
+		@include animation('fade-in .15s ease-out');
 		opacity: 0;
-		border: 1px solid rgba(255, 255, 255, 0.15);
-		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+		border: 1px solid var(--color-border-secondary);
+		border-radius: var(--radius-lg);
+		box-shadow: var(--shadow-overlay);
+		padding: var(--space-1) 0;
+		min-width: 180px;
 	}
 
 	li {
-		height: 30px;
-    line-height: 30px;
-		color: $white;
+		height: 32px;
+		line-height: 32px;
+		color: var(--color-text-primary);
 		cursor: pointer;
 		white-space: nowrap;
-		padding: 0 30px 0 10px;
+		padding: 0 var(--space-6) 0 var(--space-3);
+		transition: background var(--transition-fast), color var(--transition-fast);
+		border-radius: 0;
+
 		span {
-			color: #A2A6B1
+			color: var(--color-text-tertiary);
+			font-size: var(--text-xs);
 		}
 	}
 
 	li:hover {
-		background: rgba(255, 255, 255, 0.1);
+		background: var(--color-interactive-hover);
 	}
 
 	.separator {
 		height: 1px;
 		padding: 0;
-		margin: 5px 10px;
-		background: rgba(255, 255, 255, 0.2);
+		margin: var(--space-1) var(--space-2);
+		background: var(--color-border-secondary);
 		cursor: default;
 		pointer-events: none;
 
 		&:hover {
-			background: rgba(255, 255, 255, 0.2);
+			background: var(--color-border-secondary);
 		}
 	}
 
@@ -48,12 +62,15 @@
 
 		.item {
 			width: 100%;
+			position: relative;
+
 			&:after {
-				@include arrow('right', 12px, 8px, rgba(255,255,255,0.3));
+				content: '\203A';
 				position: absolute;
-				content: '';
-				margin-top: 10px;
-				right: 10px;
+				right: var(--space-3);
+				top: 0;
+				color: var(--color-text-tertiary);
+				font-size: var(--text-lg);
 			}
 		}
 
@@ -61,17 +78,14 @@
 			left: 100%;
 			position: absolute;
 		}
-
 	}
 }
 
 @include keyframes(fade-in) {
   0% {
-    // @include transform(scale(0.9));
     opacity: 0;
   }
   100% {
-    // @include transform(scale(1));
     opacity: 1;
   }
 }

--- a/src/components/CreditCardInput/CreditCardInput.scss
+++ b/src/components/CreditCardInput/CreditCardInput.scss
@@ -8,19 +8,22 @@
 @import 'stylesheets/globals.scss';
 
 .input {
-  @include NotoSansFont;
+  @include UIFont;
   border: 0;
   outline: 0;
-  background: $inputBackgroundColor;
-  font-size: 16px;
+  background: var(--color-bg-secondary);
+  font-size: var(--text-lg);
   width: 100%;
   height: 80px;
-  padding: 6px;
+  padding: var(--space-2);
   text-align: center;
   vertical-align: top;
   resize: none;
+  transition: background var(--transition-fast);
 
   &:focus {
+    background: var(--color-bg-tertiary);
+
     @include placeholder {
       opacity: 0;
     }

--- a/src/components/DataBrowserHeader/DataBrowserHeader.scss
+++ b/src/components/DataBrowserHeader/DataBrowserHeader.scss
@@ -8,22 +8,31 @@
 @import 'stylesheets/globals.scss';
 
 .header {
-  @include MonospaceFont;
+  @include UIFont;
   position: relative;
   display: block;
   white-space: nowrap;
   overflow: hidden;
   height: 30px;
-  padding: 4px 6px 4px 2px;
-  border-left: 4px solid transparent;
+  padding: 4px 6px 4px 6px;
+  border-right: 1px solid var(--data-header-border-color);
+  background: var(--data-header-bg);
+  transition: background var(--transition-fast);
+
+  &:hover {
+    background: var(--data-header-hover-bg);
+  }
 }
 
 .name {
-  color: white;
-  font-size: 12px;
+  color: var(--data-header-color);
+  font-size: var(--data-header-size);
+  font-weight: var(--font-weight-semibold);
+  text-transform: var(--data-header-transform);
+  letter-spacing: var(--data-header-tracking);
   height: 22px;
   line-height: 22px;
-  margin-right: 8px;
+  margin-right: 6px;
   float: left;
   max-width: 100%;
   overflow: hidden;
@@ -31,8 +40,9 @@
 }
 
 .type {
-  color: #A2A6B1;
+  color: var(--data-header-type-color);
   font-size: 10px;
+  font-weight: var(--font-weight-normal);
   height: 22px;
   line-height: 22px;
   overflow: hidden;
@@ -43,7 +53,7 @@
   padding-right: 20px;
 
   &:after {
-    @include arrow('up', 12px, 8px, #A2A6B1);
+    @include arrow('up', 12px, 8px, var(--color-accent-blue));
     content: '';
     position: absolute;
     top: 11px;
@@ -55,7 +65,7 @@
   padding-right: 20px;
 
   &:after {
-    @include arrow('down', 12px, 8px, #A2A6B1);
+    @include arrow('down', 12px, 8px, var(--color-accent-blue));
     content: '';
     position: absolute;
     top: 11px;
@@ -64,9 +74,9 @@
 }
 
 .over {
-  border-left-color: $white;
+  border-left-color: var(--color-accent-blue);
 }
 
 .dragging {
-  background: $blue;
+  background: var(--color-accent-blue-light);
 }

--- a/src/components/DataBrowserHeaderBar/DataBrowserHeaderBar.react.js
+++ b/src/components/DataBrowserHeaderBar/DataBrowserHeaderBar.react.js
@@ -97,11 +97,7 @@ export default class DataBrowserHeaderBar extends React.Component {
         wrapStyle.left = stickyLefts[i];
         wrapStyle.zIndex = 11;
       }
-      if (i % 2) {
-        wrapStyle.background = '#726F85';
-      } else {
-        wrapStyle.background = '#66637A';
-      }
+      wrapStyle.background = 'var(--color-bg-tertiary)';
       let onClick = null;
       if (
         !preventSort &&
@@ -151,16 +147,9 @@ export default class DataBrowserHeaderBar extends React.Component {
     });
 
     if (onAddColumn) {
-      const finalStyle = {};
-      if (headers.length % 2) {
-        finalStyle.background = '#726F85';
-      } else {
-        finalStyle.background = '#66637A';
-      }
-
       elements.push(
         readonly || preventSchemaEdits ? null : (
-          <div key="add" className={styles.addColumn} style={finalStyle}>
+          <div key="add" className={styles.addColumn}>
             <button type="button" className={styles.addColumnButton} onClick={onAddColumn}>
               Add a new column
             </button>

--- a/src/components/DataBrowserHeaderBar/DataBrowserHeaderBar.scss
+++ b/src/components/DataBrowserHeaderBar/DataBrowserHeaderBar.scss
@@ -12,10 +12,9 @@
   z-index: 10;
   top: 0;
   left: 0;
-  height: 0;
-  background: #66637a;
+  height: 30px;
+  background: var(--data-header-bg);
   white-space: nowrap;
-  display: block;
   min-width: 100%;
   width: max-content;
 }
@@ -31,21 +30,30 @@
   display: inline-block;
   height: 30px;
   vertical-align: top;
-  padding: 0 25px;
+  padding: 0 16px;
+  background: var(--data-header-bg);
 }
 
 .addColumnButton {
-  @include buttonReset($bg: #343445);
+  @include buttonReset($bg: var(--data-add-col-bg));
+  @include UIFont;
   display: inline-block;
   height: 20px;
-  width: 130px;
-  text-align: center;
+  padding: 0 12px;
   line-height: 20px;
   margin-top: 5px;
-  color: white;
-  border-radius: 5px;
-  vertical-align: top;
+  color: var(--data-add-col-color);
+  border: var(--data-add-col-border);
+  border-radius: var(--radius-md);
   font-size: 12px;
+  font-weight: var(--font-weight-medium);
+  vertical-align: top;
+  white-space: nowrap;
+  transition: opacity var(--transition-fast);
+
+  &:hover {
+    opacity: 0.85;
+  }
 }
 
 .check {
@@ -54,7 +62,8 @@
   vertical-align: top;
   text-align: center;
   width: 30px;
-  background: rgb(114, 111, 133);
+  background: var(--data-check-bg);
+  border-right: 1px solid var(--data-header-border-color);
 }
 
 .rowNumber {
@@ -62,11 +71,12 @@
   height: 30px;
   vertical-align: top;
   text-align: center;
-  background: rgb(114, 111, 133);
-  color: #A2A6B1;
+  background: var(--data-header-bg);
+  color: var(--data-header-type-color);
   font-size: 12px;
   padding: 0 4px;
   box-sizing: border-box;
+  border-right: 1px solid var(--data-header-border-color);
 }
 
 .handle {
@@ -77,11 +87,11 @@
   height: 30px;
   z-index: 2;
   cursor: col-resize;
-  background: rgba(255, 255, 255, 0);
+  background: rgba(0, 0, 0, 0);
   transition: background 0.15s ease;
 
   &:hover {
-    background: rgba(255, 255, 255, 0.15);
+    background: var(--color-accent-blue-light);
   }
 }
 
@@ -112,8 +122,8 @@
 }
 
 .skeletonRow {
-  border-top: 1px solid #e3e3ea;
-  border-bottom: 1px solid #e3e3ea;
+  border-top: 1px solid var(--color-border-primary);
+  border-bottom: 1px solid var(--color-border-primary);
   height: 30px;
   width: 100%;
   vertical-align: middle;
@@ -125,9 +135,9 @@
 
 @keyframes skeleton-loading {
   0% {
-    background-color: #ffffff;
+    background-color: var(--color-bg-primary);
   }
   100% {
-    background-color: #e3e3ea;
+    background-color: var(--color-border-primary);
   }
 }

--- a/src/components/DatePicker/DatePicker.scss
+++ b/src/components/DatePicker/DatePicker.scss
@@ -12,16 +12,18 @@
   height: 80px;
   line-height: 80px;
   text-align: center;
-  background: $inputBackgroundColor;
+  background: var(--color-bg-secondary);
 }
 
 .placeholder {
-  color: $secondaryTextColor;
+  color: var(--color-text-secondary);
 }
 
 .picker {
-  border: 1px solid $blue;
-  background: white;
+  border: 1px solid var(--color-accent-blue);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-elevated);
+  box-shadow: var(--shadow-sm);
 
   > * {
     margin: 10% auto 4% auto;
@@ -29,5 +31,5 @@
 }
 
 .value {
-  color: $blue;
+  color: var(--color-accent-blue);
 }

--- a/src/components/DateRange/DateRange.react.js
+++ b/src/components/DateRange/DateRange.react.js
@@ -106,7 +106,7 @@ export default class DateRange extends React.Component {
             </div>
             <div className={styles.range} onClick={this.close.bind(this)}>
               <span>{this.rangeString()}</span>
-              <Icon width={18} height={18} name="calendar-solid" fill="#169CEE" />
+              <Icon width={18} height={18} name="calendar-solid" fill="var(--color-accent-blue)" />
             </div>
           </div>
         </Popover>
@@ -115,7 +115,7 @@ export default class DateRange extends React.Component {
       content = (
         <div className={styles.range}>
           <span>{this.rangeString()}</span>
-          <Icon width={18} height={18} name="calendar-solid" fill="#169CEE" />
+          <Icon width={18} height={18} name="calendar-solid" fill="var(--color-accent-blue)" />
         </div>
       );
     }

--- a/src/components/DateRange/DateRange.scss
+++ b/src/components/DateRange/DateRange.scss
@@ -19,12 +19,18 @@ $dateRangeHeight: 30px;
   display: inline-block;
   white-space: nowrap;
   cursor: pointer;
-  font-size: 14px;
+  font-size: var(--text-base);
   height: $dateRangeHeight;
-  border: 1px solid $blue;
-  border-radius: 5px;
-  padding: 6px 12px;
-  color: $blue;
+  border: 1px solid var(--color-border-primary);
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-3);
+  color: var(--color-accent-blue);
+  background: var(--color-bg-primary);
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+
+  &:hover {
+    border-color: var(--color-border-focus);
+  }
 
   span {
     display: inline-block;
@@ -33,35 +39,36 @@ $dateRangeHeight: 30px;
 
   svg {
     vertical-align: top;
-    margin-left: 10px;
+    margin-left: var(--space-3);
   }
 }
 
 .open .range {
   position: relative;
-  background: white;
+  background: var(--color-bg-elevated);
   border-top: none;
   padding-top: 7px;
-  border-radius: 0 0 5px 5px;
+  border-radius: 0 0 var(--radius-md) var(--radius-md);
 }
 
 .calendars {
   position: absolute;
-  background: white;
-  border: 1px solid $blue;
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border-primary);
   bottom: 29px;
   left: 0;
   width: 406px;
   height: 192px;
-  padding: 10px;
-  border-radius: 5px 5px 5px 0;
+  padding: var(--space-3);
+  border-radius: var(--radius-md) var(--radius-md) var(--radius-md) 0;
+  box-shadow: var(--shadow-lg);
 
   > * {
     display: inline-block;
     vertical-align: top;
 
     &:first-child {
-      margin-right: 20px;
+      margin-right: var(--space-5);
     }
   }
 }
@@ -75,6 +82,6 @@ $dateRangeHeight: 30px;
   .calendars {
     left: auto;
     right: 0;
-    border-radius: 5px 5px 0 5px;
+    border-radius: var(--radius-md) var(--radius-md) 0 var(--radius-md);
   }
 }

--- a/src/components/DateTimeEditor/DateTimeEditor.scss
+++ b/src/components/DateTimeEditor/DateTimeEditor.scss
@@ -8,7 +8,7 @@
 @import 'stylesheets/globals.scss';
 
 .editor {
-  box-shadow: 0 1px 4px rgba(0,0,0,0.4);
+  box-shadow: var(--shadow-md);
 
   > input {
     @include MonospaceFont;
@@ -16,7 +16,14 @@
     height: 30px;
     border: none;
     outline: none;
-    padding: 0 4px;
-    font-size: 12px;
+    padding: 0 var(--space-1);
+    font-size: var(--text-xs);
+    background: var(--color-bg-elevated);
+    color: var(--color-text-primary);
+    transition: background var(--transition-fast);
+
+    &:focus {
+      background: var(--color-bg-primary);
+    }
   }
 }

--- a/src/components/DateTimeInput/DateTimeInput.scss
+++ b/src/components/DateTimeInput/DateTimeInput.scss
@@ -7,14 +7,29 @@
  */
 @import 'stylesheets/globals.scss';
 
+// Modern: compact, left-aligned
 .input {
   width: 100%;
-  height: 80px;
-  line-height: 80px;
-  text-align: center;
-  background: $inputBackgroundColor;
+  min-height: 36px;
+  line-height: 36px;
+  text-align: left;
+  background: transparent;
 }
 
 .placeholder {
-  color: $secondaryTextColor;
+  color: var(--color-text-tertiary);
+}
+
+// Classic: tall, centered, gray bg
+:global([data-theme="classic"]) {
+  .input {
+    height: 80px;
+    line-height: 80px;
+    text-align: center;
+    background: var(--color-bg-secondary);
+  }
+
+  .placeholder {
+    color: var(--color-text-secondary);
+  }
 }

--- a/src/components/DateTimePicker/DateTimePicker.scss
+++ b/src/components/DateTimePicker/DateTimePicker.scss
@@ -8,8 +8,10 @@
 @import 'stylesheets/globals.scss';
 
 .picker {
-  border: 1px solid $blue;
-  background: white;
+  border: 1px solid var(--color-border-primary);
+  background: var(--color-bg-elevated);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
 
   > *:first-child {
     margin: 10% auto 4% auto;
@@ -17,30 +19,37 @@
 }
 
 .value {
-  color: $lightBlue;
+  color: var(--color-text-secondary);
 
   strong {
-    color: $blue;
+    color: var(--color-accent-blue);
   }
 }
 
 .time {
   margin: 0;
-  padding: 12px;
-  color: $blue;
-  border-top: 1px solid $borderGrey;
+  padding: var(--space-3);
+  color: var(--color-accent-blue);
+  border-top: 1px solid var(--color-border-secondary);
   text-align: right;
 
   input {
     display: inline-block;
     width: 40px;
     height: 30px;
-    border: 1px solid $blue;
-    color: $blue;
-    border-radius: 5px;
+    border: 1px solid var(--color-border-primary);
+    color: var(--color-text-primary);
+    border-radius: var(--radius-md);
     outline: none;
     text-align: center;
-    font-size: 12px;
+    font-size: var(--text-xs);
     padding: 0;
+    background: var(--color-bg-primary);
+    transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+
+    &:focus {
+      border-color: var(--color-border-focus);
+      box-shadow: 0 0 0 2px var(--color-accent-blue-light);
+    }
   }
 }

--- a/src/components/DonutChart/DonutChart.scss
+++ b/src/components/DonutChart/DonutChart.scss
@@ -8,18 +8,16 @@
 @import 'stylesheets/globals.scss';
 
 .donutCenter {
-  fill: $pushDetailsHeaderBackground;
+  fill: var(--color-bg-secondary);
 }
 
 .path {
-  -webkit-transform: scale(1.0);
   transform: scale(1.0);
-  transition: all 0.3s;
+  transition: transform var(--transition-fast);
 
   &:hover {
-    -webkit-transform: scale(1.1);
     transform: scale(1.1);
-    transition: all 0.3s;
+    transition: transform var(--transition-fast);
   }
 
   &:first-of-type {
@@ -61,16 +59,16 @@
 
 .donutValue {
   opacity: 0;
-  transition: opacity 0.2s ease;
-  @include DosisFont;
+  transition: opacity var(--transition-fast);
+  @include HeadingFont;
   font-size: 22px;
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
   &:first-of-type {
     opacity: 1;
   }
 }
 
-.donutLabel{
+.donutLabel {
   opacity: 0.5;
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
 }

--- a/src/components/Dropdown/Dropdown.scss
+++ b/src/components/Dropdown/Dropdown.scss
@@ -7,13 +7,15 @@
  */
 @import 'stylesheets/globals.scss';
 
+// Modern: compact select trigger, no outer chrome
 .dropdown {
   position: relative;
-  background: $inputBackgroundColor;
-  font-size: 16px;
-  height: 80px;
+  background: transparent;
+  font-size: var(--text-base);
   width: 100%;
-  overflow: hidden;
+  overflow: visible;
+  display: flex;
+  align-items: center;
 }
 
 .dropdown, .menu {
@@ -24,10 +26,13 @@
 
 .menu {
   max-height: 215px;
-  border: 1px solid $blue;
-  background: white;
+  border: 1px solid var(--color-border-primary);
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-elevated);
+  box-shadow: var(--shadow-lg);
   overflow: auto;
   overscroll-behavior: none;
+  padding: var(--space-1) 0;
 
   button {
     @include buttonReset;
@@ -36,11 +41,14 @@
   }
 
   .option {
-    color: $blue;
-    border-bottom: 1px solid $borderGrey;
+    color: var(--color-text-primary);
+    border-bottom: none;
+    transition: background var(--transition-fast);
+    line-height: 36px;
+    padding: 0 var(--space-3);
 
     &:hover {
-      background: rgba(0,0,0,0.1);
+      background: var(--color-interactive-hover);
     }
   }
 
@@ -50,44 +58,86 @@
 }
 
 .current {
-  text-align: center;
-  height: 80px;
+  text-align: left;
+  height: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border-primary);
+  border-radius: var(--radius-md);
+  padding: 0 var(--space-3);
+  min-height: 36px;
+  width: 100%;
+  transition: border-color var(--transition-fast);
+
+  &:hover {
+    border-color: var(--color-border-focus);
+  }
 
   &:not(.hideArrow){
+    padding-right: 32px;
+
     &:after {
-      @include arrow('down', 12px, 8px, rgba(0,0,0,0.3));
+      @include arrow('down', 10px, 6px, $grey);
       position: absolute;
       content: '';
-      top: 36px;
-      right: 20px;
+      right: 12px;
+      top: 50%;
+      margin-top: -3px;
     }
   }
 
   .option, .placeHolder {
-    height: 80px;
-    line-height: 80px;
+    height: 36px;
+    line-height: 36px;
+    color: var(--color-text-primary);
+    font-weight: var(--font-weight-medium);
+    font-size: var(--text-sm);
   }
 
   .placeHolder {
-    color: $secondaryTextColor
+    color: var(--color-text-tertiary);
+    font-weight: normal;
   }
 }
 
 .option {
-  line-height: 50px;
-  padding: 0 14px 0 14px;
+  line-height: 40px;
+  padding: 0 var(--space-4);
   overflow: hidden;
   text-overflow: ellipsis;
+  font-size: var(--text-sm);
 }
 
 .disabled {
   cursor: default;
 
-  .current:after {
-    display: none;
+  .current {
+    background: var(--color-bg-secondary);
+    border-color: var(--color-border-secondary);
+
+    &:after {
+      display: none;
+    }
   }
 
   .option {
-    padding: 0 14px;
+    padding: 0 var(--space-4);
+    color: var(--color-text-tertiary);
+  }
+}
+
+// Classic: centered dropdown in 80px row
+:global([data-theme="classic"]) {
+  .dropdown {
+    height: 80px;
+    justify-content: center;
+    overflow: hidden;
+  }
+
+  .current {
+    text-align: center;
+    width: auto;
   }
 }

--- a/src/components/EmptyState/EmptyState.react.js
+++ b/src/components/EmptyState/EmptyState.react.js
@@ -49,14 +49,17 @@ const EmptyState = ({
   return (
     <div className={containerClass}>
       <div className={styles.content}>
-        <div className={styles.icon}>
-          <Icon width={80} height={80} fill="#343445" name={icon} />
-        </div>
+        {icon && (
+          <div className={styles.icon}>
+            <Icon width={24} height={24} fill="currentColor" name={icon} />
+          </div>
+        )}
         <div className={styles.title}>{title}</div>
-        <div className={styles.description}>{description}</div>
-        {ctaButton(cta, action)}
-        {secondaryCta && ' '}
-        {ctaButton(secondaryCta, secondaryAction)}
+        {description && <div className={styles.description}>{description}</div>}
+        <div className={styles.actions}>
+          {ctaButton(cta, action)}
+          {ctaButton(secondaryCta, secondaryAction)}
+        </div>
       </div>
       {customContent && <div className={styles.customContent}>{customContent}</div>}
     </div>

--- a/src/components/EmptyState/EmptyState.scss
+++ b/src/components/EmptyState/EmptyState.scss
@@ -12,7 +12,7 @@
   flex-direction: column;
   align-items: center;
   text-align: center;
-  gap: 32px;
+  gap: var(--space-6);
 }
 
 .content {
@@ -20,7 +20,8 @@
   flex-direction: column;
   align-items: center;
   text-align: center;
-  max-width: 600px;
+  max-width: 360px;
+  padding: var(--space-10) var(--space-6);
 }
 
 .customContent {
@@ -29,27 +30,37 @@
 }
 
 .title {
-  font-size: 46px;
-  font-weight: 100;
-  line-height: 55px;
-  white-space: nowrap;
-  margin-bottom: 45px;
+  @include UIFont;
+  font-size: var(--text-base);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-primary);
+  line-height: 1.4;
+  margin-bottom: var(--space-1);
 }
 
 .description {
-  @include DosisFont;
-  font-size: 16px;
-  letter-spacing: 0.72px;
-  line-height: 17px;
-  margin-bottom: 12px;
+  @include UIFont;
+  font-size: var(--text-sm);
+  color: var(--color-text-tertiary);
+  line-height: 1.5;
+  margin-bottom: var(--space-4);
 }
 
 .icon {
-  width: 170px;
-  height: 170px;
-  margin: 0 auto 24px auto;
-  border-radius: 100%;
-  background: #f3f0f2;
-  text-align: center;
-  padding-top: 45px;
+  width: 48px;
+  height: 48px;
+  margin: 0 auto var(--space-4) auto;
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-secondary);
+  color: var(--color-text-tertiary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.actions {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  justify-content: center;
 }

--- a/src/components/ExplorerActiveChartButton/ExplorerActiveChartButton.scss
+++ b/src/components/ExplorerActiveChartButton/ExplorerActiveChartButton.scss
@@ -23,20 +23,25 @@
   display: inline-block;
   height: 20px;
   width: 20px;
-  padding: 3px;
-  border-radius: 4px;
+  padding: var(--space-1);
+  border-radius: var(--radius-md);
   vertical-align: middle;
   cursor: pointer;
+  transition: background var(--transition-fast);
 
   svg {
     vertical-align: top;
   }
+
+  &:hover {
+    background: var(--color-interactive-hover);
+  }
 }
 
 .rightArrow {
-  @include arrow('down', 12px, 8px, $greyArrowColor);
+  @include arrow('down', 12px, 8px, var(--color-text-secondary));
   position: absolute;
-  right: 0px;
+  right: 0;
   cursor: pointer;
 }
 
@@ -46,6 +51,8 @@
   max-width: 200px;
   left: 30px;
   top: 8px;
+  color: var(--color-text-primary);
+  font-size: var(--text-sm);
 }
 
 .composerContainer {
@@ -54,7 +61,7 @@
 }
 
 .callout {
-  @include arrow('up', 20px, 10px, $explorerQueryBackgroundColor);
+  @include arrow('up', 20px, 10px, var(--color-accent-blue));
   width: 20px;
   height: 10px;
 }
@@ -65,11 +72,10 @@
 
   .button {
     margin-left: auto;
-    margin-right: 0px;
+    margin-right: 0;
   }
 
   .callout {
     margin-left: auto;
   }
 }
-

--- a/src/components/ExplorerMenuButton/ExplorerMenuButton.scss
+++ b/src/components/ExplorerMenuButton/ExplorerMenuButton.scss
@@ -22,16 +22,25 @@
   display: inline-block;
   height: 30px;
   width: 111px;
-  border: 1px solid $mainTextColor;
-  border-radius: 5px;
+  border: 1px solid var(--color-border-primary);
+  border-radius: var(--radius-md);
   line-height: 30px;
   text-align: center;
-  padding: 0 16px;
+  padding: 0 var(--space-4);
   cursor: pointer;
+  color: var(--color-text-primary);
+  background: var(--color-bg-primary);
+  font-size: var(--text-sm);
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+
+  &:hover {
+    background: var(--color-interactive-hover);
+    border-color: var(--color-accent-blue);
+  }
 }
 
 .callout {
-  @include arrow('up', 20px, 10px, $explorerQueryBackgroundColor);
+  @include arrow('up', 20px, 10px, var(--color-accent-blue));
   width: 20px;
   height: 10px;
 }
@@ -43,11 +52,10 @@
   .button {
     display: block;
     margin-left: auto;
-    margin-right: 0px;
+    margin-right: 0;
   }
 
   .callout {
     margin-left: auto;
   }
 }
-

--- a/src/components/ExplorerQueryComposer/ExplorerQueryComposer.scss
+++ b/src/components/ExplorerQueryComposer/ExplorerQueryComposer.scss
@@ -8,24 +8,24 @@
 @import 'stylesheets/globals.scss';
 
 $labelWidth: 100px;
-$placeholderColor: rgba(255, 255, 255, 0.5);
+$placeholderColor: var(--color-text-on-dark-muted);
 
 .queryComposer {
-  background-color: $explorerQueryBackgroundColor;
-  border: 1px solid $explorerQueryBackgroundColor;
-  border-radius: 5px;
-  color: white;
+  background-color: var(--color-accent-blue);
+  border: 1px solid var(--color-accent-blue);
+  border-radius: var(--radius-md);
+  color: var(--color-text-on-dark);
 
   .queryComposerBox {
-    border: 1px solid $explorerQueryBackgroundColor;
+    border: 1px solid var(--color-accent-blue);
     width: 100%;
-    padding: 10px 0;
+    padding: var(--space-3) 0;
     position: relative;
-    background-color: $blue;
+    background-color: var(--color-accent-blue);
 
     .queryComposerLabel {
       height: 100%;
-      background-color: $blue;
+      background-color: var(--color-accent-blue);
     }
   }
 
@@ -35,7 +35,7 @@ $placeholderColor: rgba(255, 255, 255, 0.5);
   }
 
   .footer {
-    padding-top: 15px;
+    padding-top: var(--space-4);
     height: 60px;
     position: relative;
   }
@@ -44,7 +44,7 @@ $placeholderColor: rgba(255, 255, 255, 0.5);
 .headerView {
   display: table;
   width: 95%;
-  padding-top: 10px;
+  padding-top: var(--space-3);
 
   .headerLabel {
     display: table-cell;
@@ -53,9 +53,9 @@ $placeholderColor: rgba(255, 255, 255, 0.5);
 
     &.textInput {
       background: none;
-      border: none;    
+      border: none;
       font-size: 1.3em;
-      color: white;
+      color: var(--color-text-on-dark);
 
       @include placeholder {
         color: $placeholderColor;
@@ -66,12 +66,17 @@ $placeholderColor: rgba(255, 255, 255, 0.5);
   .headerButtonCell {
     display: table-cell;
     width: 40px;
-    padding-left: 30px;
+    padding-left: var(--space-7);
   }
 
   .headerButton {
     @include buttonReset;
-    color: white;
+    color: var(--color-text-on-dark);
+    transition: opacity var(--transition-fast);
+
+    &:hover {
+      opacity: 0.8;
+    }
 
     &.secondaryColor {
       color: $placeholderColor;
@@ -93,7 +98,7 @@ $placeholderColor: rgba(255, 255, 255, 0.5);
 
   .filterInputStyle {
     width: 47%;
-    margin-left: 2%
+    margin-left: 2%;
   }
 
   .halfBox {
@@ -112,14 +117,19 @@ $placeholderColor: rgba(255, 255, 255, 0.5);
     display: table-cell;
     vertical-align: middle;
     width: 24px;
-    padding-left: 10px;
+    padding-left: var(--space-3);
   }
 
   .del {
     @include buttonReset;
-    color: #d8d8d8;
+    color: var(--color-text-on-dark-muted);
     font-size: 18px;
     line-height: 18px;
+    transition: color var(--transition-fast);
+
+    &:hover {
+      color: var(--color-text-on-dark);
+    }
   }
 
   .twoButton {
@@ -146,16 +156,16 @@ $placeholderColor: rgba(255, 255, 255, 0.5);
 
 .formLabel {
   text-align: left;
-  color: #fdfafb;
+  color: var(--color-bg-primary);
 }
 
 .formInput, .formInput > input {
   text-align: left;
-  color: white;
-  background-color: $darkBlue;
+  color: var(--color-text-on-dark);
+  background-color: var(--color-explorer-input-bg, #0e69a1);
   height: 30px;
   border-color: transparent;
-  border-radius: 5px;
-  padding: 0 30px 0 10px;
+  border-radius: var(--radius-md);
+  padding: 0 var(--space-7) 0 var(--space-3);
   overflow: hidden;
 }

--- a/src/components/ExplorerQueryPicker/ExplorerQueryPicker.scss
+++ b/src/components/ExplorerQueryPicker/ExplorerQueryPicker.scss
@@ -8,29 +8,33 @@
 @import 'stylesheets/globals.scss';
 
 .queryPicker {
-  background-color: $explorerQueryBackgroundColor;
-  border: 1px solid $explorerQueryBackgroundColor;
-  border-radius: 5px;
-
-  color: white;
+  background-color: var(--color-accent-blue);
+  border: 1px solid var(--color-accent-blue);
+  border-radius: var(--radius-md);
+  color: var(--color-text-on-dark);
 
   .queryContainer {
-    background-color: white;
-    color: black;
+    background-color: var(--color-bg-elevated);
+    color: var(--color-text-primary);
 
     .queryGroup {
-      padding: 15px 0px 15px 15px;
-      border: 1px solid #efefef;
+      padding: var(--space-4) 0 var(--space-4) var(--space-4);
+      border: 1px solid var(--color-border-secondary);
     }
 
     .queryItem {
-      padding-top: 8px;
-      padding-bottom: 8px;
+      padding-top: var(--space-2);
+      padding-bottom: var(--space-2);
     }
 
     .queryLabel {
       @include buttonReset;
-      color: $mainTextColor;
+      color: var(--color-text-primary);
+      transition: color var(--transition-fast);
+
+      &:hover {
+        color: var(--color-accent-blue);
+      }
     }
   }
 
@@ -38,13 +42,18 @@
     @include buttonReset;
     position: absolute;
     right: 24px;
-    color: #d8d8d8;
+    color: var(--color-text-tertiary);
     font-size: 18px;
     line-height: 18px;
+    transition: color var(--transition-fast);
+
+    &:hover {
+      color: var(--color-accent-red);
+    }
   }
 
   .header {
-    padding: 15px;
+    padding: var(--space-4);
     height: 60px;
     position: relative;
   }

--- a/src/components/Field/Field.scss
+++ b/src/components/Field/Field.scss
@@ -7,55 +7,133 @@
  */
 @import 'stylesheets/globals.scss';
 
+// =============================================================================
+// Modern layout (light / dark) — stacked label-above-input like shadcn
+// =============================================================================
+
 .field {
   position: relative;
-  border-style: solid;
-  border-color: $borderGrey;
-  border-width: 1px 1px 0 1px;
-  min-height: 80px;
-  background: white;
+  border: none;
+  background: transparent;
   display: flex;
-
-  &:last-of-type {
-    border-bottom-width: 1px;
-  }
+  flex-direction: column;
+  min-height: auto;
+  padding: 0;
+  gap: 6px;
 
   > pre[class*="language-"] {
-    border-radius: 5px;
+    border-radius: var(--radius-md);
   }
 }
 
 .left {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   flex-shrink: 0;
-  width: calc(var(--modal-min-width, 540px) * var(--modal-label-ratio, 0.5));
-  max-width: calc(var(--modal-min-width, 540px) * var(--modal-label-ratio, 0.5));
+  width: 100%;
+  max-width: 100%;
+  padding: 0;
 }
 
 .right {
-  --modal-row-min-height: 80px;
   position: relative;
-  min-height: var(--modal-row-min-height);
-  text-align: right;
+  text-align: left;
   padding: 0;
-  background: #f6fafb;
+  background: transparent;
   display: flex;
-  justify-content: center;
   align-items: center;
   flex: 1;
+  width: 100%;
+  min-height: 36px;
 }
-
 
 .header {
   min-height: 56px;
   height: 56px;
+  flex-direction: row;
+  padding: 0;
+  border-bottom: 1px solid var(--color-border-secondary);
 
   .right {
     min-height: 56px;
   }
 
   & ~ .field {
-    background: #f5f5f7;
+    background: transparent;
+  }
+}
+
+// =============================================================================
+// Classic layout — side-by-side label | input (original Parse Dashboard look)
+// =============================================================================
+
+:global([data-theme="classic"]) {
+  .field {
+    flex-direction: row;
+    min-height: 80px;
+    padding: 0;
+    gap: 0;
+    background: var(--color-bg-primary);
+    border-style: solid;
+    border-color: var(--color-border-secondary);
+    border-width: 1px 0 0 0;
+
+    &:first-of-type {
+      border-top: none;
+    }
+  }
+
+  .left {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    width: calc(var(--modal-min-width, 540px) * var(--modal-label-ratio, 0.5));
+    max-width: calc(var(--modal-min-width, 540px) * var(--modal-label-ratio, 0.5));
+    padding: var(--space-3) var(--space-4);
+  }
+
+  .right {
+    --modal-row-min-height: 80px;
+    min-height: var(--modal-row-min-height);
+    text-align: right;
+    justify-content: center;
+    background: var(--color-bg-primary);
+    width: auto;
+  }
+}
+
+// =============================================================================
+// Responsive — stacks on mobile for all themes
+// =============================================================================
+
+@media (max-width: $bp-md - 1) {
+  .field {
+    flex-direction: column;
+    min-height: auto;
+    padding: 0;
+    gap: 6px;
+  }
+
+  .left {
+    width: 100%;
+    max-width: 100%;
+    padding: 0;
+    flex-shrink: 1;
+  }
+
+  .right {
+    text-align: left;
+    width: 100%;
+    min-height: 36px;
+    padding: 0;
+  }
+
+  .header {
+    height: auto;
+    min-height: auto;
+
+    .right {
+      min-height: auto;
+    }
   }
 }

--- a/src/components/Fieldset/Fieldset.scss
+++ b/src/components/Fieldset/Fieldset.scss
@@ -7,40 +7,86 @@
  */
 @import 'stylesheets/globals.scss';
 
+// =============================================================================
+// Modern (light / dark) — clean open form, no boxing
+// =============================================================================
+
 .fieldset {
-  margin: 40px 0;
+  margin: var(--space-8) 0;
 }
 
 .legend {
-  text-align: center;
-  font-size: 22px;
-  line-height: 26px;
-  font-weight: 700;
-  color: $blue;
-  margin-bottom: 4px;
+  @include UIFont;
+  text-align: left;
+  font-size: var(--text-lg);
+  line-height: 1.4;
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  margin-bottom: var(--space-1);
 }
 
 .description {
-  @include DosisFont;
-  text-align: center;
-  font-size: 14px;
-  line-height: 16px;
-  color: $mainTextColor;
-  width: 500px;
-  margin: 0 auto 16px auto;
+  @include UIFont;
+  text-align: left;
+  font-size: var(--text-sm);
+  line-height: 1.5;
+  color: var(--color-text-secondary);
+  max-width: 500px;
+  margin: 0 0 var(--space-6) 0;
 }
 
 .fields {
-  width: 650px;
-  margin: 0 auto;
+  width: 100%;
+  max-width: 600px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
 
-  & > div:first-of-type {
-    border-top-left-radius: 5px;
-    border-top-right-radius: 5px;
+  // No borders, no card — just clean stacked fields
+  & > div {
+    border: none;
+  }
+}
+
+// =============================================================================
+// Classic — centered legend, bordered card, original look
+// =============================================================================
+
+:global([data-theme="classic"]) {
+  .fieldset {
+    margin: var(--space-10) 0;
   }
 
-  & > div:last-of-type {
-    border-bottom-left-radius: 5px;
-    border-bottom-right-radius: 5px;
+  .legend {
+    text-align: center;
+    font-size: 20px;
+    line-height: 26px;
+  }
+
+  .description {
+    text-align: center;
+    width: 500px;
+    max-width: none;
+    margin: 0 auto var(--space-5) auto;
+  }
+
+  .fields {
+    width: 650px;
+    margin: 0 auto;
+    display: block;
+    gap: 0;
+    border: 1px solid var(--color-border-primary);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+    background: var(--color-bg-primary);
+    box-shadow: var(--shadow-sm);
+
+    & > div:first-of-type {
+      border-top: none;
+    }
+
+    & > div {
+      border-top: 1px solid var(--color-border-secondary);
+    }
   }
 }

--- a/src/components/FileEditor/FileEditor.scss
+++ b/src/components/FileEditor/FileEditor.scss
@@ -8,33 +8,42 @@
 @import 'stylesheets/globals.scss';
 
 .editor {
-  background: white;
+  background: var(--color-bg-elevated);
   white-space: nowrap;
-  box-shadow: 0 1px 4px rgba(0,0,0,0.4);
-  padding: 6px;
+  box-shadow: var(--shadow-overlay);
+  padding: var(--space-2);
 }
 
 .delete, .upload, .download {
-  @include DosisFont;
+  @include HeadingFont;
   display: block;
   cursor: pointer;
-  color: white;
+  color: var(--color-text-on-dark);
   height: 20px;
   line-height: 20px;
-  font-size: 14px;
+  font-size: var(--text-base);
   text-align: center;
-  border-radius: 5px;
+  border-radius: var(--radius-md);
+  transition: background var(--transition-fast), opacity var(--transition-fast);
+
+  &:hover {
+    opacity: 0.9;
+  }
 }
 
 .delete {
-  background: $red;
+  background: var(--color-accent-red);
 }
 
 .upload, .download {
   position: relative;
   overflow: hidden;
-  background: $blue;
-  margin-bottom: 6px;
+  background: var(--color-accent-blue);
+  margin-bottom: var(--space-2);
+
+  &:hover {
+    background: var(--color-accent-blue-hover);
+  }
 
   input {
     position: absolute;

--- a/src/components/FileInput/FileInput.scss
+++ b/src/components/FileInput/FileInput.scss
@@ -11,7 +11,7 @@
   width: 100%;
   height: 80px;
   padding: 0 10%;
-  background: $inputBackgroundColor;
+  background: var(--color-bg-secondary);
   text-align: center;
   overflow: hidden;
   white-space: nowrap;
@@ -20,18 +20,21 @@
 .button {
   position: relative;
   display: inline-block;
-  height: 30px;
-  margin-top: 25px;
+  height: 32px;
+  margin-top: 24px;
   padding: 0 16px;
-  border: 1px solid $blue;
-  border-radius: 5px;
+  background: var(--btn-bg);
+  border: var(--btn-border);
+  border-radius: var(--btn-radius);
   overflow: hidden;
-  color: $blue;
-  transition: background 0.5s, color 0.5s;
+  color: var(--btn-color);
+  font-size: var(--text-sm);
+  font-weight: var(--font-weight-medium);
+  transition: background var(--transition-fast), color var(--transition-fast);
 
   &:hover {
-    background: $blue;
-    color: white;
+    background: var(--btn-hover-bg);
+    color: var(--btn-hover-color);
   }
 
   input {
@@ -45,7 +48,7 @@
   }
 
   > span {
-    line-height: 30px;
+    line-height: 32px;
   }
 }
 
@@ -53,7 +56,7 @@
   display: inline-block;
   width: 20px;
   height: 20px;
-  border: .15em solid $blue;
+  border: .15em solid var(--color-accent-blue);
   vertical-align: bottom;
   border-right-color: transparent;
   border-radius: 50%;
@@ -61,10 +64,10 @@
 }
 
 .disabled, .disabled:hover {
-  background: #e0e0ea;
-  border-color: #e0e0ea;
-  color: white;
-  
+  background: var(--color-bg-tertiary);
+  border-color: transparent;
+  color: var(--color-text-tertiary);
+
   input {
     cursor: default;
   }
@@ -77,15 +80,15 @@
 
 .label {
   display: block;
-  line-height: 30px;
-  color: $mainTextColor;
-  margin-top: 25px;
+  line-height: 32px;
+  color: var(--color-text-primary);
+  margin-top: 24px;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
 a.label {
-  color: $blue;
+  color: var(--color-accent-blue);
 }
 
 @include keyframes(spinner-border) {

--- a/src/components/FileTree/FileTree.react.js
+++ b/src/components/FileTree/FileTree.react.js
@@ -39,7 +39,7 @@ export default class FileTree extends React.Component {
             width={14}
             height={14}
             name={this.state.open ? 'folder-outline' : 'folder-solid'}
-            fill="#ffffff"
+            fill="var(--color-text-on-dark)"
           />
           {this.props.name}
         </div>

--- a/src/components/FileTree/FileTree.scss
+++ b/src/components/FileTree/FileTree.scss
@@ -5,19 +5,23 @@
  * This source code is licensed under the license found in the LICENSE file in
  * the root directory of this source tree.
  */
+@import 'stylesheets/globals.scss';
+
 .directory, .file {
-  color: #8fb9cf;
+  color: var(--color-text-on-dark-muted);
   height: 20px;
   line-height: 20px;
-  font-size: 12px;
+  font-size: var(--text-xs);
   cursor: pointer;
+  transition: color var(--transition-fast);
 }
 
 .directory {
   svg {
     vertical-align: middle;
-    fill: #8fb9cf;
-    margin-right: 6px;
+    fill: var(--color-text-on-dark-muted);
+    margin-right: var(--space-2);
+    transition: fill var(--transition-fast);
   }
 
   > span {
@@ -25,26 +29,26 @@
   }
 
   &:hover {
-    color: white;
+    color: var(--color-text-on-dark);
 
     svg {
-      fill: white;
+      fill: var(--color-text-on-dark);
     }
   }
 }
 
 .contents {
-  padding-left: 12px;
+  padding-left: var(--space-3);
 }
 
 .file {
   display: block;
-  
+
   &:hover {
-    color: white;
+    color: var(--color-text-on-dark);
   }
 }
 
 .current {
-  color: white;
+  color: var(--color-text-on-dark);
 }

--- a/src/components/Filter/Filter.react.js
+++ b/src/components/Filter/Filter.react.js
@@ -128,7 +128,7 @@ const Filter = ({
           display: 'flex',
           gap: '10px',
           padding: '12px 15px 0px 15px',
-          color: '#343445',
+          color: 'var(--color-text-primary)',
           fontWeight: '600',
         }}
       >

--- a/src/components/FlowFooter/FlowFooter.scss
+++ b/src/components/FlowFooter/FlowFooter.scss
@@ -10,11 +10,11 @@
 .footer {
   @include animation('footer-enter 0.5s cubic-bezier(0.165, 0.84, 0.44, 1)');
   position: fixed;
-  left: 300px;
+  left: $sidebar-width;
   right: 0;
   bottom: 0;
-  background: #fbfbfc;
-  border-top: 1px solid #555572;
+  background: var(--color-bg-elevated);
+  border-top: 1px solid var(--color-border-primary);
   min-height: 49px;
   padding: 9px 11px;
   transition: left 0.5s ease-in;
@@ -35,8 +35,8 @@
 }
 
 .content {
-  color: $mainTextColor;
-  font-size: 13px;
+  color: var(--color-text-primary);
+  font-size: var(--text-sm);
   line-height: 22px;
   vertical-align: bottom;
   margin: 5px 0 3px 0;
@@ -46,11 +46,11 @@
   }
 
   &.error {
-    color: $red;
+    color: var(--color-accent-red);
 
     strong {
       font-weight: 700;
-      color: $red;
+      color: var(--color-accent-red);
     }
   }
 }

--- a/src/components/FormButton/FormButton.scss
+++ b/src/components/FormButton/FormButton.scss
@@ -7,10 +7,20 @@
  */
 @import 'stylesheets/globals.scss';
 
+// Modern: compact, transparent
 .input {
   width: 100%;
-  height: 80px;
-  text-align: center;
-  padding-top: 25px;
-  background: $inputBackgroundColor;
+  text-align: left;
+  padding: var(--space-2) 0;
+  background: transparent;
+}
+
+// Classic: centered, gray bg, tall
+:global([data-theme="classic"]) {
+  .input {
+    height: 80px;
+    text-align: center;
+    padding-top: var(--space-6);
+    background: var(--color-bg-tertiary);
+  }
 }

--- a/src/components/FormNote/FormNote.scss
+++ b/src/components/FormNote/FormNote.scss
@@ -8,22 +8,27 @@
 @import 'stylesheets/globals.scss';
 
 .note {
-  color: white;
-  font-size: 12px;
+  @include UIFont;
+  font-size: var(--text-xs);
   text-align: center;
   line-height: 30px;
   min-height: 30px;
+  border-radius: 0;
 }
 
 .blue {
-  background: $blue;
+  background: var(--color-accent-blue-light);
+  color: var(--color-accent-blue);
 }
 .green {
-  background: $green;
+  background: var(--color-accent-green-light);
+  color: var(--color-accent-green);
 }
 .orange {
-  background: $orange;
+  background: var(--color-accent-orange-light);
+  color: var(--color-accent-orange);
 }
 .red {
-  background: $red;
+  background: var(--color-accent-red-light);
+  color: var(--color-accent-red);
 }

--- a/src/components/FormTable/FormTable.scss
+++ b/src/components/FormTable/FormTable.scss
@@ -11,30 +11,30 @@
   text-align: left;
   white-space: nowrap;
   min-height: 80px;
-  background: $formTableGrey;
+  background: var(--color-bg-tertiary);
 }
 
 .row {
-  background: $formTableGrey;
-  font-size: 12px;
-  padding-bottom: 4px;
+  background: var(--color-bg-tertiary);
+  font-size: var(--text-xs);
+  padding-bottom: var(--space-1);
 }
 
 .title {
   @include ellipsis();
   display: inline-block;
   width: 100%;
-  padding-right: 20px;
+  padding-right: var(--space-5);
 }
 
 .header {
   position: relative;
   height: 30px;
-  background: #e3ebef;
+  background: var(--color-bg-tertiary);
   line-height: 14px;
-  font-size: 12px;
-  padding: 9px 32px 9px 6px;
-  margin-bottom: 4px;
+  font-size: var(--text-xs);
+  padding: 9px var(--space-8) 9px var(--space-2);
+  margin-bottom: var(--space-1);
 
   span {
     vertical-align: top;
@@ -45,21 +45,21 @@
   display: inline-block;
   width: 12px;
   height: 12px;
-  border-radius: 100%;
-  margin-right: 10px;
+  border-radius: var(--radius-full);
+  margin-right: var(--space-3);
   vertical-align: middle;
 
   &.blue {
-    background: $blue;
+    background: var(--color-accent-blue);
   }
   &.green {
-    background: $green;
+    background: var(--color-accent-green);
   }
   &.orange {
-    background: $orange;
+    background: var(--color-accent-orange);
   }
   &.red {
-    background: $red;
+    background: var(--color-accent-red);
   }
 }
 
@@ -68,38 +68,43 @@
   position: absolute;
   top: 7px;
   right: 7px;
-  color: $secondaryTextColor;
+  color: var(--color-text-secondary);
   font-size: 22px;
   line-height: 22px;
+  transition: color var(--transition-fast);
+
+  &:hover {
+    color: var(--color-accent-red);
+  }
 }
 
 .info {
   @include ellipsis();
-  padding: 4px 6px;
+  padding: var(--space-1) var(--space-2);
 }
 
 .label {
-  @include DosisFont;
+  @include UIFont;
   display: inline-block;
   text-transform: uppercase;
-  color: $secondaryTextColor;
+  color: var(--color-text-secondary);
   letter-spacing: 0.1em;
   font-size: 10px;
 
   &.blue {
-    color: $blue;
+    color: var(--color-accent-blue);
   }
   &.green {
-    color: $green;
+    color: var(--color-accent-green);
   }
   &.orange {
-    color: $orange;
+    color: var(--color-accent-orange);
   }
   &.red {
-    color: $red;
+    color: var(--color-accent-red);
   }
 }
 
 .din {
-  @include DosisFont;
+  @include UIFont;
 }

--- a/src/components/FourOhFour/FourOhFour.scss
+++ b/src/components/FourOhFour/FourOhFour.scss
@@ -9,8 +9,8 @@
 
 .fourOhFour {
   height: 100vh;
-  background: #06283d;
-  color: white;
+  background: var(--color-bg-sidebar);
+  color: var(--color-text-on-dark);
   text-align: center;
 }
 
@@ -18,12 +18,11 @@
   position: absolute;
   width: 100%;
   top: 50%;
-  -webkit-transform: translateY(-50%);
   transform: translateY(-50%);
 }
 
 .error {
-  @include DosisFont;
+  @include HeadingFont;
   font-size: 240px;
 }
 
@@ -43,10 +42,15 @@
 }
 
 .back {
-  margin-top: 40px;
+  margin-top: var(--space-8);
 
   button {
     @include buttonReset;
-    color: #fff;
+    color: var(--color-text-on-dark);
+    transition: opacity var(--transition-fast);
+
+    &:hover {
+      opacity: 0.8;
+    }
   }
 }

--- a/src/components/GeoPointEditor/GeoPointEditor.scss
+++ b/src/components/GeoPointEditor/GeoPointEditor.scss
@@ -11,7 +11,7 @@
   position: absolute;
   top: 0;
   left: 0;
-  box-shadow: 0 1px 4px rgba(0,0,0,0.4);
+  box-shadow: var(--shadow-overlay);
 
   input {
     @include MonospaceFont;
@@ -19,11 +19,18 @@
     height: 30px;
     border: none;
     outline: none;
-    padding: 0 4px;
-    font-size: 12px;
+    padding: 0 var(--space-1);
+    font-size: var(--text-xs);
+    background: var(--color-bg-elevated);
+    color: var(--color-text-primary);
+    transition: background var(--transition-fast);
 
     &:first-child {
-      border-right: 1px solid #e3e3ea;
+      border-right: 1px solid var(--color-border-primary);
+    }
+
+    &:focus {
+      background: var(--color-bg-primary);
     }
   }
 }

--- a/src/components/GeoPointInput/GeoPointInput.scss
+++ b/src/components/GeoPointInput/GeoPointInput.scss
@@ -9,7 +9,7 @@
 
 .geopoint {
   width: 100%;
-  background: $inputBackgroundColor;
+  background: var(--color-bg-tertiary);
   height: 80px;
 }
 
@@ -22,8 +22,8 @@
     height: 30px;
     line-height: 30px;
     text-align: center;
-    color: $secondaryTextColor;
-    font-size: 14px;
+    color: var(--color-text-secondary);
+    font-size: var(--text-base);
   }
 }
 
@@ -36,7 +36,13 @@
     background: none;
     height: 50px;
     width: 50%;
-    font-size: 16px;
+    font-size: var(--text-lg);
     text-align: center;
+    color: var(--color-text-primary);
+    transition: background var(--transition-fast);
+
+    &:focus {
+      background: var(--color-interactive-hover);
+    }
   }
 }

--- a/src/components/GraphPanel/GraphPanel.react.js
+++ b/src/components/GraphPanel/GraphPanel.react.js
@@ -491,7 +491,7 @@ const GraphPanel = ({
     if (validationError) {
       return (
         <div className={styles.error}>
-          <Icon name="exclamation-triangle" width={48} height={48} fill="#ffffff" />
+          <Icon name="exclamation-triangle" width={48} height={48} fill="var(--color-text-on-dark)" />
           <p>Configuration Error</p>
           <p>{validationError}</p>
         </div>
@@ -501,7 +501,7 @@ const GraphPanel = ({
     if (!graphConfig) {
       return (
         <div className={styles.noData}>
-          <Icon name="chart-line" width={48} height={48} fill="#ffffff" />
+          <Icon name="chart-line" width={48} height={48} fill="var(--color-text-on-dark)" />
           <p>No graph configured.</p>
           {onNewGraph && (
             <>
@@ -520,7 +520,7 @@ const GraphPanel = ({
     if (!processedData) {
       return (
         <div className={styles.noData}>
-          <Icon name="chart-line" width={48} height={48} fill="#ffffff" />
+          <Icon name="chart-line" width={48} height={48} fill="var(--color-text-on-dark)" />
           <p>No graph data available</p>
           <p>Configure your graph settings and select data to visualize.</p>
         </div>
@@ -550,7 +550,7 @@ const GraphPanel = ({
       default:
         return (
           <div className={styles.error}>
-            <Icon name="exclamation-triangle" width={24} height={24} fill="#ffffff" />
+            <Icon name="exclamation-triangle" width={24} height={24} fill="var(--color-text-on-dark)" />
             <p>Unsupported chart type</p>
           </div>
         );
@@ -560,7 +560,7 @@ const GraphPanel = ({
   if (error) {
     return (
       <div className={styles.error}>
-        <Icon name="exclamation-triangle" width={24} height={24} fill="#ffffff" />
+        <Icon name="exclamation-triangle" width={24} height={24} fill="var(--color-text-on-dark)" />
         <p>Error loading graph data</p>
         <p>{error.message || 'Unknown error occurred'}</p>
         {onRefresh && (
@@ -570,7 +570,7 @@ const GraphPanel = ({
             className={styles.retryButton}
             aria-label="Retry loading graph data"
           >
-            <Icon name="refresh-solid" width={14} height={14} fill="#ffffff" />
+            <Icon name="refresh-solid" width={14} height={14} fill="var(--color-text-on-dark)" />
             Retry
           </button>
         )}
@@ -611,7 +611,7 @@ const GraphPanel = ({
                   aria-label="Select graph"
                   title="Select graph"
                 >
-                  <Icon name="down-solid" width={14} height={14} fill="#ffffff" />
+                  <Icon name="down-solid" width={14} height={14} fill="var(--color-text-on-dark)" />
                 </button>
                 {showGraphDropdown && (
                   <div className={styles.dropdownMenu}>
@@ -649,7 +649,7 @@ const GraphPanel = ({
                 aria-label="Edit graph configuration"
                 title="Edit graph"
               >
-                <Icon name="edit-solid" width={14} height={14} fill="#ffffff" />
+                <Icon name="edit-solid" width={14} height={14} fill="var(--color-text-on-dark)" />
               </button>
             )}
             {hasActiveGraph && onRefresh && (
@@ -660,7 +660,7 @@ const GraphPanel = ({
                 aria-label="Refresh graph data"
                 title="Refresh graph"
               >
-                <Icon name="refresh-solid" width={14} height={14} fill="#ffffff" />
+                <Icon name="refresh-solid" width={14} height={14} fill="var(--color-text-on-dark)" />
               </button>
             )}
             {onClose && (
@@ -671,7 +671,7 @@ const GraphPanel = ({
                 aria-label="Close graph panel"
                 title="Close graph"
               >
-                <Icon name="x-solid" width={14} height={14} fill="#ffffff" />
+                <Icon name="x-solid" width={14} height={14} fill="var(--color-text-on-dark)" />
               </button>
             )}
           </div>
@@ -681,7 +681,7 @@ const GraphPanel = ({
       <div className={styles.chartContainer} ref={containerRef}>
         {isLoading ? (
           <div className={styles.loading}>
-            <Icon name="spinner" width={24} height={24} fill="#ffffff" />
+            <Icon name="spinner" width={24} height={24} fill="var(--color-text-on-dark)" />
             <p>Loading graph data...</p>
           </div>
         ) : (

--- a/src/components/GraphPanel/GraphPanel.scss
+++ b/src/components/GraphPanel/GraphPanel.scss
@@ -1,18 +1,20 @@
+@import 'stylesheets/globals.scss';
+
 .container {
   height: 100%;
   display: flex;
   flex-direction: column;
-  border-radius: 4px;
+  border-radius: var(--radius-md);
 }
 
 .header {
   height: 30px;
-  font-size: 14px;
+  font-size: var(--text-base);
   margin: 0;
   padding: 0;
-  padding-left: 10px;
-  background-color: #169cee;
-  color: white;
+  padding-left: var(--space-3);
+  background-color: var(--color-accent-blue);
+  color: var(--color-text-on-dark);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -21,10 +23,11 @@
 }
 
 .title {
+  @include HeadingFont;
   margin: 0;
-  padding: 0 8px;
-  font-size: 14px;
-  color: white;
+  padding: 0 var(--space-2);
+  font-size: var(--text-base);
+  color: var(--color-text-on-dark);
   flex: 1;
   line-height: 1;
   vertical-align: middle;
@@ -39,20 +42,21 @@
   background: none;
   border: none;
   cursor: pointer;
-  padding: 4px;
-  border-radius: 3px;
-  color: white;
+  padding: var(--space-1);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-on-dark);
   opacity: 0.8;
   vertical-align: middle;
+  transition: background var(--transition-fast), opacity var(--transition-fast);
 
   &:hover {
-    background: rgba(255, 255, 255, 0.1);
+    background: rgba(255, 255, 255, 0.15);
     opacity: 1;
   }
 
   &:focus {
     outline: none;
-    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.5);
+    box-shadow: 0 0 0 2px var(--color-border-focus);
   }
 }
 
@@ -60,11 +64,11 @@
   position: absolute;
   top: 100%;
   right: 0;
-  margin-top: 4px;
-  background: white;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  margin-top: var(--space-1);
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border-primary);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-overlay);
   min-width: 220px;
   max-width: 300px;
   max-height: 400px;
@@ -73,33 +77,35 @@
 }
 
 .dropdownItem {
+  @include UIFont;
   width: 100%;
   background: none;
   border: none;
-  padding: 8px 12px;
+  padding: var(--space-2) var(--space-3);
   text-align: left;
   cursor: pointer;
-  color: #333;
-  font-size: 13px;
+  color: var(--color-text-primary);
+  font-size: var(--text-sm);
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
+  transition: background var(--transition-fast);
 
   &:hover {
-    background: #f5f5f5;
+    background: var(--color-interactive-hover);
   }
 
   &:focus {
     outline: none;
-    background: #e8e8e8;
+    background: var(--color-interactive-hover);
   }
 }
 
 .dropdownItemActive {
-  background: #e3f2fd;
+  background: var(--color-accent-blue-light);
 
   &:hover {
-    background: #bbdefb;
+    background: var(--color-accent-blue-light);
   }
 }
 
@@ -108,27 +114,27 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
 }
 
 .dropdownItemType {
-  font-size: 11px;
-  color: #666;
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
   text-transform: capitalize;
-  background: #f0f0f0;
-  padding: 2px 6px;
-  border-radius: 3px;
+  background: var(--color-bg-tertiary);
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-sm);
 }
 
 .dropdownSeparator {
   height: 1px;
-  background: #e0e0e0;
-  margin: 4px 0;
+  background: var(--color-border-primary);
+  margin: var(--space-1) 0;
 }
 
 .headerButtons {
-  gap: 8px;
-  padding-right: 8px;
+  gap: var(--space-2);
+  padding-right: var(--space-2);
 }
 
 .editButton,
@@ -137,27 +143,28 @@
   background: none;
   border: none;
   cursor: pointer;
-  padding: 4px;
-  border-radius: 3px;
-  color: white;
+  padding: var(--space-1);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-on-dark);
   opacity: 0.8;
   vertical-align: middle;
+  transition: background var(--transition-fast), opacity var(--transition-fast);
 
   &:hover {
-    background: rgba(255, 255, 255, 0.1);
-    color: white;
+    background: rgba(255, 255, 255, 0.15);
+    color: var(--color-text-on-dark);
     opacity: 1;
   }
 
   &:focus {
     outline: none;
-    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.5);
+    box-shadow: 0 0 0 2px var(--color-border-focus);
   }
 }
 
 .chartContainer {
   flex: 1;
-  padding: 16px;
+  padding: var(--space-4);
   min-height: 100px;
   position: relative;
 }
@@ -180,106 +187,109 @@
   justify-content: center;
   height: 100%;
   text-align: center;
-  color: #666;
+  color: var(--color-text-secondary);
 
   svg {
-    margin-bottom: 12px;
+    margin-bottom: var(--space-3);
     opacity: 0.5;
   }
 
   p {
-    margin: 4px 0;
-    font-size: 14px;
+    margin: var(--space-1) 0;
+    font-size: var(--text-base);
 
     &:first-of-type {
-      font-weight: 500;
+      font-weight: var(--font-weight-medium);
     }
 
     &:last-of-type {
-      font-size: 12px;
+      font-size: var(--text-xs);
       opacity: 0.7;
     }
   }
 }
 
 .error {
-  color: #d32f2f;
+  color: var(--color-accent-red);
 
   svg {
-    color: #d32f2f;
+    color: var(--color-accent-red);
     opacity: 0.8;
   }
 }
 
 .noData {
   svg {
-    color: #666;
+    color: var(--color-text-secondary);
   }
 }
 
 .retryButton {
+  @include UIFont;
   display: flex;
   align-items: center;
-  gap: 6px;
-  margin-top: 12px;
-  padding: 6px 12px;
-  background: #f5f5f5;
-  border: 1px solid #ddd;
-  border-radius: 4px;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border-primary);
+  border-radius: var(--radius-md);
   cursor: pointer;
-  font-size: 12px;
-  color: #333;
+  font-size: var(--text-xs);
+  color: var(--color-text-primary);
+  transition: background var(--transition-fast);
 
   &:hover {
-    background: #e8e8e8;
+    background: var(--color-bg-secondary);
   }
 
   &:focus {
     outline: none;
-    box-shadow: 0 0 0 2px rgba(54, 162, 235, 0.3);
+    box-shadow: 0 0 0 2px var(--color-border-focus);
   }
 }
 
 .createGraphButton {
-  margin-top: 16px;
-  padding: 10px 20px;
-  background: #169cee;
+  @include UIFont;
+  margin-top: var(--space-4);
+  padding: var(--space-3) var(--space-5);
+  background: var(--color-accent-blue);
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   cursor: pointer;
-  font-size: 14px;
-  font-weight: 500;
-  color: white;
-  transition: background 0.2s;
+  font-size: var(--text-base);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-on-dark);
+  transition: background var(--transition-fast);
 
   &:hover {
-    background: #147abd;
+    background: var(--color-accent-blue-hover);
   }
 
   &:focus {
     outline: none;
-    box-shadow: 0 0 0 3px rgba(22, 156, 238, 0.3);
+    box-shadow: 0 0 0 3px var(--color-border-focus);
   }
 
   &:active {
-    background: #0f5a8e;
+    background: var(--color-accent-blue-hover);
   }
 }
 
 .previewNotice {
-  margin-top: 24px !important;
-  padding-top: 4px;
-  font-size: 11px;
-  color: #999;
+  margin-top: var(--space-6) !important;
+  padding-top: var(--space-1);
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
   max-width: 400px;
   line-height: 1.4;
 }
 
 .configInfo {
-  padding: 8px 16px;
-  background: #f8f8f8;
-  border-top: 1px solid #e8e8e8;
-  font-size: 11px;
-  color: #666;
+  padding: var(--space-2) var(--space-4);
+  background: var(--color-bg-secondary);
+  border-top: 1px solid var(--color-border-secondary);
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
   text-align: center;
 }

--- a/src/components/InlineSubmitInput/InlineSubmitInput.scss
+++ b/src/components/InlineSubmitInput/InlineSubmitInput.scss
@@ -8,7 +8,7 @@
 @import 'stylesheets/globals.scss';
 
 .wrapper {
-  background: $inputBackgroundColor;
+  background: var(--color-bg-primary);
   padding: 0px 5px;
 }
 
@@ -17,17 +17,24 @@
 }
 
 .button {
-  @include buttonReset($border: 1px solid #159cee, $padding: 0px 7px);
+  @include buttonReset($bg: var(--btn-bg), $border: var(--btn-border), $padding: 0px 7px);
   position: absolute;
   top: 30px;
   right: 15px;
-  height: 20px;
-  line-height: 20px;
+  height: 22px;
+  line-height: 22px;
   outline: 0;
   text-decoration: none;
   text-align: center;
-  border-radius: 5px;
+  border-radius: var(--btn-radius);
   cursor: pointer;
   font-size: 10px;
-  color: #159cee;
+  color: var(--btn-color);
+  font-weight: var(--font-weight-medium);
+  transition: background var(--transition-fast), color var(--transition-fast);
+
+  &:hover {
+    background: var(--btn-hover-bg);
+    color: var(--btn-hover-color);
+  }
 }

--- a/src/components/JsonEditor/JsonEditor.scss
+++ b/src/components/JsonEditor/JsonEditor.scss
@@ -11,16 +11,16 @@
   position: relative;
   display: inline-block;
   width: 100%;
-  font-family: 'Source Code Pro', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+  @include MonospaceFont;
   font-size: 15px;
   line-height: 1.5;
-  background: $inputBackgroundColor;
+  background: var(--color-bg-primary);
 }
 
 // Shared text styles
 .highlightLayer,
 .inputLayer {
-  padding: 10px;
+  padding: var(--space-3);
   margin: 0;
   border: none;
   font-family: inherit;
@@ -41,7 +41,7 @@
   bottom: 0;
   pointer-events: none;
   background: transparent;
-  color: #555572;
+  color: var(--color-text-primary);
   overflow: hidden;
 
   code {
@@ -57,31 +57,31 @@
   // Prism token colors (GitHub light theme)
   :global {
     .token.property {
-      color: #005cc5; // Blue - JSON keys
+      color: var(--color-accent-blue);
     }
 
     .token.string {
-      color: #000000; // Black - string values
+      color: var(--color-text-primary);
     }
 
     .token.number {
-      color: #098658; // Dark green - numbers
+      color: var(--color-accent-green);
     }
 
     .token.boolean {
-      color: #d73a49; // Red - true/false
+      color: var(--color-accent-red);
     }
 
     .token.null {
-      color: #d73a49; // Red - null
+      color: var(--color-accent-red);
     }
 
     .token.punctuation {
-      color: #24292e; // Dark gray - brackets, commas
+      color: var(--color-text-secondary);
     }
 
     .token.operator {
-      color: #24292e; // Dark gray - colons
+      color: var(--color-text-secondary);
     }
   }
 }
@@ -93,7 +93,7 @@
   min-width: calc(var(--modal-min-width) * (1 - var(--modal-label-ratio)));
   background: transparent;
   color: transparent;
-  caret-color: #333;
+  caret-color: var(--color-text-primary);
   resize: both;
   outline: none;
   min-height: 80px;
@@ -101,6 +101,6 @@
   overflow: auto;
 
   &::placeholder {
-    color: #bbb;
+    color: var(--color-text-tertiary);
   }
 }

--- a/src/components/KeyField/KeyField.scss
+++ b/src/components/KeyField/KeyField.scss
@@ -9,10 +9,10 @@
 
 .key {
   @include MonospaceFont;
-  background: $inputBackgroundColor;
+  background: var(--color-bg-primary);
   width: 100%;
   height: 80px;
   line-height: 80px;
-  font-size: 12px;
+  font-size: var(--text-xs);
   text-align: center;
 }

--- a/src/components/Label/Label.scss
+++ b/src/components/Label/Label.scss
@@ -8,15 +8,30 @@
 @import 'stylesheets/globals.scss';
 
 .label {
-  font-size: 13px;
+  @include UIFont;
+  font-size: var(--text-sm);
 }
 
 .text {
-  font-weight: 700;
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-primary);
+  font-size: var(--text-sm);
+  line-height: 1;
 }
 
 .description {
   margin-top: 2px;
-  color: $secondaryTextColor;
-  line-height: 13px;
+  color: var(--color-text-tertiary);
+  line-height: 1.4;
+  font-size: var(--text-xs);
+  font-weight: normal;
+
+  a {
+    color: var(--color-accent-blue);
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
 }

--- a/src/components/Loader/Loader.scss
+++ b/src/components/Loader/Loader.scss
@@ -21,13 +21,13 @@
     transform: translate(-50%, -50%);
 
     &:nth-child(3n) {
-      background: $red;
+      background: var(--color-accent-red);
     }
     &:nth-child(3n + 1) {
-      background: $green;
+      background: var(--color-accent-green);
     }
     &:nth-child(3n + 2) {
-      background: $blue;
+      background: var(--color-accent-blue);
     }
   }
 }

--- a/src/components/LoaderContainer/LoaderContainer.scss
+++ b/src/components/LoaderContainer/LoaderContainer.scss
@@ -9,7 +9,7 @@
 	position: relative;
 	.loaderParent {
 		visibility: hidden;
-		background: rgba(255, 255, 255, 0.7);
+		background: color-mix(in srgb, var(--color-bg-elevated) 70%, transparent);
 		position: absolute;
 		width: 100%;
 		height: 100%;
@@ -19,7 +19,7 @@
 			visibility: visible;
 		}
 		&.solid {
-			background: white;
+			background: var(--color-bg-elevated);
 		}
 	}
 }

--- a/src/components/LoaderDots/LoaderDots.scss
+++ b/src/components/LoaderDots/LoaderDots.scss
@@ -20,7 +20,7 @@ $dotSize: 8px;
     width: $dotSize;
     height: $dotSize;
     border-radius: $dotSize;
-    background-color: black;
+    background-color: var(--color-text-primary);
     margin: 4px;
 
     &:nth-child(2) {

--- a/src/components/LogView/LogView.scss
+++ b/src/components/LogView/LogView.scss
@@ -8,5 +8,5 @@
 @import 'stylesheets/globals.scss';
 
 .view {
-  background: $logViewBackgroundColor;
+  background: var(--color-bg-primary);
 }

--- a/src/components/LogView/LogViewEntry.scss
+++ b/src/components/LogView/LogViewEntry.scss
@@ -8,13 +8,13 @@
 @import 'stylesheets/globals.scss';
 
 .entry {
-	@include MonospaceFont;
-  font-size: 14px;
+  @include MonospaceFont;
+  font-size: var(--text-base);
   list-style: none;
-  margin-bottom: 15px;
+  margin-bottom: var(--space-4);
 
   &.error {
-    color: red;
+    color: var(--color-accent-red);
   }
 
   .content {
@@ -22,26 +22,26 @@
   }
 
   .time {
-    color: green;
+    color: var(--color-accent-green);
   }
 
   //TODO: handle keywords that should be highlighted - use global vars for colors
   .highlight {
 
     &.error {
-      color: red;
+      color: var(--color-accent-red);
     }
 
     &.info {
-      color: purple;
+      color: var(--color-accent-blue);
     }
 
     &.warning {
-      color: orange;
+      color: var(--color-accent-orange);
     }
 
     &.success {
-      color: green;
+      color: var(--color-accent-green);
     }
   }
 }

--- a/src/components/LoginForm/LoginForm.react.js
+++ b/src/components/LoginForm/LoginForm.react.js
@@ -20,7 +20,7 @@ export default class LoginForm extends React.Component {
   render() {
     return (
       <div className={styles.login} style={{ marginTop: this.props.marginTop || '-220px' }}>
-        <Icon width={80} height={80} name="infinity" fill="#093A59" />
+        <Icon width={80} height={80} name="infinity" fill="var(--color-text-primary)" />
         <form method="post" ref={this.formRef} action={this.props.endpoint} className={styles.form}>
           <CSRFInput />
           <div className={styles.header}>{this.props.header}</div>

--- a/src/components/LoginForm/LoginForm.scss
+++ b/src/components/LoginForm/LoginForm.scss
@@ -11,69 +11,79 @@
   position: absolute;
   top: 50%;
   left: 50%;
-  margin-left: -175px;
+  margin-left: -190px;
   text-align: center;
-  width: 350px;
+  width: 380px;
 }
 
 .form {
-  margin-top: 30px;
+  margin-top: var(--space-6);
+  background: var(--color-bg-elevated);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  border: 1px solid var(--color-border-secondary);
+  overflow: hidden;
 }
 
 .header {
   height: 50px;
   line-height: 50px;
-  border-radius: 5px 5px 0 0;
-  color: $blue;
-  font-size: 16px;
-  font-weight: 700;
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  color: var(--color-accent-blue);
+  font-size: var(--text-lg);
+  font-weight: var(--font-weight-semibold);
   text-align: center;
-  background: white;
-  border-bottom: 1px solid #e0e0e1;
+  background: var(--color-bg-elevated);
+  border-bottom: 1px solid var(--color-border-secondary);
 }
 
 .footer {
-  @include NotoSansFont;
+  @include UIFont;
   position: relative;
   height: 40px;
   padding: 10px 0;
   width: 100%;
-  background: white;
-  border-radius: 0 0 5px 5px;
-  color: #c1c0c9;
-  font-size: 12px;
+  background: var(--color-bg-secondary);
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
+  color: var(--color-text-tertiary);
+  font-size: var(--text-xs);
   text-align: center;
+  border-top: 1px solid var(--color-border-secondary);
 
   a {
-    color: #c1c0c9;
+    color: var(--color-text-tertiary);
+    transition: color var(--transition-fast);
 
     &:hover {
-      color: $mainTextColor;
+      color: var(--color-text-primary);
     }
   }
 }
 
 .submit {
-  @include NotoSansFont;
+  @include UIFont;
   display: block;
-  background: $green;
+  background: var(--color-accent-blue);
   height: 42px;
   width: 100%;
-  font-size: 16px;
+  font-size: var(--text-base);
+  font-weight: var(--font-weight-medium);
   line-height: 42px;
-  border-radius: 5px;
-  color: white;
-  margin-top: 15px;
+  border-radius: var(--radius-md);
+  color: var(--color-text-on-dark);
+  margin-top: var(--space-4);
   outline: none;
   border: none;
   cursor: pointer;
+  transition: background var(--transition-fast);
 
   &:hover, &:focus {
-    background: $darkGreen;
+    background: var(--color-accent-blue-hover);
   }
 
   &:disabled {
-    background: #dadada;
+    background: var(--color-bg-tertiary);
+    color: var(--color-text-tertiary);
     cursor: default;
   }
 }

--- a/src/components/LoginRow/LoginRow.scss
+++ b/src/components/LoginRow/LoginRow.scss
@@ -9,12 +9,12 @@
   display: block;
   position: relative;
   height: 50px;
-  border-bottom: 1px solid #e0e0e1;
+  border-bottom: 1px solid var(--color-border-primary);
 }
 
 .label {
   width: 110px;
-  background: #f9f9fa;
+  background: var(--color-bg-secondary);
   font-size: 13px;
   font-weight: 700;
   height: 49px;
@@ -27,7 +27,7 @@
 .input {
   margin-left: 110px;
   height: 49px;
-  background: #f0f4f6;
+  background: var(--color-bg-tertiary);
 
   input {
     display: block;
@@ -41,7 +41,7 @@
     font-size: 13px;
 
     &:focus {
-      background: rgba(6,40,61,0.1);
+      background: var(--color-interactive-hover);
     }
   }
 }

--- a/src/components/Modal/Modal.react.js
+++ b/src/components/Modal/Modal.react.js
@@ -15,16 +15,11 @@ import PropTypes from 'lib/PropTypes';
 import styles from 'components/Modal/Modal.scss';
 
 const origin = new Position(0, 0);
-const buttonColors = {
-  danger: 'red',
-  info: 'blue',
-  valid: 'green',
-};
 
 const Modal = ({
   type = Modal.Types.INFO,
   icon,
-  iconSize = 36,
+  iconSize = 30,
   children,
   title,
   subtitle,
@@ -154,20 +149,25 @@ const Modal = ({
   if (children) {
     children = React.Children.map(children, c => {
       if (c && c.type === Field && c.props.label) {
-        return React.cloneElement(c, { ...c.props, labelPadding: 24 });
+        return React.cloneElement(c, { ...c.props, labelPadding: 0 });
       }
       return c;
     });
   }
 
+  // Button color mapping for type-specific primary actions
+  const buttonColors = {
+    danger: 'red',
+    info: undefined, // default primary style
+    valid: 'green',
+  };
+
   const footer = customFooter || (
     <div style={{ textAlign: buttonsInCenter ? 'center' : 'right' }} className={styles.footer}>
-      {showCancel && <Button value={cancelText} onClick={onCancel} disabled={!canCancel} />}
+      {showCancel && <Button value={cancelText} color="ghost" onClick={onCancel} disabled={!canCancel} />}
       {showContinue && (
         <Button
-          primary={true}
           value={continueText}
-          color={buttonColors[type]}
           disabled={!!disabled}
           onClick={onContinue}
           progress={progress}
@@ -184,24 +184,28 @@ const Modal = ({
     </div>
   );
 
-  const wrappedChildren = textModal ? <div className={styles.textModal}>{children}</div> : children;
+  const wrappedChildren = textModal ? (
+    <div className={styles.textModal}>{children}</div>
+  ) : children ? (
+    <div className={styles.body}>{children}</div>
+  ) : null;
+
+  // Icon fill: theme-aware — on classic it's white-on-colored-header, on modern it's accent color
+  const iconFillMap = {
+    danger: 'var(--color-accent-red)',
+    info: 'var(--color-accent-blue)',
+    valid: 'var(--color-accent-green)',
+  };
 
   return (
-    <Popover fadeIn={true} fixed={true} position={origin} modal={true} color="rgba(17,13,17,0.8)">
+    <Popover fadeIn={true} fixed={true} position={origin} modal={true} color="rgba(0,0,0,0.5)">
       <div ref={modalRef} className={[styles.modal, styles[type]].join(' ')} style={{ width }}>
         <div className={styles.header}>
-          <div
-            style={{
-              top: React.Children.count(subtitle) === 0 ? '37px' : '25px',
-            }}
-            className={styles.title}
-          >
-            {title}
-          </div>
-          <div className={styles.subtitle}>{subtitle}</div>
+          <div className={styles.title}>{title}</div>
+          {subtitle ? <div className={styles.subtitle}>{subtitle}</div> : null}
           {icon ? (
             <div className={styles.icon}>
-              <Icon width={iconSize} height={iconSize} name={icon} fill="#ffffff" />
+              <Icon width={iconSize} height={iconSize} name={icon} fill={iconFillMap[type] || 'var(--color-text-secondary)'} />
             </div>
           ) : null}
         </div>

--- a/src/components/Modal/Modal.scss
+++ b/src/components/Modal/Modal.scss
@@ -16,96 +16,169 @@
   width: auto;
   min-width: var(--modal-min-width);
   max-height: 90vh;
-  background: white;
-  border-radius: 5px;
+  background: var(--color-bg-elevated);
+  border-radius: var(--radius-lg);
   overflow: hidden;
   transition: width 0.5s cubic-bezier(1, 0, 0, 1);
   display: flex;
   flex-direction: column;
-
-  > *:not(:first-child):not(:last-child) {
-    border-color: $borderGrey;
-    border-width: 0 0 1px 0;
-    border-style: solid;
-    overflow: auto;
-    min-height: 0;
-  }
+  box-shadow: var(--shadow-overlay);
+  border: 1px solid var(--color-border-secondary);
 }
 
+// ---------------------------------------------------------------------------
+// Header — clean bg, high-contrast text, no colored block
+// ---------------------------------------------------------------------------
+
 .header {
-  height: 90px;
+  padding: var(--space-5) var(--space-6) var(--space-4);
   position: relative;
-  transition: background 0.3s ease;
   flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  background: var(--color-bg-elevated);
+  border-bottom: 1px solid var(--color-border-secondary);
 }
 
 .title {
-  position: absolute;
-  font-size: 22px;
-  font-weight: 500;
-  color: white;
-  left: 28px;
+  font-size: var(--text-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  line-height: var(--leading-tight);
+  padding-right: 40px;
 }
 
 .subtitle {
-  @include DosisFont;
-  position: absolute;
-  font-size: 14px;
-  color: white;
-  top: 52px;
-  left: 28px;
+  @include UIFont;
+  font-size: var(--text-sm);
+  color: var(--color-text-tertiary);
+  margin-top: 2px;
+  line-height: var(--leading-normal);
+  padding-right: 40px;
 }
 
 .icon {
   position: absolute;
-  top: 19px;
-  right: 28px;
-  width: 52px;
-  height: 52px;
+  top: var(--space-5);
+  right: var(--space-5);
+  width: 32px;
+  height: 32px;
   text-align: center;
-  border-radius: 100%;
-  background: rgba(0, 0, 0, 0.3);
-  svg{
+  border-radius: var(--radius-md);
+  background: var(--color-bg-tertiary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  svg {
     position: relative;
-    top: 50%;
-    @include transform(translateY(-50%));
   }
 }
 
-.danger {
-  .header {
-    background: $red;
-  }
+// ---------------------------------------------------------------------------
+// Type variants — only affect icon tint & primary button color
+// ---------------------------------------------------------------------------
+
+.danger .icon { background: var(--color-accent-red-light); }
+.info .icon   { background: var(--color-bg-tertiary); }
+.valid .icon  { background: var(--color-accent-green-light); }
+
+// ---------------------------------------------------------------------------
+// Body — proper spacing between stacked Fields
+// ---------------------------------------------------------------------------
+
+.body {
+  overflow: auto;
+  min-height: 0;
+  padding: var(--space-5) var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
 }
 
-.info {
-  .header {
-    background: $blue;
-  }
-}
-
-.valid {
-  .header {
-    background: $green;
-  }
-}
+// ---------------------------------------------------------------------------
+// Footer — right-aligned buttons with clear hierarchy
+// ---------------------------------------------------------------------------
 
 .footer {
-  padding: 17px 28px;
+  padding: var(--space-4) var(--space-6);
   flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  border-top: 1px solid var(--color-border-secondary);
+  background: var(--color-bg-elevated);
 
   > * {
-    margin: 0 12px 0 0;
-
-    &:last-child {
-      margin-right: 0;
-    }
+    margin: 0;
   }
 }
 
 .textModal {
   text-align: center;
-  padding: 17px 55px 0 55px;
+  padding: var(--space-6) var(--space-8) var(--space-4);
+  color: var(--color-text-secondary);
+  font-size: var(--text-base);
+  line-height: var(--leading-normal);
+}
+
+// ---------------------------------------------------------------------------
+// Classic — restore the colored-header look
+// ---------------------------------------------------------------------------
+
+:global([data-theme="classic"]) {
+  .modal {
+    border-radius: var(--radius-xl);
+  }
+
+  .header {
+    border-bottom: none;
+    border-top: none;
+    padding: var(--space-5) var(--space-6);
+  }
+
+  .danger .header {
+    background: var(--color-accent-red);
+  }
+
+  .info .header {
+    background: var(--color-accent-blue);
+  }
+
+  .valid .header {
+    background: var(--color-accent-green);
+  }
+
+  .title {
+    color: var(--color-text-on-dark);
+  }
+
+  .subtitle {
+    color: var(--color-text-on-dark-muted);
+  }
+
+  .icon {
+    background: rgba(255, 255, 255, 0.15);
+
+    svg {
+      fill: var(--color-text-on-dark);
+    }
+  }
+
+  .danger .icon,
+  .info .icon,
+  .valid .icon {
+    background: rgba(255, 255, 255, 0.15);
+  }
+
+  .footer {
+    background: var(--color-bg-secondary);
+  }
+
+  .body {
+    border-bottom: 1px solid var(--color-border-primary);
+  }
 }
 
 @include modalKeyframes();

--- a/src/components/MoneyInput/MoneyInput.scss
+++ b/src/components/MoneyInput/MoneyInput.scss
@@ -8,20 +8,23 @@
 @import 'stylesheets/globals.scss';
 
 .moneyInput {
-  @include DosisFont;
+  @include HeadingFont;
   border: 0;
   outline: 0;
-  background: $inputBackgroundColor;
+  background: var(--color-bg-secondary);
   font-size: 22px;
   width: 100%;
-  padding: 6px;
+  padding: var(--space-2);
   vertical-align: top;
   resize: none;
   height: 80px;
-  color: $green;
+  color: var(--color-accent-green);
   text-align: center;
+  transition: background-color var(--transition-fast);
 
   &:focus {
+    background: var(--color-bg-primary);
+
     @include placeholder {
       opacity: 0;
     }

--- a/src/components/MultiSelect/MultiSelect.scss
+++ b/src/components/MultiSelect/MultiSelect.scss
@@ -9,8 +9,8 @@
 
 .dropdown {
   position: relative;
-  background: $inputBackgroundColor;
-  font-size: 16px;
+  background: var(--color-bg-secondary);
+  font-size: var(--text-base);
   width: 100%;
   overflow: hidden;
 }
@@ -24,10 +24,12 @@
 
 .menu {
   max-height: 200px;
-  border: 1px solid $blue;
-  background: white;
+  border: 1px solid var(--color-border-focus);
+  background: var(--color-bg-elevated);
   overflow: auto;
   overscroll-behavior: none;
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
 
   > *:last-child .option {
     border-bottom: none;
@@ -40,30 +42,32 @@
   white-space: normal;
   padding: 20px;
   line-height: 40px;
+  color: var(--color-text-primary);
 }
 
 .option {
   position: relative;
-  height: 48px;
-  line-height: 50px;
+  height: 44px;
+  line-height: 44px;
   padding: 0 50px 0 14px;
-  color: $blue;
-  border-bottom: 1px solid $borderGrey;
+  color: var(--color-text-primary);
+  border-bottom: 1px solid var(--color-border-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
+  transition: background var(--transition-fast);
 
   &:hover {
-    background: rgba(0, 0, 0, 0.1);
+    background: var(--color-interactive-hover);
 
     .unchecked {
-      background: white;
+      background: var(--color-bg-primary);
     }
   }
 }
 
 .option.disabled {
   &:hover {
-    background: white;
+    background: var(--color-bg-primary);
     cursor: default;
   }
 }
@@ -71,18 +75,18 @@
 .checked,
 .unchecked {
   position: absolute;
-  width: 32px;
-  height: 32px;
-  border-radius: 100%;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-full);
   top: 8px;
   right: 8px;
 }
 
 .unchecked {
-  background: #e0e0ea;
+  background: var(--color-border-primary);
 }
 .checked {
-  background: #00dc7c;
+  background: var(--color-accent-green);
 
   svg {
     position: absolute;
@@ -92,7 +96,7 @@
 }
 
 .current.placeholder {
-  color: $secondaryTextColor;
+  color: var(--color-text-tertiary);
   text-align: center;
 }
 
@@ -100,16 +104,13 @@
   background: none;
 }
 
-.dropdown.dense {
-  background: none;
-}
 .dense {
   .checked,
   .unchecked {
     position: absolute;
     width: 18px;
     height: 18px;
-    border-radius: 100%;
+    border-radius: var(--radius-full);
     top: 4px;
     right: 4px;
   }

--- a/src/components/MultiSelect/MultiSelectOption.react.js
+++ b/src/components/MultiSelect/MultiSelectOption.react.js
@@ -14,7 +14,7 @@ const MultiSelectOption = ({ checked, children, dense, disabled, ...other }) => 
 
   const icon = checked ? (
     <div className={styles.checked}>
-      <Icon width={dense ? 15 : 20} height={dense ? 15 : 20} name="check" fill="#ffffff" />
+      <Icon width={dense ? 15 : 20} height={dense ? 15 : 20} name="check" fill="var(--color-text-on-dark)" />
     </div>
   ) : (
     <div className={styles.unchecked} />

--- a/src/components/NonPrintableHighlighter/NonPrintableHighlighter.scss
+++ b/src/components/NonPrintableHighlighter/NonPrintableHighlighter.scss
@@ -15,94 +15,94 @@
 }
 
 .warningContainer {
-  margin-top: 8px;
+  margin-top: var(--space-2);
 }
 
 .warningBadge {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
+  gap: var(--space-2);
   width: 100%;
-  padding: 8px 10px;
-  background: #fff3cd;
-  border: 1px solid #ffc107;
-  border-radius: 4px;
+  padding: var(--space-2) var(--space-2);
+  background: var(--color-bg-warning);
+  border: 1px solid var(--color-accent-orange);
+  border-radius: var(--radius-md);
   cursor: pointer;
   user-select: none;
-  transition: background-color 0.15s ease;
+  transition: background-color var(--transition-fast);
 
   &:hover {
-    background: #ffe69c;
+    background: var(--color-bg-warning-hover);
   }
 
   &.expanded {
-    border-radius: 4px 4px 0 0;
-    border-bottom: 1px solid #ffc107;
+    border-radius: var(--radius-md) var(--radius-md) 0 0;
+    border-bottom: 1px solid var(--color-accent-orange);
   }
 }
 
 .warningIcon {
-  color: #856404;
-  font-size: 14px;
+  color: var(--color-text-warning);
+  font-size: var(--text-sm);
 }
 
 .warningText {
-  color: #856404;
-  font-size: 12px;
-  font-weight: 500;
+  color: var(--color-text-warning);
+  font-size: var(--text-xs);
+  font-weight: var(--font-weight-medium);
 }
 
 .detailsPanel {
-  padding: 10px 12px;
-  background: #fff8e1;
-  border: 1px solid #ffe082;
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-bg-warning);
+  border: 1px solid var(--color-accent-orange);
   border-top: none;
-  border-radius: 0 0 4px 4px;
+  border-radius: 0 0 var(--radius-md) var(--radius-md);
 }
 
 .charList {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: var(--space-2);
 }
 
 .charItem {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  padding: 3px 8px;
-  background: #fff;
-  border: 1px solid #ddd;
-  border-radius: 3px;
+  gap: var(--space-1);
+  padding: 3px var(--space-2);
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border-primary);
+  border-radius: var(--radius-sm);
 }
 
 .charLabel {
-  font-family: monospace;
+  @include MonospaceFont;
   font-size: 11px;
-  font-weight: 600;
-  color: #d32f2f;
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-accent-red);
 }
 
 .charCode {
-  font-family: monospace;
+  @include MonospaceFont;
   font-size: 10px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .charCount {
-  font-family: monospace;
-  font-size: 10px;
-  font-weight: 600;
-  color: #1976d2;
+  @include MonospaceFont;
+  font-size: var(--text-xs);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-accent-blue);
   margin-left: 2px;
 }
 
 .charPositions {
-  font-family: monospace;
+  @include MonospaceFont;
   font-size: 10px;
-  color: #888;
-  margin-left: 4px;
+  color: var(--color-text-secondary);
+  margin-left: var(--space-1);
 }
 
 // Info badge styles for non-alphanumeric character detection
@@ -114,50 +114,50 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
+  gap: var(--space-2);
   width: 100%;
-  padding: 8px 10px;
-  background: #e3f2fd;
-  border: 1px solid #2196f3;
-  border-radius: 4px;
+  padding: var(--space-2) var(--space-2);
+  background: var(--color-bg-info);
+  border: 1px solid var(--color-accent-blue);
+  border-radius: var(--radius-md);
   cursor: pointer;
   user-select: none;
-  transition: background-color 0.15s ease;
+  transition: background-color var(--transition-fast);
 
   &:hover {
-    background: #bbdefb;
+    background: var(--color-bg-info-hover);
   }
 
   &.expanded {
-    border-radius: 4px 4px 0 0;
-    border-bottom: 1px solid #2196f3;
+    border-radius: var(--radius-md) var(--radius-md) 0 0;
+    border-bottom: 1px solid var(--color-accent-blue);
   }
 }
 
 .infoIcon {
-  color: #1565c0;
-  font-size: 14px;
+  color: var(--color-accent-blue);
+  font-size: var(--text-sm);
 }
 
 .infoText {
-  color: #1565c0;
-  font-size: 12px;
-  font-weight: 500;
+  color: var(--color-accent-blue);
+  font-size: var(--text-xs);
+  font-weight: var(--font-weight-medium);
 }
 
 .infoDetailsPanel {
-  padding: 10px 12px;
-  background: #e8f4fd;
-  border: 1px solid #90caf9;
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-bg-info);
+  border: 1px solid var(--color-accent-blue);
   border-top: none;
-  border-radius: 0 0 4px 4px;
+  border-radius: 0 0 var(--radius-md) var(--radius-md);
 }
 
 .charLabelInfo {
-  font-family: monospace;
+  @include MonospaceFont;
   font-size: 11px;
-  font-weight: 600;
-  color: #1565c0;
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-accent-blue);
 }
 
 // Regex validation badge styles
@@ -169,62 +169,62 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
+  gap: var(--space-2);
   width: 100%;
-  padding: 8px 10px;
-  background: #e8f5e9;
-  border: 1px solid #4caf50;
-  border-radius: 4px;
+  padding: var(--space-2) var(--space-2);
+  background: var(--color-bg-success);
+  border: 1px solid var(--color-accent-green);
+  border-radius: var(--radius-md);
   cursor: pointer;
   user-select: none;
-  transition: background-color 0.15s ease;
+  transition: background-color var(--transition-fast);
 
   &:hover {
-    background: #c8e6c9;
+    background: var(--color-bg-success-hover);
   }
 
   &.expanded {
-    border-radius: 4px 4px 0 0;
-    border-bottom: 1px solid #4caf50;
+    border-radius: var(--radius-md) var(--radius-md) 0 0;
+    border-bottom: 1px solid var(--color-accent-green);
   }
 }
 
 .regexIcon {
-  color: #2e7d32;
-  font-size: 14px;
-  font-family: monospace;
+  color: var(--color-accent-green);
+  font-size: var(--text-sm);
+  @include MonospaceFont;
   font-weight: 700;
 }
 
 .regexText {
-  color: #2e7d32;
-  font-size: 12px;
-  font-weight: 500;
+  color: var(--color-accent-green);
+  font-size: var(--text-xs);
+  font-weight: var(--font-weight-medium);
 }
 
 .regexDetailsPanel {
-  padding: 10px 12px;
-  background: #f1f8e9;
-  border: 1px solid #a5d6a7;
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-bg-success);
+  border: 1px solid var(--color-accent-green);
   border-top: none;
-  border-radius: 0 0 4px 4px;
+  border-radius: 0 0 var(--radius-md) var(--radius-md);
 }
 
 .regexLabelValid {
-  font-family: monospace;
+  @include MonospaceFont;
   font-size: 11px;
-  font-weight: 600;
-  color: #2e7d32;
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-accent-green);
 }
 
 .regexLabelInvalid {
-  font-family: monospace;
+  @include MonospaceFont;
   font-size: 11px;
-  font-weight: 600;
-  color: #d32f2f;
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-accent-red);
 }
 
 .regexSummaryInvalid {
-  color: #d32f2f;
-  font-weight: 600;
+  color: var(--color-accent-red);
+  font-weight: var(--font-weight-semibold);
 }

--- a/src/components/NumberEditor/NumberEditor.scss
+++ b/src/components/NumberEditor/NumberEditor.scss
@@ -11,7 +11,7 @@
   position: absolute;
   top: 0;
   left: 0;
-  box-shadow: 0 1px 4px rgba(0,0,0,0.4);
+  box-shadow: var(--shadow-md);
 
   input {
     @include MonospaceFont;
@@ -19,7 +19,14 @@
     height: 30px;
     border: none;
     outline: none;
-    padding: 0 4px;
-    font-size: 12px;
+    padding: 0 var(--space-1);
+    font-size: var(--text-xs);
+    background: var(--color-bg-elevated);
+    color: var(--color-text-primary);
+    transition: background var(--transition-fast);
+
+    &:focus {
+      background: var(--color-bg-primary);
+    }
   }
 }

--- a/src/components/PasswordStrength/PasswordStrength.scss
+++ b/src/components/PasswordStrength/PasswordStrength.scss
@@ -16,42 +16,43 @@
 .grey, .red, .yellow, .green {
   width: 5px;
   height: 5px;
-  border-radius: 5px;
+  border-radius: var(--radius-full);
   margin-bottom: 3px;
-  transition: background 0.3s cubic-bezier(0.175,0.885,0.32,1.275);
+  transition: background var(--transition-fast) cubic-bezier(0.175,0.885,0.32,1.275);
 }
 
 .grey {
-  background: #babaca;
+  background: var(--color-border-primary);
 }
 
 .red {
-  background: $red;
+  background: var(--color-accent-red);
 }
 
 .yellow {
-  background: $yellow;
+  background: var(--color-accent-orange);
 }
 
 .green {
-  background: $green;
+  background: var(--color-accent-green);
 }
 
 .tip {
   position: absolute;
-  padding: 6px;
-  border-radius: 5px;
-  background: rgba(0,0,0,0.7);
-  color: white;
-  font-size: 13px;
+  padding: var(--space-2);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-elevated);
+  color: var(--color-text-primary);
+  font-size: var(--text-sm);
   top: -36px;
   left: -99999px;
   opacity: 0;
-  transition: opacity 0.3s ease;
+  transition: opacity var(--transition-fast);
   white-space: nowrap;
+  box-shadow: var(--shadow-overlay);
 
   &:after {
-    @include arrow('down', 7px, 5px, rgba(0,0,0,0.7));
+    @include arrow('down', 7px, 5px, var(--color-bg-elevated));
     content: '';
     position: absolute;
     bottom: -5px;

--- a/src/components/PermissionsDialog/PermissionsDialog.scss
+++ b/src/components/PermissionsDialog/PermissionsDialog.scss
@@ -7,354 +7,369 @@
  */
  @import 'stylesheets/globals.scss';
 
- $labelWidth: 330px;
- $colWidth: 82px;
- $writeColWidth: 92px;
- $addFieldColWidth: 118px;
- $deleteColWidth: 44px;
+$labelWidth: 330px;
+$colWidth: 82px;
+$writeColWidth: 92px;
+$addFieldColWidth: 118px;
+$deleteColWidth: 44px;
 
- $sumReadColsWidth: calc(3 * #{$colWidth});
- $sumWriteColsWidth: calc(3 * #{$writeColWidth});
+$sumReadColsWidth: calc(3 * #{$colWidth});
+$sumWriteColsWidth: calc(3 * #{$writeColWidth});
 
- $permissionsDialogWidth: calc(#{$labelWidth} + (2 * #{$colWidth}) + #{$deleteColWidth});
- $permissionsDialogMaxWidth: calc(#{$labelWidth} + #{$sumReadColsWidth} + #{$sumWriteColsWidth} + #{$addFieldColWidth} + #{$deleteColWidth});
+$permissionsDialogWidth: calc(#{$labelWidth} + (2 * #{$colWidth}) + #{$deleteColWidth});
+$permissionsDialogMaxWidth: calc(#{$labelWidth} + #{$sumReadColsWidth} + #{$sumWriteColsWidth} + #{$addFieldColWidth} + #{$deleteColWidth});
 
- $simplePointerWriteWidth: calc( #{$colWidth} + #{$addFieldColWidth});
- $pointerWriteWidth: calc( #{$sumWriteColsWidth} + #{$addFieldColWidth});
+$simplePointerWriteWidth: calc( #{$colWidth} + #{$addFieldColWidth});
+$pointerWriteWidth: calc( #{$sumWriteColsWidth} + #{$addFieldColWidth});
 
- $clpDialogWidth: calc(#{$permissionsDialogWidth} + #{$addFieldColWidth});
+$clpDialogWidth: calc(#{$permissionsDialogWidth} + #{$addFieldColWidth});
 
- .dialog {
-   @include modalAnimation();
-   position: absolute;
-   top: 50%;
-   left: 50%;
-   width: $permissionsDialogWidth;
-   background: white;
-   border-radius: 5px;
-   overflow: hidden;
-   transition: width 0.3s 0.15s ease-out;
- }
-
- .clp{
-   width: $clpDialogWidth;
-
-   .level{
-     width: $clpDialogWidth;
-   }
-   // 118px for add field in CLP only
-   .fourth {
-     width: $addFieldColWidth;
-   }
- }
-
- .clp.advanced{
-   .fourth {
-     width: $colWidth;
-   }
- }
-
- .header {
-   height: 50px;
-   background: $blue;
-   position: relative;
-   color: #ffffff;
-   line-height: 50px;
-   font-size: 16px;
-   text-align: center;
-
-   .settings {
-     position: absolute;
-     top: 15px;
-     right: 15px;
-     cursor: pointer;
-
-     svg {
-       fill: #0E69A1;
-       vertical-align: top;
-     }
-
-     &:hover svg {
-       fill: #094367;
-     }
-   }
-
-   .arrow {
-     position: absolute;
-     @include arrow('up', 12px, 6px, #0E69A1);
-     top: 44px;
-     right: 19px;
-   }
- }
-
-
- .level {
-   height: 50px;
-   width: $permissionsDialogWidth; //   width: 658px;
-   background: #0E69A1;
-   position: relative;
-   color: white;
-   transition: width 0.3s 0.15s ease-out;
-
-   > div {
-     margin: 0;
-     position: absolute;
-     top: 10px;
-     right: 10px;
-   }
-
-   > span {
-     display: inline-block;
-     font-size: 12;
-     height: 50px;
-     line-height: 50px;
-     padding-left: 20px;
-   }
- }
-
- .tableWrap {
-   height: 300px;
-   overflow-y: auto;
-   overflow-x: hidden;
- }
-
- .second, .third, .fourth {
-   width: $colWidth;
- }
- .fifth, .sixth, .seventh {
-   width: $writeColWidth;
- }
- .eighth {
-   width: $addFieldColWidth;
- }
- .nineth {
-   width: $deleteColWidth;
- }
-
- .table {
-   position: relative;
-   min-height:300px;
-
-   .overlay {
-     position: absolute;
-     top: 0;
-     bottom: 0;
-     pointer-events: none;
-     background: rgba(0,0,40,0.03);
-
-     &.second {
-       left: $labelWidth;
-     }
-     &.fourth {
-       left: calc(#{$labelWidth} + (2 * #{$colWidth}));
-     }
-     &.sixth {
-       left: calc(#{$labelWidth} + #{$sumReadColsWidth} + #{$writeColWidth});
-     }
-     &.eighth {
-       left: calc(#{$labelWidth} + #{$sumReadColsWidth} + #{$sumWriteColsWidth});
-     }
-   }
- }
-
- .footer {
-   position: relative;
-   height: 51px;
-   border-top: 1px solid #e3e3ea;
-
-   .details {
-     font-size: 12px;
-     padding-left: 20px;
-
-     a {
-       color: $blue;
-     }
-   }
-
-   .actions {
-     float: right;
-     padding: 10px 15px;
-
-     button {
-       margin-left: 10px;
-     }
-   }
- }
-
- .headers {
-   overflow: hidden;
-   transition: height .3s cubic-bezier(0.645,0.045,0.355,1) .5s;
-   background: #56AEE3;
-   height: 0;
-   padding-left: $labelWidth;
-   text-align: center;
-   color: white;
-   font-size: 12px;
-
-   div {
-     float: left;
-     border-left: 1px solid white;
-     height: 20px;
-     line-height: 20px;
-     vertical-align: top;
-   }
- }
-
- .readHeader {
-   width: $sumReadColsWidth;
- }
-
- .writeHeader {
-   width: $sumWriteColsWidth;
- }
-
- .addHeader {
-   width: $addFieldColWidth;
-   border-right: 1px solid white;
- }
-
- .advanced {
-   width: $permissionsDialogMaxWidth;
-
-   .level {
-     width: $permissionsDialogMaxWidth;
-   }
-
-   .headers {
-     height: 20px;
-   }
- }
-
- .row {
-  display: flex;
-  min-height: 50px;
-  height: 100%;
-  vertical-align: middle;
-  font-size: 15px;
-  border-bottom: 1px solid #e3e3ea;
-  white-space: nowrap;
-
-   &:nth-child(odd) {
-     background: rgba(14, 105, 161, 0.03);
-   }
- }
-
- .row.public {
-   background: rgba(22, 156, 238, 0.18);
-   border-bottom: 1px solid #0E69A1;
-   color: $blue;
- }
-
-
- .label {
-  display: inline-flex;
-  width: $labelWidth;
-  padding: 0 20px;
-  flex-direction: column;
-  align-self: center;
+.dialog {
+  @include modalAnimation();
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: $permissionsDialogWidth;
+  background: var(--color-bg-elevated);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  transition: width 0.3s 0.15s ease-out;
+  box-shadow: var(--shadow-overlay);
 }
 
- .check {
-   display: inline-flex;
-   flex-direction: column;
-   align-self: center;
-   text-align: center;
+.clp{
+  width: $clpDialogWidth;
 
-   > svg {
-     fill: $blue;
-     vertical-align: middle;
-     align-self: center;
-   }
- }
+  .level{
+    width: $clpDialogWidth;
+  }
+  // 118px for add field in CLP only
+  .fourth {
+    width: $addFieldColWidth;
+  }
+}
 
- .pointerRead {
-   display: inline-block;
-   width: $sumReadColsWidth;
-   padding: 5px 10px;
- }
+.clp.advanced{
+  .fourth {
+    width: $colWidth;
+  }
+}
 
- .pointerWrite {
-   width: $simplePointerWriteWidth;
-   padding: 0px 10px;
-   display: inline-block;
- }
+.header {
+  height: 50px;
+  background: var(--color-accent-blue);
+  position: relative;
+  color: var(--color-text-on-dark);
+  line-height: 50px;
+  font-size: var(--text-lg);
+  text-align: center;
 
- .checkboxWrap {
-   position: relative;
-   vertical-align: top;
-   border: 1px solid #e3e3ea;
-   height: 40px;
-   line-height: 40px;
-   text-align: center;
-   border-radius: 5px;
-   background: white;
- }
+  .settings {
+    position: absolute;
+    top: 15px;
+    right: 15px;
+    cursor: pointer;
 
- .entry {
-   height: 30px;
-   width: 290px;
-   border: 1px solid $mainTextColor;
-   border-radius: 5px;
-   font-size: 14px;
-   outline: none;
-   padding: 0 6px;
-   margin: 10px 0 0 20px;
-   vertical-align: top;
- }
+    svg {
+      fill: var(--color-text-on-dark-muted);
+      vertical-align: top;
+      transition: fill var(--transition-fast);
+    }
 
- .error {
-   border-color: $red;
-   color: $red;
- }
+    &:hover svg {
+      fill: var(--color-text-on-dark);
+    }
+  }
 
- .delete {
-   display: inline-block;
-   vertical-align: top;
-   width: 32px;
-   height: 50px;
-   padding-top: 15px;
-   text-align: right;
+  .arrow {
+    position: absolute;
+    @include arrow('up', 12px, 6px, var(--color-accent-blue-hover));
+    top: 44px;
+    right: 19px;
+  }
+}
 
-   button {
-     @include buttonReset;
-   }
 
-   svg {
-     vertical-align: top;
-     cursor: pointer;
-     fill: #C1C7CD;
+.level {
+  height: 50px;
+  width: $permissionsDialogWidth;
+  background: var(--color-accent-blue-hover);
+  position: relative;
+  color: var(--color-text-on-dark);
+  transition: width 0.3s 0.15s ease-out;
 
-     &:hover {
-       fill: $red;
-     }
-   }
- }
+  > div {
+    margin: 0;
+    position: absolute;
+    top: 10px;
+    right: 10px;
+  }
 
- .pillHolder{
-   max-width: 100px;
-   position: relative;
-   display: inline-block;
-   top: 5px;
- }
+  > span {
+    display: inline-block;
+    font-size: var(--text-xs);
+    height: 50px;
+    line-height: 50px;
+    padding-left: var(--space-5);
+  }
+}
 
- .pillType{
-  width: auto;
+.tableWrap {
+  height: 300px;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.second, .third, .fourth {
+  width: $colWidth;
+}
+.fifth, .sixth, .seventh {
+  width: $writeColWidth;
+}
+.eighth {
+  width: $addFieldColWidth;
+}
+.nineth {
+  width: $deleteColWidth;
+}
+
+.table {
+  position: relative;
+  min-height:300px;
+
+  .overlay {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    pointer-events: none;
+    background: var(--color-interactive-hover);
+
+    &.second {
+      left: $labelWidth;
+    }
+    &.fourth {
+      left: calc(#{$labelWidth} + (2 * #{$colWidth}));
+    }
+    &.sixth {
+      left: calc(#{$labelWidth} + #{$sumReadColsWidth} + #{$writeColWidth});
+    }
+    &.eighth {
+      left: calc(#{$labelWidth} + #{$sumReadColsWidth} + #{$sumWriteColsWidth});
+    }
+  }
+}
+
+.footer {
+  position: relative;
+  height: 51px;
+  border-top: 1px solid var(--color-border-primary);
+
+  .details {
+    font-size: var(--text-xs);
+    padding-left: var(--space-5);
+
+    a {
+      color: var(--color-accent-blue);
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+
+  .actions {
+    float: right;
+    padding: var(--space-3) var(--space-4);
+
+    button {
+      margin-left: var(--space-3);
+    }
+  }
+}
+
+.headers {
+  overflow: hidden;
+  transition: height .3s cubic-bezier(0.645,0.045,0.355,1) .5s;
+  background: var(--color-accent-blue);
+  height: 0;
+  padding-left: $labelWidth;
+  text-align: center;
+  color: var(--color-text-on-dark);
+  font-size: var(--text-xs);
+
+  div {
+    float: left;
+    border-left: 1px solid var(--color-text-on-dark);
+    height: 20px;
+    line-height: 20px;
+    vertical-align: top;
+  }
+}
+
+.readHeader {
+  width: $sumReadColsWidth;
+}
+
+.writeHeader {
+  width: $sumWriteColsWidth;
+}
+
+.addHeader {
+  width: $addFieldColWidth;
+  border-right: 1px solid var(--color-text-on-dark);
+}
+
+.advanced {
+  width: $permissionsDialogMaxWidth;
+
+  .level {
+    width: $permissionsDialogMaxWidth;
+  }
+
+  .headers {
+    height: 20px;
+  }
+}
+
+.row {
+ display: flex;
+ min-height: 50px;
+ height: 100%;
+ vertical-align: middle;
+ font-size: var(--text-base);
+ border-bottom: 1px solid var(--color-border-primary);
+ white-space: nowrap;
+ transition: background var(--transition-fast);
+
+  &:nth-child(odd) {
+    background: var(--color-interactive-hover);
+  }
+}
+
+.row.public {
+  background: var(--color-accent-blue-light);
+  border-bottom: 1px solid var(--color-accent-blue-hover);
+  color: var(--color-accent-blue);
+}
+
+
+.label {
+ display: inline-flex;
+ width: $labelWidth;
+ padding: 0 var(--space-5);
+ flex-direction: column;
+ align-self: center;
+}
+
+.check {
   display: inline-flex;
-  height: 20;
-  padding: 2px 8px 0 8px;
+  flex-direction: column;
+  align-self: center;
+  text-align: center;
+
+  > svg {
+    fill: var(--color-accent-blue);
+    vertical-align: middle;
+    align-self: center;
+  }
+}
+
+.pointerRead {
+  display: inline-block;
+  width: $sumReadColsWidth;
+  padding: var(--space-1) var(--space-3);
+}
+
+.pointerWrite {
+  width: $simplePointerWriteWidth;
+  padding: 0 var(--space-3);
+  display: inline-block;
+}
+
+.checkboxWrap {
+  position: relative;
+  vertical-align: top;
+  border: 1px solid var(--color-border-primary);
+  height: 40px;
+  line-height: 40px;
+  text-align: center;
+  border-radius: var(--radius-md);
+  background: var(--color-bg-primary);
+}
+
+.entry {
+  height: 30px;
+  width: 290px;
+  border: 1px solid var(--color-border-primary);
+  border-radius: var(--radius-md);
+  font-size: var(--text-base);
+  outline: none;
+  padding: 0 var(--space-2);
+  margin: var(--space-3) 0 0 var(--space-5);
+  vertical-align: top;
+  background: var(--color-bg-primary);
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+
+  &:focus {
+    border-color: var(--color-border-focus);
+    box-shadow: 0 0 0 2px var(--color-accent-blue-light);
+  }
+}
+
+.error {
+  border-color: var(--color-accent-red);
+  color: var(--color-accent-red);
+}
+
+.delete {
+  display: inline-block;
+  vertical-align: top;
+  width: 32px;
+  height: 50px;
+  padding-top: 15px;
+  text-align: right;
+
+  button {
+    @include buttonReset;
+  }
+
+  svg {
+    vertical-align: top;
+    cursor: pointer;
+    fill: var(--color-text-tertiary);
+    transition: fill var(--transition-fast);
+
+    &:hover {
+      fill: var(--color-accent-red);
+    }
+  }
+}
+
+.pillHolder{
+  max-width: 100px;
+  position: relative;
+  display: inline-block;
+  top: 5px;
+}
+
+.pillType{
+ width: auto;
+ display: inline-flex;
+ height: 20;
+ padding: 2px var(--space-2) 0 var(--space-2);
 }
 
 .prefix {
-  color:  #0E69A1;
+  color: var(--color-accent-blue-hover);
 }
 
 .hint{
-  color: $secondaryTextColor;
-  font-size: 0.8em;
+  color: var(--color-text-secondary);
+  font-size: var(--text-xs);
 }
 
 .selectable{
-   user-select: text;
+  user-select: text;
 }
 
  @include modalKeyframes();

--- a/src/components/Pill/Pill.react.js
+++ b/src/components/Pill/Pill.react.js
@@ -30,12 +30,12 @@ const Pill = ({
     </span>
     {followClick && (
       <a onClick={e => !e.metaKey && onClick()}>
-        <Icon name="right-outline" width={20} height={20} fill="#1669a1" />
+        <Icon name="right-outline" width={20} height={20} fill="var(--color-accent-blue)" />
       </a>
     )}
     {!followClick && fileDownloadLink && (
       <a href={fileDownloadLink} target="_blank" rel="noreferrer">
-        <Icon name="right-outline" width={20} height={20} fill="#1669a1" />
+        <Icon name="right-outline" width={20} height={20} fill="var(--color-accent-blue)" />
       </a>
     )}
   </span>

--- a/src/components/Pill/Pill.scss
+++ b/src/components/Pill/Pill.scss
@@ -8,13 +8,13 @@
 @import 'stylesheets/globals.scss';
 
 .pill {
-  @include MonospaceFont;
+  @include UIFont;
   position: relative;
   display: inline-block;
-  color: #0E69A1;
+  color: var(--color-cell-text);
   height: 20px;
   line-height: 20px;
-  border-radius: 10px;
+  border-radius: var(--radius-sm);
   font-size: 11px;
   width: 100%;
   overflow: hidden;
@@ -25,7 +25,7 @@
     right: 0;
     height: 20px;
     width: 20px;
-    background: #d6e5f2;
+    background: var(--color-interactive-hover);
     border-radius: 50%;
     margin-left: 5px;
     & svg  {

--- a/src/components/PlatformCard/PlatformCard.scss
+++ b/src/components/PlatformCard/PlatformCard.scss
@@ -10,11 +10,17 @@
 .card {
   width: 200px;
   height: 80px;
-  background-color: $lightGrey;
-  border-radius: 5px;
-  padding: 10px;
+  background-color: var(--color-bg-tertiary);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
   display: table;
   table-layout: fixed;
+  transition: box-shadow var(--transition-fast), background-color var(--transition-fast);
+
+  &:hover {
+    background-color: var(--color-interactive-hover);
+    box-shadow: var(--shadow-sm);
+  }
 }
 
 .left {
@@ -25,14 +31,16 @@
 
 .right {
   display: table-cell;
-  padding-left: 20px;
+  padding-left: var(--space-5);
   vertical-align: middle;
 }
 
 .name {
-  color: $platformCardTextColor;
+  color: var(--color-text-primary);
+  font-weight: var(--font-weight-medium);
 }
 
 .subtitle {
-  color: $platformCardSecondaryTextColor;
+  color: var(--color-text-secondary);
+  font-size: var(--text-xs);
 }

--- a/src/components/ProtectedFieldsDialog/ProtectedFieldsDialog.scss
+++ b/src/components/ProtectedFieldsDialog/ProtectedFieldsDialog.scss
@@ -25,28 +25,29 @@ $permissionsDialogWidth: calc(
   top: 50%;
   left: 50%;
   width: $permissionsDialogWidth;
-  background: white;
-  border-radius: 5px;
+  background: var(--color-bg-elevated);
+  border-radius: var(--radius-lg);
   overflow: hidden;
   transition: width 0.3s 0.15s ease-out;
+  box-shadow: var(--shadow-overlay);
 }
 
 .header {
   height: 50px;
-  background: $blue;
+  background: var(--color-accent-blue);
   position: relative;
-  color: #ffffff;
+  color: var(--color-text-on-dark);
   line-height: 50px;
-  font-size: 16px;
+  font-size: var(--text-lg);
   text-align: center;
 }
 
 .level {
   height: 50px;
-  width: $permissionsDialogWidth; //   width: 658px;
-  background: #0e69a1;
+  width: $permissionsDialogWidth;
+  background: var(--color-accent-blue-hover);
   position: relative;
-  color: white;
+  color: var(--color-text-on-dark);
   transition: width 0.3s 0.15s ease-out;
 
   > div {
@@ -58,10 +59,10 @@ $permissionsDialogWidth: calc(
 
   > span {
     display: inline-block;
-    font-size: 12;
+    font-size: var(--text-xs);
     height: 50px;
     line-height: 50px;
-    padding-left: 20px;
+    padding-left: var(--space-5);
   }
 }
 
@@ -84,7 +85,7 @@ $permissionsDialogWidth: calc(
     top: 0;
     bottom: 0;
     pointer-events: none;
-    background: rgba(0, 0, 40, 0.03);
+    background: var(--color-interactive-hover);
 
     &.second {
       left: $labelWidth;
@@ -95,23 +96,27 @@ $permissionsDialogWidth: calc(
 .footer {
   position: relative;
   height: 51px;
-  border-top: 1px solid #e3e3ea;
+  border-top: 1px solid var(--color-border-primary);
 
   .details {
-    font-size: 12px;
-    padding-left: 20px;
+    font-size: var(--text-xs);
+    padding-left: var(--space-5);
 
     a {
-      color: $blue;
+      color: var(--color-accent-blue);
+
+      &:hover {
+        text-decoration: underline;
+      }
     }
   }
 
   .actions {
     float: right;
-    padding: 10px 15px;
+    padding: var(--space-3) var(--space-4);
 
     button {
-      margin-left: 10px;
+      margin-left: var(--space-3);
     }
   }
 }
@@ -126,25 +131,26 @@ $permissionsDialogWidth: calc(
   min-height: 50px;
   height: 100%;
   vertical-align: middle;
-  font-size: 15px;
-  border-bottom: 1px solid #e3e3ea;
+  font-size: var(--text-base);
+  border-bottom: 1px solid var(--color-border-primary);
   white-space: nowrap;
+  transition: background var(--transition-fast);
 
   &:nth-child(odd) {
-    background: rgba(14, 105, 161, 0.03);
+    background: var(--color-interactive-hover);
   }
 }
 
 .row.public {
-  background: rgba(22, 156, 238, 0.18);
-  border-bottom: 1px solid #0e69a1;
-  color: $blue;
+  background: var(--color-accent-blue-light);
+  border-bottom: 1px solid var(--color-accent-blue-hover);
+  color: var(--color-accent-blue);
 }
 
 .label {
   display: inline-flex;
   width: $labelWidth;
-  padding: 0 20px;
+  padding: 0 var(--space-5);
   flex-direction: column;
   align-self: center;
 }
@@ -152,18 +158,25 @@ $permissionsDialogWidth: calc(
 .entry {
   height: 30px;
   width: $entryWidth;
-  border: 1px solid $mainTextColor;
-  border-radius: 5px;
-  font-size: 14px;
+  border: 1px solid var(--color-border-primary);
+  border-radius: var(--radius-md);
+  font-size: var(--text-base);
   outline: none;
-  padding: 0 6px;
-  margin: 10px $entryMargin;
+  padding: 0 var(--space-2);
+  margin: var(--space-3) $entryMargin;
   vertical-align: top;
+  background: var(--color-bg-primary);
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+
+  &:focus {
+    border-color: var(--color-border-focus);
+    box-shadow: 0 0 0 2px var(--color-accent-blue-light);
+  }
 }
 
 .error {
-  border-color: $red;
-  color: $red;
+  border-color: var(--color-accent-red);
+  color: var(--color-accent-red);
   overflow: hidden;
   white-space: normal;
 }
@@ -183,10 +196,11 @@ $permissionsDialogWidth: calc(
   svg {
     vertical-align: top;
     cursor: pointer;
-    fill: #c1c7cd;
+    fill: var(--color-text-tertiary);
+    transition: fill var(--transition-fast);
 
     &:hover {
-      fill: $red;
+      fill: var(--color-accent-red);
     }
   }
 }
@@ -196,14 +210,14 @@ $permissionsDialogWidth: calc(
   overflow: hidden;
   display: inline-flex;
   align-self: center;
-  padding-left: 4px;
+  padding-left: var(--space-1);
 }
 
 .pillType {
   width: auto;
   display: inline-flex;
   height: 20;
-  padding: 2px 8px 0 8px;
+  padding: 2px var(--space-2) 0 var(--space-2);
 }
 
 .multiselect {
@@ -215,14 +229,14 @@ $permissionsDialogWidth: calc(
 }
 
 .hint {
-  color: $secondaryTextColor;
-  font-size: 0.8em;
+  color: var(--color-text-secondary);
+  font-size: var(--text-xs);
 }
 .selectable {
   user-select: text;
 }
 .prefix {
-  color: #0e69a1;
+  color: var(--color-accent-blue-hover);
 }
 
 .suggestions {
@@ -233,8 +247,8 @@ $permissionsDialogWidth: calc(
 
 .entry input {
   width: $entryWidth !important;
-  padding: 0 6px;
-  margin: 10px 20px;
+  padding: 0 var(--space-2);
+  margin: var(--space-3) var(--space-5);
 }
 
 @include modalKeyframes();

--- a/src/components/PushAudienceDialog/InstallationCondition.scss
+++ b/src/components/PushAudienceDialog/InstallationCondition.scss
@@ -10,14 +10,15 @@
 .conditionInput {
   float: left;
   width: 210px;
-  border-right: 2px solid white;
+  border-right: 2px solid var(--color-bg-primary);
 }
 
 //custom label
 .description {
-  margin-top: 2px;
-  color: $pink;
+  margin-top: var(--space-1);
+  color: var(--color-accent-red);
   @include buttonReset;
+  font-size: var(--text-xs);
 }
 
 .valueInput {
@@ -28,19 +29,24 @@
 .date {
   input {
     position: relative;
-    background: #f6fafb;
-    font-size: 16px;
+    background: var(--color-bg-secondary);
+    font-size: var(--text-lg);
     height: 80px;
     width: 100%;
     overflow: hidden;
     border: 0;
-    padding: 0 5px;
+    padding: 0 var(--space-2);
+    transition: background var(--transition-fast);
+
+    &:focus {
+      background: var(--color-interactive-hover);
+    }
   }
 }
 
 .empty {
   position: relative;
-  background: #B0B1B1;
+  background: var(--color-text-tertiary);
   font-size: 30px;
   line-height: 80px;
   text-align: center;

--- a/src/components/PushAudienceDialog/PushAudienceDialog.scss
+++ b/src/components/PushAudienceDialog/PushAudienceDialog.scss
@@ -9,13 +9,13 @@
 
 .addConditions {
   text-align: center;
-  padding: 25px 20px;
+  padding: var(--space-6) var(--space-5);
   border-style: solid;
-  border-color: $borderGrey;
+  border-color: var(--color-border-primary);
   border-width: 1px 1px 0 1px;
 
   &.nonEmptyConditions {
-    padding: 4px;
+    padding: var(--space-1);
     a {
      border: none;
     }
@@ -23,7 +23,7 @@
 }
 
 .footer {
-  padding: 17px 28px;
+  padding: var(--space-4) var(--space-7);
   text-align: right;
 
   &:nth-child(2) {
@@ -31,7 +31,7 @@
   }
 
   > * {
-    margin: 0 12px 0 0;
+    margin: 0 var(--space-3) 0 0;
 
     &:last-child {
       margin-right: 0;
@@ -44,19 +44,20 @@
   text-align: left;
 
   .audienceSizeText {
-    font-weight: 700;
+    font-weight: var(--font-weight-semibold);
     font-size: 10px;
     letter-spacing: 1.6px;
-    color: $secondaryTextColor;
+    color: var(--color-text-secondary);
+    text-transform: uppercase;
   }
 
   .audienceSizeDescription {
-    margin-top: 2px;
-    color: $blue;
+    margin-top: var(--space-1);
+    color: var(--color-accent-blue);
   }
 }
 
 .filter {
   max-height: 50vh;
-  overflow-y: scroll;
+  overflow-y: auto;
 }

--- a/src/components/PushAudiencesSelector/PushAudiencesOption.react.js
+++ b/src/components/PushAudiencesSelector/PushAudiencesOption.react.js
@@ -80,7 +80,7 @@ export default class PushAudiencesOption extends PushAudiencesBaseRow {
             <div className={styles.headline}>
               {this.props.icon ? (
                 <div className={styles.icon}>
-                  <Icon width={18} height={18} fill="#343445" name={this.props.icon} />
+                  <Icon width={18} height={18} fill="var(--color-text-primary)" name={this.props.icon} />
                 </div>
               ) : null}
               <span style={this.props.icon ? { verticalAlign: 'top', paddingLeft: 5 } : {}}>

--- a/src/components/PushAudiencesSelector/PushAudiencesOption.scss
+++ b/src/components/PushAudiencesSelector/PushAudiencesOption.scss
@@ -6,47 +6,58 @@
  * the root directory of this source tree.
  */
 @import 'stylesheets/globals.scss';
+
 //select width values are hardcoded
 //current usecase is fixed width container
 .row {
   width: 100%;
   display: block;
-  padding: 15px 20px;
+  padding: var(--space-4) var(--space-5);
   cursor: pointer;
   float: left;
+  transition: background var(--transition-fast);
+
   .radiobutton {
     float: left;
-    margin-right: 10px;
+    margin-right: var(--space-3);
   }
+
   &:nth-child(even) {
-    background: #f2f6f8;
+    background: var(--color-bg-secondary);
   }
+
   &:nth-child(odd) {
-    background: #fbfbfc;
+    background: var(--color-bg-secondary);
   }
+
   &:hover {
-    background: #EAEAEA;
+    background: var(--color-interactive-hover);
   }
+
   &.everyone {
     .audienceInfo {
-      margin-top: 7px;
+      margin-top: var(--space-2);
     }
   }
+
   .cell {
     display: inline-block;
-    margin-top: 7px;
+    margin-top: var(--space-2);
   }
+
   .col1 {
     width: 50%;
     float: left;
     margin-top: 0;
   }
+
   .col2 {
     width: 20%;
-    margin-top: 7px;
+    margin-top: var(--space-2);
   }
+
   .input {
-    margin-right: 12px;
+    margin-right: var(--space-3);
     position: relative;
     top: -2px;
   }
@@ -55,23 +66,26 @@
     margin-left: 30px;
 
     .headline {
-      font-size: 14px;
+      font-size: var(--text-sm);
+      font-weight: var(--font-weight-medium);
+      color: var(--color-text-primary);
     }
 
     .subline {
-      font-size: 12px;
+      font-size: var(--text-xs);
+      color: var(--color-text-secondary);
     }
 
     .shortInfo {
-    	@include ellipsis();
-      margin-right: 5px;
+      @include ellipsis();
+      margin-right: var(--space-2);
       max-width: 190px;
       float: left;
     }
 
     .longInfo {
       overflow: hidden;
-      margin: 10px 10px 0 0;
+      margin: var(--space-3) var(--space-3) 0 0;
 
       .platformInfo {
         float: left;
@@ -83,13 +97,20 @@
       }
 
       .detailsHeaderListItem {
-        color: $secondaryTextColor;
+        color: var(--color-text-secondary);
+        font-size: var(--text-xs);
       }
     }
 
     .moreDetails {
       @include buttonReset;
-      color: $blue;
+      color: var(--color-accent-blue);
+      font-size: var(--text-xs);
+      transition: color var(--transition-fast);
+
+      &:hover {
+        color: var(--color-accent-blue-hover);
+      }
 
       &.hideMoreDetails {
         display: none;

--- a/src/components/PushAudiencesSelector/PushAudiencesSelector.scss
+++ b/src/components/PushAudiencesSelector/PushAudiencesSelector.scss
@@ -6,32 +6,40 @@
  * the root directory of this source tree.
  */
 @import 'stylesheets/globals.scss';
+
 .container {
   position: relative;
   width: 100%;
   overflow: hidden;
   min-height: 200px;
+
   .header {
     position: absolute;
     top: 0;
     left: 0;
     width: 100%;
-    color: white;
-    background: #66637A;
-    padding: 8px 20px 6px 20px;
-    font-size: 14px;
+    color: var(--color-text-on-dark);
+    background: var(--color-text-secondary);
+    padding: var(--space-2) var(--space-5) var(--space-2) var(--space-5);
+    font-size: var(--text-sm);
+    font-weight: var(--font-weight-medium);
+    letter-spacing: 0.3px;
   }
+
   .body {
     padding-top: 31px;
     max-height: 400px;
     overflow: auto;
   }
+
   .cell {
     display: inline-block;
   }
+
   .col1 {
     width: 50%;
   }
+
   .col2 {
     width: 20%;
   }

--- a/src/components/PushExperimentDropdown/PushExperimentDropdown.scss
+++ b/src/components/PushExperimentDropdown/PushExperimentDropdown.scss
@@ -6,15 +6,15 @@
  * the root directory of this source tree.
  */
 @import 'stylesheets/globals.scss';
-       
+
 .dropdown {
   display: inline-block;
   vertical-align: top;
   height: 32px;
   text-align: left;
   white-space: nowrap;
-  font-size: 14px;
-  margin-right: 10px;
+  font-size: var(--text-sm);
+  margin-right: var(--space-3);
 
   &:nth-last-child(2) {
     margin-right: 0;
@@ -22,18 +22,18 @@
 }
 
 .current, .menu {
-  background: $white;
-  border-radius: $borderRadiusConst;
-  border: 1px solid $blue;
-  color: $blue;
+  background: var(--color-bg-primary);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-accent-blue);
+  color: var(--color-accent-blue);
   cursor: pointer;
 
   &.red {
-    border-color: $red;
+    border-color: var(--color-accent-red);
   }
 
   &.green {
-    border-color: $green;
+    border-color: var(--color-accent-green);
   }
 
   &.blueGreen {
@@ -49,7 +49,8 @@
   position: relative;
   height: 30px;
   line-height: 30px;
-  padding: 0 30px 0 10px;
+  padding: 0 var(--space-7) 0 var(--space-3);
+  transition: background var(--transition-fast);
 
   div {
     overflow-x: hidden;
@@ -61,21 +62,25 @@
     position: absolute;
     content: '';
     top: 12px;
-    right: 10px;
+    right: var(--space-3);
+  }
+
+  &:hover {
+    background: var(--color-interactive-hover);
   }
 
   &.green {
-    color: $green;
+    color: var(--color-accent-green);
     &:after {
       @include arrow('down', 12px, 8px, $green);
-    }    
+    }
   }
 
   &.red {
-    color: $red;
+    color: var(--color-accent-red);
     &:after {
       @include arrow('down', 12px, 8px, $red);
-    }    
+    }
   }
 
   &.blueGreen {
@@ -96,17 +101,19 @@
 .menu {
   max-height: 360px;
   overflow-y: auto;
-  font-size: 14px;
-  border: 1px solid $blue;
+  font-size: var(--text-sm);
+  border: 1px solid var(--color-accent-blue);
+  box-shadow: var(--shadow-sm);
 
   div {
     height: 30px;
     line-height: 30px;
-    padding: 0 10px;
+    padding: 0 var(--space-3);
+    transition: background var(--transition-fast), color var(--transition-fast);
 
     &:hover {
-      background: rgba($blue, 0.1);
-      color: $white;
+      background: var(--color-interactive-hover);
+      color: var(--color-accent-blue);
     }
   }
 }

--- a/src/components/PushOpenRate/PushOpenRate.scss
+++ b/src/components/PushOpenRate/PushOpenRate.scss
@@ -10,22 +10,24 @@
 .wrapper {
   width: 320px;
   text-align: center;
-  padding: 10px;
+  padding: var(--space-3);
   margin: 0 auto;
 
   .title {
     height: 20px;
+    font-size: var(--text-sm);
+    font-weight: var(--font-weight-medium);
   }
 
   .percent {
     height: 160px;
     width: 160px;
-    border-radius: 80px;
+    border-radius: var(--radius-full);
     border: 3px solid;
-    margin: 10px auto;
+    margin: var(--space-3) auto;
 
     .rate {
-      @include DosisFont;
+      @include HeadingFont;
       font-size: 40px;
       font-weight: 100;
       padding: 38px 0 0 0;
@@ -34,41 +36,41 @@
   }
 
   .count_wrap {
-    color: $mainTextColor;
+    color: var(--color-text-primary);
 
     .count {
       font-size: 30px;
-      @include DosisFont;
+      @include HeadingFont;
     }
   }
 }
 
 .blue {
-  color: $blue;
-  background: white;
+  color: var(--color-accent-blue);
+  background: var(--color-bg-primary);
 }
 
 .blue_inv {
-  color: white;
-  background: $blue;
+  color: var(--color-text-on-dark);
+  background: var(--color-accent-blue);
 }
 
 .pink {
-  color: $pink;
-  background: white;
+  color: var(--color-accent-red);
+  background: var(--color-bg-primary);
 }
 
 .pink_inv {
-  color: white;
-  background: $pink;
+  color: var(--color-text-on-dark);
+  background: var(--color-accent-red);
 }
 
 .yellow {
-  color: $yellow;
-  background: white;
+  color: var(--color-accent-orange);
+  background: var(--color-bg-primary);
 }
 
 .yellow_inv {
-  color: white;
-  background: $yellow;
+  color: var(--color-text-on-dark);
+  background: var(--color-accent-orange);
 }

--- a/src/components/PushPreview/PushPreview.scss
+++ b/src/components/PushPreview/PushPreview.scss
@@ -10,9 +10,10 @@
 .wrap {
   width: 650px;
   height: 404px;
-  border-radius: 5px;
-  border: 1px solid $borderGrey;
-  background: #fbfbfc;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border-primary);
+  background: var(--color-bg-secondary);
+  overflow: hidden;
 }
 
 .left {
@@ -28,8 +29,8 @@
 }
 
 .section {
-  padding: 16px 20px;
-  border-bottom: 1px solid $borderGrey;
+  padding: var(--space-4) var(--space-5);
+  border-bottom: 1px solid var(--color-border-primary);
 
   &:last-child {
     border-bottom: none;
@@ -37,49 +38,53 @@
 }
 
 .title {
-  @include DosisFont;
-  font-size: 11px;
+  @include HeadingFont;
+  font-size: var(--text-xs);
   text-transform: uppercase;
   letter-spacing: 2px;
-  color: rgba(85, 85, 114, 0.63);
+  color: var(--color-text-tertiary);
+  font-weight: var(--font-weight-semibold);
 }
 
 .row {
-  font-size: 13px;
-  margin: 6px 0;
+  font-size: var(--text-xs);
+  margin: var(--space-2) 0;
   min-height: 16px;
 }
 
 .rowLabel {
   float: left;
-  font-weight: 700;
+  font-weight: var(--font-weight-semibold);
   width: 100px;
+  color: var(--color-text-secondary);
 }
 
 .rowContent {
   margin-left: 100px;
   word-break: break-word;
+  color: var(--color-text-primary);
 }
 
 .preview {
   width: 323px;
   height: 402px;
-  border-radius: 0 5px 5px 0;
-  background-color: #F2F6F8;
+  border-radius: 0 var(--radius-lg) var(--radius-lg) 0;
+  background-color: var(--color-bg-secondary);
 }
 
 .noPreview {
   width: 325px;
   height: 404px;
-  background-color: #F2F6F8;
+  background-color: var(--color-bg-secondary);
   text-align: center;
-  font-size: 18px;
+  font-size: var(--text-base);
   padding-top: 100px;
+  color: var(--color-text-tertiary);
 }
 
 .typeSelect {
   position: absolute;
-  top: 15px;
+  top: var(--space-4);
   left: 0;
   width: 100%;
   text-align: center;
@@ -87,7 +92,7 @@
 
 .testSelect {
   position: absolute;
-  bottom: 15px;
+  bottom: var(--space-4);
   left: 0;
   width: 100%;
   text-align: center;
@@ -97,7 +102,7 @@
   background-image: url(iphone.jpg);
   background-size: 325px auto;
   font-family: '.SFNSDisplay-Regular', 'Helvetica Neue', 'Lucida Grande', sans-serif;
-  color: white;
+  color: var(--color-text-on-dark);
 
   .time {
     position: absolute;
@@ -111,7 +116,7 @@
     position: absolute;
     top: 230px;
     width: 100%;
-    font-size: 12px;
+    font-size: var(--text-xs);
     text-align: center;
   }
 
@@ -120,7 +125,7 @@
     top: 256px;
     width: 218px;
     left: 55px;
-    padding-left: 20px;
+    padding-left: var(--space-5);
   }
 
   .appIcon {
@@ -129,8 +134,8 @@
     top: 0;
     width: 13px;
     height: 13px;
-    border-radius: 3px;
-    background: $blue;
+    border-radius: var(--radius-sm);
+    background: var(--color-accent-blue);
   }
 
   .appName {
@@ -168,7 +173,7 @@
     position: absolute;
     top: 180px;
     width: 100%;
-    color: white;
+    color: var(--color-text-on-dark);
     font-size: 60px;
     text-align: center;
   }
@@ -180,7 +185,7 @@
     font-size: 8px;
     letter-spacing: 2px;
     text-transform: uppercase;
-    color: white;
+    color: var(--color-text-on-dark);
     text-align: center;
   }
 
@@ -189,12 +194,13 @@
     top: 285px;
     width: 208px;
     left: 56px;
-    background: white;
-    box-shadow: 0px 1px 1px rgba(0,0,0,0.24);
-    padding: 20px 10px 0 40px;
+    background: var(--color-bg-elevated);
+    box-shadow: var(--shadow-md);
+    padding: var(--space-5) var(--space-3) 0 40px;
     min-height: 38px;
     max-height: 47px;
     overflow: hidden;
+    border-radius: var(--radius-sm);
   }
 
   .appIcon {
@@ -203,15 +209,15 @@
     top: 7px;
     width: 24px;
     height: 24px;
-    border-radius: 12px;
-    background: $blue;
+    border-radius: var(--radius-full);
+    background: var(--color-accent-blue);
   }
 
   .appName {
     position: absolute;
     top: 7px;
     left: 40px;
-    color: black;
+    color: var(--color-text-primary);
     font-size: 10px;
   }
 
@@ -219,12 +225,12 @@
     position: absolute;
     top: 9px;
     right: 6px;
-    color: rgba(0,0,0,0.5);
+    color: var(--color-text-secondary);
     font-size: 8px;
   }
 
   .message {
-    color: rgba(0,0,0,0.5);
+    color: var(--color-text-secondary);
     font-size: 10px;
   }
 }
@@ -233,7 +239,7 @@
   background-image: url(laptop.jpg);
   background-size: 325px auto;
   font-family: '.SFNSDisplay-Regular', 'Helvetica Neue', 'Lucida Grande', sans-serif;
-  color: #555252;
+  color: var(--color-text-primary);
 
   .time, .date {
     display: none;
@@ -245,10 +251,10 @@
     top: 114px;
     width: 240px;
     height: 47px;
-    background: #f0f0f0;
-    border-radius: 4px;
-    box-shadow: 0 0 4px rgba(0,0,0,0.3);
-    padding: 4px 6px 4px 36px;
+    background: var(--color-bg-tertiary);
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-md);
+    padding: var(--space-1) var(--space-2) var(--space-1) 36px;
   }
 
   .appIcon {
@@ -257,12 +263,13 @@
     height: 24px;
     top: 6px;
     left: 5px;
-    background: $blue;
+    background: var(--color-accent-blue);
   }
 
   .appName {
     font-size: 10px;
-    margin-bottom: 2px;
+    margin-bottom: var(--space-1);
+    font-weight: var(--font-weight-medium);
   }
 
   .message {
@@ -276,7 +283,7 @@
   background-image: url(windowsphone.jpg);
   background-size: 325px auto;
   font-family: 'Arial', sans-serif;
-  color: white;
+  color: var(--color-text-on-dark);
 
   .date, .appName {
     display: none;
@@ -294,7 +301,7 @@
     top: 134px;
     left: 50px;
     right: 50px;
-    font-size: 11px;
+    font-size: var(--text-xs);
     white-space: nowrap;
     overflow: hidden;
   }
@@ -305,5 +312,9 @@
   bottom: 0;
   width: 100%;
   height: 100px;
-  background-image: linear-gradient(rgba(251, 251, 252, 0), rgba(251, 251, 252, 0.7) 50%, rgba(251, 251, 252, 1) 90%);
+  background-image: linear-gradient(
+    var(--color-bg-secondary-transparent, rgba(251, 251, 252, 0)),
+    var(--color-bg-secondary-semi, rgba(251, 251, 252, 0.7)) 50%,
+    var(--color-bg-secondary, rgba(251, 251, 252, 1)) 90%
+  );
 }

--- a/src/components/RadioButton/RadioButton.scss
+++ b/src/components/RadioButton/RadioButton.scss
@@ -6,9 +6,11 @@
  * the root directory of this source tree.
  */
 @import 'stylesheets/globals.scss';
+
 .radiobutton {
   display: inline-block;
-  margin-right: 12px;
+  margin-right: var(--space-3);
+
   input[type=radio] {
     opacity: 0;
     width: 0;
@@ -17,18 +19,20 @@
     margin: 0;
     position: absolute;
   }
+
   span {
     position: relative;
     display: inline-block;
     width: 20px;
     height: 20px;
-    background: #d0d0d0;
-    border-radius: 10px;
+    background: var(--color-border-primary);
+    border-radius: var(--radius-full);
     cursor: pointer;
     top: 4px;
+    transition: background var(--transition-fast), box-shadow var(--transition-fast);
 
     &:hover {
-      background: #b0b0b0;
+      background: var(--color-text-tertiary);
     }
 
     &:after {
@@ -36,8 +40,8 @@
       content: '';
       width: 0;
       height: 0;
-      border-radius: 100%;
-      background: white;
+      border-radius: var(--radius-full);
+      background: var(--color-bg-primary);
 
       top: 50%;
       left: 50%;
@@ -48,11 +52,15 @@
   }
 
   input:checked + span {
-    background: #5298fc;
+    background: var(--color-accent-blue);
 
     &:after {
       width: 8px;
       height: 8px;
     }
+  }
+
+  input:focus-visible + span {
+    box-shadow: 0 0 0 2px var(--color-accent-blue-light);
   }
 }

--- a/src/components/Range/Range.scss
+++ b/src/components/Range/Range.scss
@@ -8,19 +8,19 @@
 @import 'stylesheets/globals.scss';
 
 @mixin rangeTrack {
-  background-color: #e0e0ea;
+  background-color: var(--color-border-primary);
   width: 100%;
   height: 10px;
-  border-radius: 5px;
+  border-radius: var(--radius-md);
   outline: none;
 }
 
 @mixin rangeThumb {
-  background-color: #fdfafb;
+  background-color: var(--color-bg-primary);
   width: 24px;
   height: 24px;
-  border-radius: 12px;
-  box-shadow: 0 1px 4px rgba(0,0,0,0.12);
+  border-radius: var(--radius-full);
+  box-shadow: var(--shadow-sm);
   cursor: pointer;
 }
 
@@ -50,13 +50,13 @@
 }
 
 .tracker {
-  @include DosisFont;
+  @include HeadingFont;
   @include transform(translateX(-50%));
   position: absolute;
-  background: $orange;
-  color: white;
-  font-size: 11px;
-  border-radius: 4px;
+  background: var(--color-accent-orange);
+  color: var(--color-text-on-dark);
+  font-size: var(--text-xs);
+  border-radius: var(--radius-md);
   height: 18px;
   line-height: 18px;
   padding: 0 6px;

--- a/src/components/ScrollHint/ScrollHint.scss
+++ b/src/components/ScrollHint/ScrollHint.scss
@@ -7,7 +7,7 @@
  */
 .scrollHint.active::before{
     content: '╲╱';
-    color: rgb(116, 214, 249);
+    color: var(--color-accent-blue);
     position: absolute;
     opacity: 0.8;
     text-shadow: 0 0 .5rem rgba(0,0,0,0.5);

--- a/src/components/SegmentSelect/SegmentSelect.scss
+++ b/src/components/SegmentSelect/SegmentSelect.scss
@@ -12,28 +12,33 @@
   height: 24px;
 
   a {
-    @include DosisFont;
+    @include HeadingFont;
     display: inline-block;
     height: 24px;
     line-height: 24px;
-    padding: 0 12px;
-    font-size: 12px;
+    padding: 0 var(--space-3);
+    font-size: var(--text-xs);
     border-style: solid;
-    border-color: $blue;
+    border-color: var(--color-accent-blue);
     border-width: 1px 0 1px 1px;
-    color: $blue;
+    color: var(--color-accent-blue);
+    transition: background var(--transition-fast), color var(--transition-fast);
 
     &:first-child {
-      border-radius: 5px 0 0 5px;
+      border-radius: var(--radius-md) 0 0 var(--radius-md);
     }
     &:last-child {
-      border-radius: 0 5px 5px 0;
+      border-radius: 0 var(--radius-md) var(--radius-md) 0;
       border-right-width: 1px;
     }
 
+    &:hover:not(.current) {
+      background: var(--color-accent-blue-light);
+    }
+
     &.current {
-      background: $blue;
-      color: white;
+      background: var(--color-accent-blue);
+      color: var(--color-text-on-dark);
     }
   }
 }

--- a/src/components/Sidebar/MobileNav.react.js
+++ b/src/components/Sidebar/MobileNav.react.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016-present, Parse, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+import React from 'react';
+import Icon from 'components/Icon/Icon.react';
+import styles from 'components/Sidebar/MobileNav.scss';
+
+const HamburgerIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+    <line x1="3" y1="5" x2="17" y2="5" />
+    <line x1="3" y1="10" x2="17" y2="10" />
+    <line x1="3" y1="15" x2="17" y2="15" />
+  </svg>
+);
+
+const MobileNav = ({ appName, isOpen, onToggle }) => {
+  return (
+    <>
+      <div className={styles.mobileHeader}>
+        <button className={styles.hamburger} onClick={onToggle} aria-label="Toggle navigation">
+          {isOpen ? <Icon name="x-outline" width={20} height={20} fill="currentColor" /> : <HamburgerIcon />}
+        </button>
+        <span className={styles.appName}>{appName || 'Parse Dashboard'}</span>
+      </div>
+      {isOpen && <div className={styles.overlay} onClick={onToggle} />}
+    </>
+  );
+};
+
+export default MobileNav;

--- a/src/components/Sidebar/MobileNav.scss
+++ b/src/components/Sidebar/MobileNav.scss
@@ -1,0 +1,70 @@
+@import 'stylesheets/globals.scss';
+
+.mobileHeader {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: $mobile-header-height;
+  background: var(--color-bg-toolbar);
+  border-bottom: 1px solid var(--color-border-primary);
+  z-index: 101;
+  align-items: center;
+  padding: 0 var(--space-3);
+  gap: var(--space-3);
+}
+
+@media (max-width: $bp-md - 1) {
+  .mobileHeader {
+    display: flex;
+  }
+}
+
+.hamburger {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border: none;
+  background: none;
+  cursor: pointer;
+  border-radius: var(--radius-md);
+  color: var(--color-text-primary);
+  transition: background var(--transition-fast);
+  flex-shrink: 0;
+  padding: 0;
+
+  &:hover {
+    background: var(--color-interactive-hover);
+  }
+}
+
+.appName {
+  @include UIFont;
+  font-size: var(--text-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.overlay {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 99;
+  backdrop-filter: blur(2px);
+}
+
+@media (max-width: $bp-md - 1) {
+  .overlay {
+    display: block;
+  }
+}

--- a/src/components/Sidebar/Sidebar.react.js
+++ b/src/components/Sidebar/Sidebar.react.js
@@ -10,14 +10,17 @@ import AppsMenu from 'components/Sidebar/AppsMenu.react';
 import AppName from 'components/Sidebar/AppName.react';
 import isInsidePopover from 'lib/isInsidePopover';
 import Pin from 'components/Sidebar/Pin.react';
-import React, { useEffect, useState, useContext } from 'react';
+import React, { useEffect, useState, useContext, useRef } from 'react';
 import SidebarHeader from 'components/Sidebar/SidebarHeader.react';
 import SidebarSection from 'components/Sidebar/SidebarSection.react';
 import SidebarSubItem from 'components/Sidebar/SidebarSubItem.react';
 import styles from 'components/Sidebar/Sidebar.scss';
+import ThemeSelector from 'components/Sidebar/ThemeSelector.react';
 import { CurrentApp } from 'context/currentApp';
 import Icon from 'components/Icon/Icon.react';
 const mountPath = window.PARSE_DASHBOARD_PATH;
+
+const COLLAPSE_WIDTH = 1024;
 
 const Sidebar = ({
   prefix,
@@ -30,50 +33,50 @@ const Sidebar = ({
   appSelector,
   primaryBackgroundColor,
   secondaryBackgroundColor,
+  mobileOpen,
+  onMobileClose,
 }) => {
   const currentApp = useContext(CurrentApp);
-  const collapseWidth = 980;
   const [appsMenuOpen, setAppsMenuOpen] = useState(false);
-  const [collapsed, setCollapsed] = useState(false);
-  const [fixed, setFixed] = useState(true);
+  const [collapsed, setCollapsed] = useState(window.innerWidth <= COLLAPSE_WIDTH);
+  const [fixed, setFixed] = useState(window.innerWidth > COLLAPSE_WIDTH);
   const [dashboardUser, setDashboardUser] = useState('');
-  fetch(mountPath).then(response => {
-    setDashboardUser(response.headers.get('username'));
-  });
-  let currentWidth = window.innerWidth;
+  const prevWidth = useRef(window.innerWidth);
+
+  useEffect(() => {
+    fetch(mountPath).then(response => {
+      setDashboardUser(response.headers.get('username'));
+    });
+  }, []);
 
   const windowResizeHandler = () => {
-    if (window.innerWidth <= collapseWidth && currentWidth > collapseWidth) {
-      if (document.body.className.indexOf(' expanded') === -1) {
-        document.body.className += ' expanded';
-      }
+    const w = window.innerWidth;
+    if (w <= COLLAPSE_WIDTH && prevWidth.current > COLLAPSE_WIDTH) {
+      document.body.classList.add('expanded');
       setCollapsed(true);
       setFixed(false);
-    } else if (window.innerWidth > collapseWidth && currentWidth <= collapseWidth) {
-      document.body.className = document.body.className.replace(' expanded', '');
+    } else if (w > COLLAPSE_WIDTH && prevWidth.current <= COLLAPSE_WIDTH) {
+      document.body.classList.remove('expanded');
       setCollapsed(false);
       setFixed(true);
     }
-    // Update window width
-    currentWidth = window.innerWidth;
+    prevWidth.current = w;
   };
 
   useEffect(() => {
     window.addEventListener('resize', windowResizeHandler);
-
-    return () => {
-      window.removeEventListener('resize', windowResizeHandler);
-    };
+    return () => window.removeEventListener('resize', windowResizeHandler);
   });
 
   const sidebarClasses = [styles.sidebar];
   if (fixed) {
-    document.body.className = document.body.className.replace(' expanded', '');
+    document.body.classList.remove('expanded');
   } else if (!fixed && collapsed) {
     sidebarClasses.push(styles.collapsed);
-    if (document.body.className.indexOf(' expanded') === -1) {
-      document.body.className += ' expanded';
-    }
+    document.body.classList.add('expanded');
+  }
+  if (mobileOpen) {
+    sidebarClasses.push(styles.mobileOpen);
   }
 
   const _subMenu = subsections => {
@@ -93,6 +96,7 @@ const Sidebar = ({
               actionHandler={active ? actionHandler : null}
               active={active}
               icon={icon}
+              onNavigate={onMobileClose}
             >
               {active ? children : null}
             </SidebarSubItem>
@@ -156,8 +160,7 @@ const Sidebar = ({
                 style={style}
                 link={prefix + link}
                 active={active}
-                primaryBackgroundColor={primaryBackgroundColor}
-                secondaryBackgroundColor={secondaryBackgroundColor}
+                onNavigate={onMobileClose}
               >
                 {!collapsed && active ? _subMenu(subsections) : null}
               </SidebarSection>
@@ -185,14 +188,15 @@ const Sidebar = ({
     >
       <SidebarHeader isCollapsed={!appsMenuOpen && collapsed} dashboardUser={dashboardUser} />
       {sidebarContent}
-      {dashboardUser && (
-        <div className={styles.footer}>
+      <div className={styles.footer}>
+        <ThemeSelector />
+        {dashboardUser && (
           <a href={`${mountPath}logout`} className={styles.more}>
             <Icon height={16} width={16} name="logout" />
             Logout
           </a>
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 };

--- a/src/components/Sidebar/Sidebar.scss
+++ b/src/components/Sidebar/Sidebar.scss
@@ -9,107 +9,136 @@
 
 $headerHeight: 48px;
 $menuSectionHeight: 24px;
-$sidebarMenuItemHeight: 48px;
-$footerHeight: 36px;
+$sidebarMenuItemHeight: 36px;
+$footerHeight: 44px;
+
+// ============================================
+// Sidebar Shell
+// ============================================
 
 .sidebar {
   position: fixed;
-  width: 300px;
+  width: $sidebar-width;
   top: 0;
   left: 0;
   bottom: 0;
-  background: #0c5582;
-  color: #fff;
+  background: linear-gradient(180deg, var(--color-bg-sidebar) 0%, var(--color-bg-sidebar-bottom) 100%);
+  color: var(--color-text-on-dark);
   z-index: 100;
+  transition: width var(--transition-normal);
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid rgba(255, 255, 255, 0.06);
 
   &.collapsed {
-    left: 0;
-    width: 54px;
+    width: $sidebar-collapsed-width;
 
     .section_header > svg {
       margin: 0;
     }
 
     .pinContainer > svg {
-      fill: white;
+      fill: var(--color-text-on-dark);
     }
   }
 }
 
+@media (max-width: $bp-md - 1) {
+  .sidebar {
+    transform: translateX(-100%) !important;
+    transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1) !important;
+    z-index: 200;
+    width: 280px !important;
+
+    &.mobileOpen {
+      transform: translateX(0) !important;
+    }
+  }
+}
+
+// ============================================
+// Content Area (scrollable sections)
+// ============================================
+
 .content {
-  position: absolute;
+  position: relative;
   overflow-y: auto;
-  top: $headerHeight;
-  right: 0;
-  bottom: 36px;
-  left: 0;
+  flex: 1;
+  padding: 4px 0;
 }
 
 .apps + .content {
-  top: $headerHeight + $sidebarMenuItemHeight;
+  // flex handles spacing
 }
+
+// ============================================
+// Footer
+// ============================================
 
 .footer {
-  @include DosisFont;
-  position: absolute;
-  background: #05283c;
-  padding: 10px 0;
-  text-align: center;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  @include UIFont;
+  position: relative;
+  padding: 10px 12px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
 
   a {
-    color: white;
+    color: var(--color-text-on-dark-muted);
     text-decoration: none;
-    border-right: 1px solid #385261;
-    font-size: 13px;
-    padding: 0 12px;
-    vertical-align: top;
+    font-size: var(--text-xs);
+    transition: color var(--transition-fast);
 
-
-    &:first-child {
-      padding-left: 0;
-    }
-    &:last-child {
-      padding-right: 0;
-      border: none;
+    &:hover {
+      color: var(--color-text-on-dark);
     }
   }
 }
+
+// ============================================
+// Header (logo + version)
+// ============================================
 
 .header {
-  background: #05283c;
   height: $headerHeight;
-  padding: 10px 14px;
+  padding: 0 14px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 
   :global(.icon) {
-    width: 28px;
-    height: 28px;
-    float: left;
+    width: 24px;
+    height: 24px;
+    flex-shrink: 0;
   }
 }
+
+// ============================================
+// App Name / Selector
+// ============================================
 
 .currentApp, .menuRow {
   @include ellipsis();
   display: block;
-  background: #094162;
-  height: $sidebarMenuItemHeight;
-  padding: 10px 14px;
-
-  color: white;
-  font-size: 18px;
-  font-weight: 700;
-  line-height: 30px;
+  height: $sidebarMenuItemHeight + 8px;
+  padding: 8px 12px;
+  color: var(--color-text-on-dark);
+  font-size: var(--text-base);
+  font-weight: var(--font-weight-semibold);
+  line-height: 28px;
 }
 
 .menuRow {
   cursor: pointer;
-  border-bottom: 1px solid #0c5582;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 
   > *:first-child {
     display: inline-block;
-    max-width: 200px;
+    max-width: 160px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -117,6 +146,10 @@ $footerHeight: 36px;
 
   > *:not(:first-child) {
     float: right;
+  }
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.06);
   }
 }
 
@@ -134,18 +167,18 @@ $footerHeight: 36px;
     .currentAppName {
       overflow: hidden;
       text-overflow: ellipsis;
-      max-width: 215px;
+      max-width: 170px;
     }
 
     &:after {
-      @include arrow('down', 10px, 7px, #132B39);
+      @include arrow('down', 10px, 7px, rgba(255, 255, 255, 0.2));
       content: '';
       margin-left: 10px;
     }
 
     &:hover {
       &:after {
-        border-top-color: white;
+        border-top-color: var(--color-text-on-dark);
       }
     }
   }
@@ -158,24 +191,23 @@ $footerHeight: 36px;
   padding: 6px;
 }
 
+// ============================================
+// Apps Menu (dropdown)
+// ============================================
+
 .appsMenu {
   overflow: auto;
-  background: #094162;
-  width: 300px;
-
-  .menuRow:hover {
-    background: #0c5582;
-  }
+  width: $sidebar-width;
 
   .currentApp {
     .currentAppName {
       &:after {
-        @include arrow('up', 10px, 7px, #132B39);
+        @include arrow('up', 10px, 7px, rgba(255, 255, 255, 0.2));
       }
 
       &:hover {
         &:after {
-          border-bottom-color: white;
+          border-bottom-color: var(--color-text-on-dark);
         }
       }
     }
@@ -183,187 +215,235 @@ $footerHeight: 36px;
 
   .appListContainer {
     overflow-y: auto;
-    height: calc(100vh - #{$headerHeight} - #{$menuSectionHeight} - #{$sidebarMenuItemHeight} - #{$footerHeight});
+    height: calc(100vh - #{$headerHeight} - #{$menuSectionHeight} - #{$sidebarMenuItemHeight + 8px} - #{$footerHeight});
   }
 }
 
 .menuSection {
-  @include DosisFont;
+  @include HeadingFont;
   height: $menuSectionHeight;
   line-height: 24px;
-  background: #0c5582;
-  color: #84A5BC;
+  color: var(--color-text-on-dark-muted);
   text-transform: uppercase;
-  letter-spacing: 2px;
-  font-size: 8px;
+  letter-spacing: 1.5px;
+  font-size: 10px;
+  font-weight: var(--font-weight-medium);
   padding: 0 14px;
-  border-bottom: 1px solid #094162;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
 
 .createApp {
-  @include DosisFont;
+  @include UIFont;
   display: block;
-  background: $blue;
+  background: var(--color-accent-blue);
   color: white;
-  width: 91%;
-  height: 30px;
-  line-height: 30px;
-  border-radius: 5px;
+  width: calc(100% - 24px);
+  height: 32px;
+  line-height: 32px;
+  border-radius: var(--radius-md);
   text-align: center;
   margin: 12px auto;
-  font-size: 12px;
+  font-size: var(--text-xs);
+  font-weight: var(--font-weight-medium);
+  transition: background var(--transition-fast);
 
   &:hover {
-    background: #0c5582;
+    background: var(--color-accent-blue-hover);
   }
 }
+
+// ============================================
+// Section (nav item)
+// ============================================
 
 .section {
-  background: #0c5582;
+  padding: 0 8px;
 
   :global(.icon) {
-    margin-right: 14px;
+    margin-right: 10px;
   }
 }
 
+// Active section — clean Tailwind-style rounded highlight
 .active {
-  background: #159cee;
+  .section_header {
+    background: rgba(255, 255, 255, 0.1);
+    color: #ffffff;
+    font-weight: var(--font-weight-semibold);
+    border-radius: var(--radius-md);
 
-  .section_header{
-    font-weight: 700;
-    &:hover{
-      background: #159cee;
+    > svg {
+      opacity: 1;
     }
   }
 }
 
 .section_header {
-  display: block;
+  display: flex;
+  align-items: center;
   height: $sidebarMenuItemHeight;
-  font-size: 18px;
-  line-height: 28px;
-  padding: 12px 14px;
-  color: white;
+  font-size: var(--text-sm);
+  line-height: 20px;
+  padding: 0 10px;
+  color: var(--color-text-on-dark-muted);
+  border-radius: var(--radius-md);
+  transition: background var(--transition-fast), color var(--transition-fast);
 
-  &:hover{
-    background-color: #0D5E91;
+  &:hover {
+    background: rgba(255, 255, 255, 0.06);
+    color: var(--color-text-on-dark);
   }
 
   > span {
     vertical-align: top;
-    @include DosisFont;
+    @include UIFont;
+    font-weight: var(--font-weight-medium);
   }
 
   > svg {
-    margin-right: 14px;
+    margin-right: 10px;
+    flex-shrink: 0;
+    opacity: 0.5;
   }
 }
 
+// ============================================
+// Sub-items (expanded under active section)
+// ============================================
+
 .section_contents {
-  background: #0e69a0;
-  padding: 16px 14px 16px 50px;
+  padding: 2px 0 6px 14px;
 }
 
+// Active sub-item — just white text, bold
 .subitem {
   position: relative;
   height: 28px;
   line-height: 28px;
-  font-size: 16px;
-  font-weight: 700;
-  color: white;
+  font-size: var(--text-sm);
+  font-weight: var(--font-weight-medium);
+  color: #ffffff;
   display: flex;
   align-items: center;
+  padding: 0 8px;
+  border-radius: var(--radius-md);
 }
 
+// Inactive sub-item (link) — muted, brightens on hover
 a.subitem {
-  color: #8fb9cf;
-  font-weight: 400;
+  color: var(--color-text-on-dark-muted);
+  font-weight: var(--font-weight-normal);
   display: flex;
   align-items: center;
   width: 100%;
+  transition: color var(--transition-fast);
 
   &:hover {
-    color: white;
+    color: var(--color-text-on-dark);
   }
 
   svg {
     &:hover {
-      fill: white;
+      fill: var(--color-text-on-dark);
     }
   }
 }
 
+// ============================================
+// Action (button inside sub-item)
+// ============================================
+
 .action {
-  @include DosisFont;
+  @include UIFont;
   position: absolute;
-  font-size: 12px;
-  font-weight: 400;
+  font-size: var(--text-xs);
+  font-weight: var(--font-weight-normal);
   padding: 0 8px;
   line-height: 20px;
-  top: 4px;
+  top: 5px;
   right: 0px;
-  background: #0c5987;
-  color: white;
-  border-radius: 3px;
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--color-text-on-dark);
+  border-radius: var(--radius-sm);
+  transition: background var(--transition-fast);
 
   &:hover {
-    background: #094162;
+    background: rgba(255, 255, 255, 0.2);
   }
 }
 
+// ============================================
+// Logo & Version
+// ============================================
+
 .logo {
-  float: left;
+  flex-shrink: 0;
 }
 
 .version {
-  @include DosisFont;
+  @include UIFont;
   position: relative;
-  width: 75px;
   height: 100%;
   font-size: 10px;
   display: flex;
   align-items: center;
-  float: left;
-  margin-left: 6px;
-  white-space: nowrap;
-  color: white;
+  margin-left: 10px;
+  color: var(--color-text-on-dark-muted);
+  overflow: hidden;
+  flex: 1;
+  min-width: 0;
 
   > *:first-child {
-    position: absolute;
-    letter-spacing: 2px;
-    line-height: 12px;
-    text-transform: uppercase;
-  }
-
-  > *:first-child {
+    letter-spacing: 0.5px;
+    line-height: 14px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
     transition: all 0.4s 0.16s cubic-bezier(0.77, 0, 0.175, 1);
   }
 }
 
+// ============================================
+// More / Logout
+// ============================================
+
 .more {
   display: flex;
-  justify-content: center;
   align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  font-size: var(--text-xs);
+  color: var(--color-text-on-dark-muted);
+  transition: color var(--transition-fast), background var(--transition-fast);
+
   svg {
-    fill: #0C5582;
-    transition: fill 0.2s ease-in;
-    margin-right: 4px;
+    fill: var(--color-text-on-dark-muted);
+    transition: fill var(--transition-fast);
   }
 
   &:hover {
+    color: var(--color-text-on-dark);
+    background: rgba(255, 255, 255, 0.06);
+
     svg {
-      fill: $blue;
+      fill: var(--color-text-on-dark);
     }
   }
 }
+
+// ============================================
+// Popup (legacy menu)
+// ============================================
 
 .popup {
   position: absolute;
   bottom: 4px;
   left: -183px;
-  background: white;
+  background: var(--color-bg-elevated);
   width: 200px;
-  border-radius: 5px;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-overlay);
 
   &:after {
     @include arrow('down', 12px, 6px, #ffffff);
@@ -374,51 +454,58 @@ a.subitem {
   }
 
   a {
-    @include NotoSansFont;
+    @include UIFont;
     display: block;
     height: 40px;
     line-height: 41px;
-    font-size: 13px;
+    font-size: var(--text-sm);
     text-align: center;
-    border-bottom: 1px solid #e0e0ea;
-    color: $mainTextColor;
+    border-bottom: 1px solid var(--color-border-secondary);
+    color: var(--color-text-primary);
     padding-right: 8px;
-    &:hover{
-      background-color: darken(white,4%)
+
+    &:hover {
+      background-color: var(--color-interactive-hover);
     }
 
     &:first-child {
-      border-radius: 5px 5px 5px 5px;
+      border-radius: var(--radius-lg) var(--radius-lg) 0 0;
     }
 
     &:last-child {
       border-bottom: 0;
-      border-radius: 5px 5px 5px 5px;
+      border-radius: 0 0 var(--radius-lg) var(--radius-lg);
     }
 
-    .emoji{
+    .emoji {
       padding-left: 4px;
       padding-right: 2px;
     }
   }
 }
 
+// ============================================
+// Pin Container (collapsed state)
+// ============================================
+
 .pinContainer {
-  height: 48px;
+  height: $sidebarMenuItemHeight + 8px;
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: #094162;
 
   svg {
     cursor: pointer;
-    height: 40px;
-    width: 40px;
-    padding: 10px 10px 10px 10px;
-    fill: #132B39;
+    height: 36px;
+    width: 36px;
+    padding: 8px;
+    fill: rgba(255, 255, 255, 0.3);
+    border-radius: var(--radius-md);
+    transition: fill var(--transition-fast), background var(--transition-fast);
 
     &:hover {
-      fill: white;
+      fill: var(--color-text-on-dark);
+      background: rgba(255, 255, 255, 0.06);
     }
   }
 }

--- a/src/components/Sidebar/SidebarHeader.react.js
+++ b/src/components/Sidebar/SidebarHeader.react.js
@@ -12,6 +12,18 @@ import styles from 'components/Sidebar/Sidebar.scss';
 // get the package.json environment variable
 const version = process.env.version;
 
+// Modern Parse logo — just the infinity path without the circle background
+const ParseLogo = ({ size = 22 }) => (
+  <svg width={size} height={size} viewBox="20 20 60 60" fill="currentColor">
+    <path d="M58.29 62.17H33.75c-3.553 0-5.658 2.172-5.658 5.396 0 2.83 1.908 5.434 4.67 5.434 3.16 0 5.04-2.776 5.238-6h7c-.33 7.763-5.066 12-12.303 12-6.776 0-11.776-4.658-11.776-11.5 0-7.105 5.33-11.5 13.225-11.5h24.342c8.224 0 14.474-6.592 14.474-14.75C72.96 33.026 67.37 27 59.41 27c-7.895 0-14.21 6.092-14.21 16.618V51H37.96v-7.382C37.96 29.538 47.04 20 59.54 20c11.973 0 20.657 8.947 20.657 21.118 0 12.237-9.342 21.053-21.908 21.053" />
+  </svg>
+);
+
+// Classic Parse logo — full circle with infinity symbol
+const ClassicParseLogo = ({ size = 28 }) => (
+  <Icon width={size} height={size} name="infinity" fill={'#ffffff'} />
+);
+
 export default class SidebarHeader extends React.Component {
   constructor() {
     super();
@@ -19,14 +31,18 @@ export default class SidebarHeader extends React.Component {
   }
   render() {
     const { isCollapsed = false, dashboardUser } = this.props;
+    const isClassic = typeof document !== 'undefined' &&
+      document.documentElement.getAttribute('data-theme') === 'classic';
+    const Logo = isClassic ? ClassicParseLogo : ParseLogo;
+
     const headerContent = isCollapsed ? (
       <div className={styles.logo}>
-        <Icon width={28} height={28} name="infinity" fill={'#ffffff'} />
+        <Logo />
       </div>
     ) : (
       <>
         <Link className={styles.logo} to={{ pathname: '/apps' }}>
-          <Icon width={28} height={28} name="infinity" fill={'#ffffff'} />
+          <Logo />
         </Link>
         <Link to="/apps">
           <div className={styles.version}>

--- a/src/components/Sidebar/SidebarSection.react.js
+++ b/src/components/Sidebar/SidebarSection.react.js
@@ -17,9 +17,8 @@ const SidebarSection = ({
   link,
   icon,
   style,
-  primaryBackgroundColor,
-  secondaryBackgroundColor,
   isCollapsed,
+  onNavigate,
 }) => {
   const classes = [styles.section];
   if (active) {
@@ -27,14 +26,14 @@ const SidebarSection = ({
   }
   let iconContent = null;
   if (icon) {
-    iconContent = <Icon width={25} height={25} name={icon} fill="#ffffff" />;
+    iconContent = <Icon width={20} height={20} name={icon} fill="currentColor" />;
   }
   if (isCollapsed) {
     classes.push(styles.collapsed);
     return (
       <div className={classes.join(' ')}>
         <div
-          style={{background: primaryBackgroundColor, ...style}}
+          style={style}
           className={styles.section_header}
         >
           {iconContent}
@@ -46,21 +45,21 @@ const SidebarSection = ({
     <div className={classes.join(' ')}>
       {active ? (
         <div
-          style={{background: primaryBackgroundColor, ...style, }}
+          style={style}
           className={styles.section_header}
         >
           {iconContent}
           <span>{name}</span>
         </div>
       ) : (
-        <Link style={style} className={styles.section_header} to={{ pathname: link || '' }}>
+        <Link style={style} className={styles.section_header} to={{ pathname: link || '' }} onClick={onNavigate}>
           {iconContent}
           <span>{name}</span>
         </Link>
       )}
 
       {children ? (
-        <div className={styles.section_contents} style={{ background: secondaryBackgroundColor }}>
+        <div className={styles.section_contents}>
           {children}
         </div>
       ) : null}

--- a/src/components/Sidebar/SidebarSubItem.react.js
+++ b/src/components/Sidebar/SidebarSubItem.react.js
@@ -10,13 +10,13 @@ import React from 'react';
 import styles from 'components/Sidebar/Sidebar.scss';
 import Icon from 'components/Icon/Icon.react';
 
-const SidebarSubItem = ({ active, name, action, link, children, icon }) => {
+const SidebarSubItem = ({ active, name, action, link, children, icon, onNavigate }) => {
   if (active) {
     return (
       <div>
         <div className={styles.subitem}>
           {name}
-          {icon && <Icon name={icon} width={16} height={16} fill="white" style={{ marginLeft: '4px', marginTop: '2px' }} />}
+          {icon && <Icon name={icon} width={16} height={16} fill="currentColor" style={{ marginLeft: '4px', marginTop: '2px' }} />}
           {action ? action.renderButton() : null}
         </div>
         <div>{children}</div>
@@ -26,9 +26,9 @@ const SidebarSubItem = ({ active, name, action, link, children, icon }) => {
 
   return (
     <div>
-      <Link className={styles.subitem} to={{ pathname: link }}>
+      <Link className={styles.subitem} to={{ pathname: link }} onClick={onNavigate}>
         {name}
-        {icon && <Icon name={icon} width={16} height={16} fill="#8fb9cf" style={{ marginLeft: '4px', marginTop: '2px' }} />}
+        {icon && <Icon name={icon} width={16} height={16} fill="currentColor" style={{ marginLeft: '4px', marginTop: '2px' }} />}
       </Link>
     </div>
   );

--- a/src/components/Sidebar/ThemeSelector.react.js
+++ b/src/components/Sidebar/ThemeSelector.react.js
@@ -1,0 +1,82 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { getSavedTheme, setTheme } from 'lib/theme';
+import styles from 'components/Sidebar/ThemeSelector.scss';
+
+const THEMES = [
+  { value: 'light', label: 'Light' },
+  { value: 'dark', label: 'Dark' },
+  { value: 'classic', label: 'Classic' },
+  { value: 'auto', label: 'Auto' },
+];
+
+const ThemeSelector = () => {
+  const [current, setCurrent] = useState(getSavedTheme);
+  const [open, setOpen] = useState(false);
+  const ref = useRef(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      if (ref.current && !ref.current.contains(e.target)) {
+        setOpen(false);
+      }
+    };
+    if (open) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [open]);
+
+  // Listen for system theme changes when in auto mode
+  useEffect(() => {
+    if (current !== 'auto' || !window.matchMedia) {
+      return;
+    }
+    const mql = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = () => setTheme('auto');
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }, [current]);
+
+  const handleSelect = (value) => {
+    setCurrent(value);
+    setTheme(value);
+    setOpen(false);
+  };
+
+  const currentLabel = THEMES.find(t => t.value === current)?.label || 'Light';
+
+  return (
+    <div className={styles.themeSelector} ref={ref}>
+      <button
+        className={styles.trigger}
+        onClick={() => setOpen(!open)}
+        title="Change theme"
+      >
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M12 2.25a.75.75 0 01.75.75v2.25a.75.75 0 01-1.5 0V3a.75.75 0 01.75-.75zM7.5 12a4.5 4.5 0 119 0 4.5 4.5 0 01-9 0zm11.394-5.834a.75.75 0 00-1.06-1.06l-1.591 1.59a.75.75 0 101.06 1.061l1.591-1.59zM12 18a.75.75 0 01.75.75V21a.75.75 0 01-1.5 0v-2.25A.75.75 0 0112 18zM7.758 17.303a.75.75 0 00-1.061-1.06l-1.591 1.59a.75.75 0 001.06 1.061l1.591-1.59zM6 12a.75.75 0 01-.75.75H3a.75.75 0 010-1.5h2.25A.75.75 0 016 12zM6.697 7.757a.75.75 0 001.06-1.06l-1.59-1.591a.75.75 0 00-1.061 1.06l1.59 1.591zM18 12a.75.75 0 01.75-.75H21a.75.75 0 010 1.5h-2.25A.75.75 0 0118 12zm-.697 5.303a.75.75 0 00-1.06 1.06l1.59 1.591a.75.75 0 101.061-1.06l-1.59-1.591z" />
+        </svg>
+        <span>{currentLabel}</span>
+      </button>
+      {open && (
+        <div className={styles.menu}>
+          {THEMES.map(({ value, label }) => (
+            <button
+              key={value}
+              className={`${styles.option} ${value === current ? styles.active : ''}`}
+              onClick={() => handleSelect(value)}
+            >
+              {label}
+              {value === current && (
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z" />
+                </svg>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ThemeSelector;

--- a/src/components/Sidebar/ThemeSelector.scss
+++ b/src/components/Sidebar/ThemeSelector.scss
@@ -1,0 +1,72 @@
+@import 'stylesheets/globals.scss';
+
+.themeSelector {
+  position: relative;
+}
+
+.trigger {
+  @include UIFont;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-on-dark-muted);
+  font-size: var(--text-xs);
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  transition: color var(--transition-fast), background var(--transition-fast);
+
+  svg {
+    flex-shrink: 0;
+  }
+
+  &:hover {
+    color: var(--color-text-on-dark);
+    background: rgba(255, 255, 255, 0.1);
+  }
+}
+
+.menu {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border-secondary);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-overlay);
+  padding: var(--space-1) 0;
+  min-width: 120px;
+  z-index: 200;
+}
+
+.option {
+  @include UIFont;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-sm);
+  color: var(--color-text-primary);
+  transition: background var(--transition-fast);
+
+  &:hover {
+    background: var(--color-interactive-hover);
+  }
+
+  &.active {
+    color: var(--color-accent-blue);
+    font-weight: var(--font-weight-medium);
+  }
+
+  svg {
+    margin-left: var(--space-2);
+    flex-shrink: 0;
+  }
+}

--- a/src/components/SlowQueriesFilter/SlowQueriesFilter.scss
+++ b/src/components/SlowQueriesFilter/SlowQueriesFilter.scss
@@ -13,51 +13,53 @@
 
 .entry {
   height: 30px;
-  padding: 8px;
+  padding: var(--space-2);
+  transition: background var(--transition-fast);
 
   svg {
-    fill: #66637A;
+    fill: var(--color-text-secondary);
+    transition: fill var(--transition-fast);
   }
 
   &:hover svg {
-    fill: white;
+    fill: var(--color-text-on-dark);
   }
 }
 
 .entry.active {
-  background: $blue;
-  border-radius: 5px;
+  background: var(--color-accent-blue);
+  border-radius: var(--radius-md);
 
   svg {
-    fill: white;
+    fill: var(--color-text-on-dark);
   }
 }
 
 .active .title, .active .body {
-  background: $blue;
+  background: var(--color-accent-blue);
 }
 
 .title {
-  background: #797691;
-  padding: 8px;
-  border-radius: 5px 5px 0 0;
+  background: var(--color-bg-tertiary);
+  padding: var(--space-2);
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
 
   svg {
-    fill: white;
+    fill: var(--color-text-on-dark);
   }
 }
 
 .entry, .title {
-  @include DosisFont;
+  @include HeadingFont;
   position: relative;
   bottom: -4px;
-  font-size: 14px;
-  color: #ffffff;
+  font-size: var(--text-base);
+  color: var(--color-text-on-dark);
   cursor: pointer;
 
   svg {
     vertical-align: top;
-    margin-right: 6px;
+    margin-right: var(--space-2);
   }
 
   span {
@@ -72,17 +74,18 @@
   position: absolute;
   top: 30px;
   right: 0;
-  border-radius: 5px 0 5px 5px;
-  background: #797691;
+  border-radius: var(--radius-md) 0 var(--radius-md) var(--radius-md);
+  background: var(--color-bg-tertiary);
   width: 470px;
-  font-size: 14px;
+  font-size: var(--text-base);
+  box-shadow: var(--shadow-md);
 }
 
 .row {
-  padding: 8px 15px;
+  padding: var(--space-2) var(--space-4);
 
   > * {
-    margin-right: 10px;
+    margin-right: var(--space-2);
 
     &:nth-last-child(1) {
       margin-right: 0;
@@ -93,17 +96,22 @@
     @include MonospaceFont;
     height: 30px;
     width: 140px;
-    background: #343445;
+    background: var(--color-bg-sidebar);
     border: none;
     outline: none;
-    border-radius: 5px;
+    border-radius: var(--radius-md);
     vertical-align: top;
-    padding: 0 8px;
-    color: white;
-    font-size: 14px;
+    padding: 0 var(--space-2);
+    color: var(--color-text-on-dark);
+    font-size: var(--text-base);
+    transition: background var(--transition-fast);
+
+    &:focus {
+      background: var(--color-accent-blue-hover);
+    }
   }
 }
 
 .active .row input {
-  background: #0E69A1;
+  background: var(--color-accent-blue-hover);
 }

--- a/src/components/StatusIndicator/StatusIndicator.scss
+++ b/src/components/StatusIndicator/StatusIndicator.scss
@@ -8,9 +8,9 @@
 @import 'stylesheets/globals.scss';
 
 .status {
-  @include DosisFont;
+  @include HeadingFont;
   display: inline-block;
-  font-size: 14px;
+  font-size: var(--text-base);
   letter-spacing: 0.1em;
   text-transform: uppercase;
 
@@ -19,31 +19,31 @@
     display: inline-block;
     width: 11px;
     height: 11px;
-    border-radius: 100%;
-    margin-right: 8px;
+    border-radius: var(--radius-full);
+    margin-right: var(--space-2);
   }
 }
 
 .blue {
-  color: $blue;
+  color: var(--color-accent-blue);
 
   &:before {
-    background: $blue;
+    background: var(--color-accent-blue);
   }
 }
 
 .red {
-  color: $red;
+  color: var(--color-accent-red);
 
   &:before {
-    background: $red;
+    background: var(--color-accent-red);
   }
 }
 
 .green {
-  color: $green;
+  color: var(--color-accent-green);
 
   &:before {
-    background: $green;
+    background: var(--color-accent-green);
   }
 }

--- a/src/components/StringEditor/StringEditor.scss
+++ b/src/components/StringEditor/StringEditor.scss
@@ -11,7 +11,7 @@
   position: absolute;
   top: 0;
   left: 0;
-  box-shadow: 0 1px 4px rgba(0,0,0,0.4);
+  box-shadow: var(--shadow-md);
 
   input {
     @include MonospaceFont;
@@ -19,27 +19,41 @@
     height: 30px;
     border: none;
     outline: none;
-    padding: 0 4px;
-    font-size: 12px;
+    padding: 0 var(--space-1);
+    font-size: var(--text-xs);
+    background: var(--color-bg-elevated);
+    color: var(--color-text-primary);
+    transition: background var(--transition-fast);
+
+    &:focus {
+      background: var(--color-bg-primary);
+    }
   }
 
   &.readonly {
-    box-shadow: 0px 0px 2px 1px rgb(0 0 0 / 20%);
+    box-shadow: var(--shadow-sm);
   }
 
   input:disabled {
-    background-color: #f2f2f2;
-    color: #666;
+    background-color: var(--color-bg-tertiary);
+    color: var(--color-text-secondary);
   }
 
   textarea {
     @include MonospaceFont;
     width: 200px;
     height: 93px;
-    font-size: 12px;
-    padding: 4px;
+    font-size: var(--text-xs);
+    padding: var(--space-1);
     resize: none;
     border: none;
     outline: none;
+    background: var(--color-bg-elevated);
+    color: var(--color-text-primary);
+    transition: background var(--transition-fast);
+
+    &:focus {
+      background: var(--color-bg-primary);
+    }
   }
 }

--- a/src/components/SuggestionsList/SuggestionsList.scss
+++ b/src/components/SuggestionsList/SuggestionsList.scss
@@ -8,30 +8,31 @@
 @import 'stylesheets/globals.scss';
 
 .suggestions {
-  border: 1px solid $mainTextColor;
+  border: 1px solid var(--color-border-primary);
   border-top-width: 0;
   list-style: none;
   max-height: 143px;
   overflow-y: auto;
-  -moz-box-shadow: 0px 0px 0px #666, 0px 4px 8px #666;
-  -webkit-box-shadow: 0px 0px 0px #666, 0px 4px 8px #666;
-  box-shadow:0px 0px 0px #666, 0px 4px 8px #666;
+  box-shadow: var(--shadow-md);
+  border-radius: 0 0 var(--radius-md) var(--radius-md);
 }
 
 .suggestions li {
-  background: white;
-  padding-left: 10px;
-  font-family:"Open Sans", sans-serif;  
+  @include UIFont;
+  background: var(--color-bg-elevated);
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-base);
+  transition: background-color var(--transition-fast), color var(--transition-fast);
 }
 
 .active,
 .suggestions li:hover {
-  color: #0e69a1;
+  color: var(--color-accent-blue);
   cursor: pointer;
-  font-weight: 500;
-  background: rgba(255, 255, 255, 0.1) !important;
+  font-weight: var(--font-weight-medium);
+  background: var(--color-interactive-hover) !important;
 }
 
 .suggestions li:not(:last-of-type) {
-  border-bottom: 1px solid #999;
+  border-bottom: 1px solid var(--color-border-secondary);
 }

--- a/src/components/Table/Table.scss
+++ b/src/components/Table/Table.scss
@@ -9,43 +9,48 @@
 
 .header {
   display: inline-block;
-  color: white;
-  font-size: 14px;
-  line-height: 30px;
+  color: var(--color-text-secondary);
+  font-size: 12px;
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  line-height: 36px;
   padding: 0 16px;
-  background: #66637A;
-  height: 30px;
+  background: var(--color-bg-tertiary);
+  height: 36px;
 }
 
-
-//common table styles that can be imported
-
 .table {
-  background: #fdfafb;
+  background: var(--color-bg-primary);
   width: 100%;
   text-align: left;
 }
 
 .head {
-  color: white;
-  font-size: 14px;
-  line-height: 30px;
+  color: var(--color-text-secondary);
+  font-size: 12px;
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  line-height: 36px;
   padding: 0 16px;
-  background: #66637A;
-  height: 30px;
+  background: var(--color-bg-tertiary);
+  height: 36px;
 }
 
 .tr {
-  background: #fdfafb;
-  border-bottom: 1px solid $borderGrey;
+  background: var(--color-bg-primary);
+  border-bottom: 1px solid var(--color-border-secondary);
+  transition: background var(--transition-fast);
 
-  &:nth-child(2n) {
-    background: #f4f5f7;
+  &:hover {
+    background: var(--color-interactive-hover);
   }
 }
 
 .td {
-  line-height: 30px;
-  padding: 10px 16px;
+  line-height: 20px;
+  padding: var(--space-2) 16px;
   max-width: 0;
+  color: var(--color-text-primary);
 }

--- a/src/components/TextInput/TextInput.react.js
+++ b/src/components/TextInput/TextInput.react.js
@@ -34,11 +34,23 @@ class TextInput extends React.Component {
     }
   }
 
+  getHeight() {
+    if (this.props.height) {
+      return this.props.height;
+    }
+    // Classic theme uses 80px default; modern themes use auto-sizing
+    const isClassic =
+      typeof document !== 'undefined' &&
+      document.documentElement.getAttribute('data-theme') === 'classic';
+    return isClassic ? 80 : undefined;
+  }
+
   render() {
     const classes = [styles.text_input];
     if (this.props.monospace) {
       classes.push(styles.monospace);
     }
+    const height = this.getHeight();
     if (this.props.multiline) {
       return (
         <textarea
@@ -50,7 +62,7 @@ class TextInput extends React.Component {
           style={
             this.props.rows && this.props.rows > 3
               ? this.props.style
-              : { height: this.props.height || 80, ...this.props.style }
+              : { height, ...this.props.style }
           }
           placeholder={this.props.placeholder}
           value={this.props.value}
@@ -66,7 +78,7 @@ class TextInput extends React.Component {
         type={this.props.hidden ? 'password' : 'text'}
         disabled={!!this.props.disabled}
         className={classes.join(' ')}
-        style={{ height: this.props.height || 80, ...this.props.style }}
+        style={{ height, ...this.props.style }}
         placeholder={this.props.placeholder}
         value={this.props.value}
         onChange={this.changeValue.bind(this)}

--- a/src/components/TextInput/TextInput.scss
+++ b/src/components/TextInput/TextInput.scss
@@ -8,48 +8,63 @@
 @import 'stylesheets/globals.scss';
 
 .text_input {
-  @include NotoSansFont;
-  border: 0;
+  @include UIFont;
+  border: 1px solid var(--color-border-primary);
   outline: 0;
-  background: $inputBackgroundColor;
-  color: #000;
-  font-size: 16px;
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  font-size: var(--text-sm);
   width: 100%;
-  min-width: calc(var(--modal-min-width) * (1 - var(--modal-label-ratio)));
-  min-height: var(--modal-row-min-height);
-  padding: 6px;
+  min-height: 36px;
+  padding: var(--space-2) var(--space-3);
   vertical-align: top;
   resize: both;
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-xs, 0 1px 2px rgba(0, 0, 0, 0.05));
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
 
   @include placeholder {
-    color: #999;
-    opacity: 1;
+    color: var(--color-text-tertiary);
+    opacity: 0.7;
   }
 
   &:disabled {
-    color: $mainTextColor;
+    color: var(--color-text-secondary);
+    background: var(--color-bg-secondary);
   }
 
   &:focus {
+    border-color: var(--color-border-focus);
+    box-shadow: 0 0 0 1px var(--color-border-focus);
+
     @include placeholder {
       opacity: 0;
     }
   }
 }
 
+// Classic theme: restore the centered-in-field style
+:global([data-theme="classic"]) {
+  .text_input {
+    width: calc(100% - var(--space-6));
+    margin: auto;
+  }
+}
+
 input.monospace, textarea.monospace {
   @include MonospaceFont;
+
+  @include placeholder {
+    font-family: var(--font-sans);
+  }
 }
 
 input.text_input {
-  text-align: center;
+  text-align: left;
 }
 
 textarea.text_input:not(.monospace) {
   @include placeholder {
-    text-align: center;
-    position: relative;
-    top: 50%;
-    line-height: 9px;
+    text-align: left;
   }
 }

--- a/src/components/Toggle/Toggle.scss
+++ b/src/components/Toggle/Toggle.scss
@@ -14,50 +14,48 @@
 }
 
 .label {
-  @include DosisFont;
-  font-size: 13px;
-  color: #babac4;
-  transition: color 0.15s ease-out;
+  @include UIFont;
+  font-size: var(--text-sm);
+  color: var(--color-text-tertiary);
+  transition: color var(--transition-fast) ease-out;
   cursor: pointer;
   padding: 8px;
 
   &:last-of-type {
-    color: #555473;
+    color: var(--color-text-primary);
   }
 }
 
+// Modern: shadcn Switch — off=muted, on=primary
 .switch {
   display: inline-block;
   position: relative;
-  width: 40px;
-  height: 18px;
-  border-radius: 8px;
-  background: #159cee;
+  width: 36px;
+  height: 20px;
+  border-radius: var(--radius-full);
+  background: var(--color-text-primary);
   vertical-align: top;
-  margin: 6px 8px 0 8px;
+  margin: 5px 8px 0 8px;
   cursor: pointer;
+  transition: background var(--transition-fast) ease-out;
 
   &:after {
     content: '';
     position: absolute;
-    width: 24px;
-    height: 24px;
-    border-radius: 12px;
-    background: #fdfafb;
-    top: 9px;
-    left: 31px;
-    margin-left: -12px;
-    margin-top: -12px;
-    box-shadow: 0 0 2px rgba(0,0,0,0.4);
-    transition: left 0.15s ease-out;
+    width: 16px;
+    height: 16px;
+    border-radius: var(--radius-full);
+    background: var(--color-bg-primary);
+    top: 2px;
+    left: 18px;
+    box-shadow: var(--shadow-xs);
+    transition: left var(--transition-fast) ease-out;
   }
 }
 
+// "colored" class gives the red/green gradient — only used in classic
 .colored {
-  background: linear-gradient(90deg, rgb(0, 219, 124), rgb(0, 219, 124) 50%, rgb(255, 57, 94) 50%, rgb(255, 57, 94));
-  background-size: 200%;
-  background-position: 0;
-  transition: background-position 0.15s ease-out;
+  background: var(--color-text-primary);
 }
 
 .switchNoMargin {
@@ -67,39 +65,59 @@
 .left {
   .label {
     &:first-of-type {
-      color: #555473;
+      color: var(--color-text-primary);
     }
 
     &:last-of-type {
-      color: #babac4;
+      color: var(--color-text-tertiary);
     }
   }
 
-  .colored {
-    background-position: 100%;
+  .switch {
+    background: var(--color-border-primary);
   }
 
   .switch:after {
-    left: 9px;
+    left: 2px;
   }
 }
 
 .darkBg {
   .label {
     &:first-of-type {
-      color: #babac4;
+      color: var(--color-text-tertiary);
     }
     &:last-of-type {
-      color: #ffffff;
+      color: var(--color-text-on-dark);
     }
   }
 
   &.left .label {
     &:first-of-type {
-      color: #ffffff;
+      color: var(--color-text-on-dark);
     }
     &:last-of-type {
-      color: #babac4;
+      color: var(--color-text-tertiary);
     }
+  }
+}
+
+// Classic: restore red/green gradient toggle
+:global([data-theme="classic"]) {
+  .colored {
+    background: linear-gradient(90deg, var(--color-accent-green), var(--color-accent-green) 50%, var(--color-accent-red) 50%, var(--color-accent-red));
+    background-size: 200%;
+    background-position: 0;
+    transition: background-position var(--transition-fast) ease-out;
+  }
+
+  .left .colored {
+    background-position: 100%;
+  }
+
+  .left .switch {
+    background: linear-gradient(90deg, var(--color-accent-green), var(--color-accent-green) 50%, var(--color-accent-red) 50%, var(--color-accent-red));
+    background-size: 200%;
+    background-position: 100%;
   }
 }

--- a/src/components/Toolbar/Toolbar.react.js
+++ b/src/components/Toolbar/Toolbar.react.js
@@ -18,7 +18,7 @@ const Toolbar = props => {
   if (props.relation || (props.filters && props.filters.size && action !== NavigationType.Pop)) {
     backButton = (
       <a className={styles.iconButton} onClick={() => navigate(-1)}>
-        <Icon width={32} height={32} fill="#ffffff" name="left-outline" />
+        <Icon width={24} height={24} fill="currentColor" name="left-outline" />
       </a>
     );
   }
@@ -41,7 +41,7 @@ const Toolbar = props => {
         <div className={styles.panelButtons}>
           {props.isAutoScrolling && (
             <button onClick={props.stopAutoScroll} className={`${styles.btn} ${styles.btnAutoScroll}`}>
-              <Icon width={18} height={18} fill="#ffffff" name="x-outline" />
+              <Icon width={16} height={16} fill="currentColor" name="x-outline" />
               Auto-scroll
             </button>
           )}
@@ -49,12 +49,12 @@ const Toolbar = props => {
             <>
               {props.panelCount > 1 && (
                 <button onClick={props.removePanel} className={styles.btn}>
-                  <Icon width={18} height={18} fill="#797592" name="minus-outline" />
+                  <Icon width={16} height={16} fill="currentColor" name="minus-outline" />
                     Remove Panel
                 </button>
               )}
               <button onClick={props.addPanel} className={styles.btn}>
-                <Icon width={18} height={18} fill="#797592" name="plus-outline" />
+                <Icon width={16} height={16} fill="currentColor" name="plus-outline" />
                   Add Panel
               </button>
             </>
@@ -62,12 +62,12 @@ const Toolbar = props => {
           <button onClick={props.togglePanel} className={styles.btn}>
             {props.isPanelVisible ? (
               <>
-                <Icon width={18} height={18} fill="#797592" name="x-outline" />
+                <Icon width={16} height={16} fill="currentColor" name="x-outline" />
                   Hide {props.panelCount > 1 ? `${props.panelCount} Panels` : 'Panel'}
               </>
             ) : (
               <>
-                <Icon width={18} height={18} fill="#797592" name="left-outline" />
+                <Icon width={16} height={16} fill="currentColor" name="left-outline" />
                   Show {props.panelCount > 1 ? `${props.panelCount} Panels` : 'Panel'}
               </>
             )}

--- a/src/components/Toolbar/Toolbar.scss
+++ b/src/components/Toolbar/Toolbar.scss
@@ -11,11 +11,16 @@
   position: fixed;
   top: 0;
   right: 0;
-  left: 300px;
-  background: #353446;
-  height: 96px;
-  color: white;
+  left: $sidebar-width;
+  background: var(--color-bg-toolbar);
+  height: $toolbar-height;
+  color: var(--color-text-on-dark);
   z-index: 5;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  align-items: center;
+  padding: 0 var(--space-4);
 }
 
 body:global(.expanded) {
@@ -24,10 +29,31 @@ body:global(.expanded) {
   }
 }
 
+@media (max-width: $bp-md - 1) {
+  .toolbar {
+    left: 0;
+    top: $mobile-header-height;
+    padding: 0 var(--space-2);
+  }
+
+  .titleText {
+    display: none;
+  }
+
+  .nav {
+    display: none;
+  }
+
+  .actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+}
+
 .objectPickerContent {
   .toolbar {
-    background: #00db7c;
-    height: 80px;
+    background: var(--color-accent-green);
+    height: calc($toolbar-height - 16px);
     right: 135px;
 
     .nav {
@@ -41,81 +67,103 @@ body:global(.expanded) {
 }
 
 .title {
-  position: absolute;
-  left: 14px;
-  bottom: 10px;
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  flex-shrink: 1;
 }
 
 .nav {
   display: inline-block;
+  flex-shrink: 0;
 }
 
 .iconButton {
-  display: block;
-  padding-top: 10px;
-  padding-right: 10px;
+  display: flex;
+  align-items: center;
+  padding: var(--space-2);
   cursor: pointer;
+  border-radius: var(--radius-md);
+  color: var(--color-text-on-dark-muted);
+  transition: background var(--transition-fast), color var(--transition-fast);
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.1);
+    color: var(--color-text-on-dark);
+  }
 }
 
 .titleText {
   display: inline-block;
+  min-width: 0;
 }
 
 .section {
-  @include DosisFont;
-  color: #757985;
+  @include HeadingFont;
+  color: var(--color-text-on-dark-muted);
   text-transform: uppercase;
-  font-size: 8px;
-  letter-spacing: 1.6px;
+  font-size: var(--text-xs);
+  letter-spacing: 0.5px;
+  font-weight: var(--font-weight-medium);
 }
 
 .subsection {
-  font-size: 18px;
+  font-size: var(--text-lg);
+  font-weight: var(--font-weight-semibold);
   vertical-align: bottom;
   margin-right: 10px;
+  color: var(--color-text-on-dark);
 }
 
 .details {
-  color: #80848f;
-  font-size: 12px;
+  color: var(--color-text-on-dark-muted);
+  font-size: var(--text-xs);
 }
 
 .actions {
-  position: absolute;
-  right: 14px;
-  top: 4px;
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  margin-left: auto;
+  flex-shrink: 1;
+  min-width: 0;
+  overflow: visible;
 }
 
 .panelButtons {
-  position: absolute;
-  right: 5px;
-  bottom: 5px;
   display: flex;
-  gap: 5px;
+  align-items: center;
+  gap: var(--space-1);
+  margin-left: var(--space-2);
 }
 
 .btn {
   position: relative;
   border: none;
-  padding: 6px 8px;
+  padding: var(--space-1) var(--space-2);
   background: none;
-  color: white;
+  color: var(--color-text-on-dark-muted);
   display: flex;
   align-items: center;
-  gap: 5px;
+  gap: var(--space-1);
   cursor: pointer;
   white-space: nowrap;
+  font-size: var(--text-sm);
+  border-radius: var(--radius-md);
+  transition: background var(--transition-fast), color var(--transition-fast);
 
   svg {
-
-    &:hover {
-      fill: #ffffff;
-    }
+    fill: var(--color-text-on-dark-muted);
+    transition: fill var(--transition-fast);
   }
 
   &:hover {
+    background: rgba(255, 255, 255, 0.1);
+    color: var(--color-text-on-dark);
+
     svg {
-      fill: #ffffff;
+      fill: var(--color-text-on-dark);
     }
   }
 
@@ -124,20 +172,31 @@ body:global(.expanded) {
     cursor: not-allowed;
 
     &:hover {
+      background: none;
       svg {
-        fill: #797592;
+        fill: var(--color-text-on-dark-muted);
       }
     }
   }
 }
 
 .btnAutoScroll {
-  background-color: #169cee;
-  border-radius: 4px;
+  background-color: var(--color-accent-blue);
+  color: var(--color-text-on-dark);
+  border-radius: var(--radius-md);
   animation: pulse 1.5s ease-in-out infinite;
 
+  svg {
+    fill: var(--color-text-on-dark);
+  }
+
   &:hover {
-    background-color: #1486cc;
+    background-color: var(--color-accent-blue-hover);
+    color: var(--color-text-on-dark);
+
+    svg {
+      fill: var(--color-text-on-dark);
+    }
   }
 }
 

--- a/src/components/Tooltip/Tooltip.scss
+++ b/src/components/Tooltip/Tooltip.scss
@@ -17,9 +17,10 @@ $calloutSize: 10px;
     display: none;
     width: 300px;
     line-height: 16px;
-    background-color: $white;
-    border: 1px solid $mainTextColor;
-    border-radius: 5px;
+    background-color: var(--color-bg-elevated);
+    border: 1px solid var(--color-border-secondary);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-md);
     // TODO we don't want to use z-index. But this makes everything easier
     // since we can do everything in CSS. We need to revisit this in the future
     z-index: 100;
@@ -34,13 +35,13 @@ $calloutSize: 10px;
 
       // Faking arrow with border by making 2 arrows.
       .callout1 {
-        @include arrow('down', ($calloutSize + 1) * 2, $calloutSize + 1, $mainTextColor);
+        @include arrow('down', ($calloutSize + 1) * 2, $calloutSize + 1, var(--color-border-secondary));
         position: absolute;
         left: 20px;
       }
 
       .callout2 {
-        @include arrow('down', $calloutSize * 2, $calloutSize, $white);
+        @include arrow('down', $calloutSize * 2, $calloutSize, var(--color-bg-elevated));
         position: absolute;
         left: 20px;
       }
@@ -49,5 +50,7 @@ $calloutSize: 10px;
 }
 
 .tooltipContent {
-  padding: 15px;
+  padding: var(--space-4);
+  color: var(--color-text-primary);
+  font-size: var(--text-sm);
 }

--- a/src/dashboard/Analytics/Explorer/Explorer.react.js
+++ b/src/dashboard/Analytics/Explorer/Explorer.react.js
@@ -345,7 +345,7 @@ class Explorer extends DashboardView {
           className={styles.toolbarAction}
           style={{ borderRight: '1px solid #66637a' }}
         >
-          <Icon name="question-solid" width={14} height={14} fill="#66637a" />
+          <Icon name="question-solid" width={14} height={14} fill="var(--color-text-secondary)" />
           FAQ
         </button>
         <button
@@ -353,7 +353,7 @@ class Explorer extends DashboardView {
           onClick={this.handleDownload.bind(this)}
           className={styles.toolbarAction}
         >
-          <Icon name="download" width={14} height={14} fill="#66637a" />
+          <Icon name="download" width={14} height={14} fill="var(--color-text-secondary)" />
           Download
         </button>
       </Toolbar>

--- a/src/dashboard/Analytics/Explorer/Explorer.scss
+++ b/src/dashboard/Analytics/Explorer/Explorer.scss
@@ -8,7 +8,7 @@
 @import 'stylesheets/globals.scss';
 
 .content {
-  padding: 96px 0px 0px 0px;
+  padding: $toolbar-height 0px 0px 0px;
   min-height: 100vh;
   position: relative;
 }
@@ -22,7 +22,7 @@
 }
 
 .header {
-  top: 96px;
+  top: $toolbar-height;
   border-bottom: 1px solid $translucentGrey;
 }
 
@@ -31,7 +31,7 @@
   overflow: auto;
   left: 0px;
   right: 0px;
-  top: 146px;
+  top: calc($toolbar-height + 50px);
   bottom: 50px;
 }
 
@@ -45,7 +45,7 @@
 
 .toolbarAction {
   @include buttonReset($padding: 0 20px);
-  color: white;
+  color: var(--color-text-on-dark);
 
   > *:not(svg) {
     margin: 5px;

--- a/src/dashboard/Analytics/Overview/Overview.react.js
+++ b/src/dashboard/Analytics/Overview/Overview.react.js
@@ -243,8 +243,8 @@ export default class Overview extends DashboardView {
           <div className={styles.healthInfo}>
             {this.state.error !== undefined ? (
               <div>
-                <Icon name="cloud-sad" fill="#ff395e" width={88} height={64} />
-                <h2 style={{ color: '#ff395e' }}>There is an issue with your app!</h2>
+                <Icon name="cloud-sad" fill="var(--color-accent-red)" width={88} height={64} />
+                <h2 style={{ color: 'var(--color-accent-red)' }}>There is an issue with your app!</h2>
                 <div>{this.state.error}</div>
                 <Button
                   onClick={() => {
@@ -257,7 +257,7 @@ export default class Overview extends DashboardView {
               </div>
             ) : (
               <div>
-                <Icon name="cloud-happy" fill="#00db7c" width={88} height={64} />
+                <Icon name="cloud-happy" fill="var(--color-accent-green)" width={88} height={64} />
                 <h2>Your app is healthy!</h2>
               </div>
             )}

--- a/src/dashboard/Analytics/Overview/Overview.scss
+++ b/src/dashboard/Analytics/Overview/Overview.scss
@@ -8,14 +8,14 @@
 @use 'sass:math';
 @import 'stylesheets/globals.scss';
 
-$overviewBackground: #fbfbfc;
+$overviewBackground: var(--color-bg-secondary);
 $containerWidth: 720px;
 $containerPadding: 20px;
 $infoWidth: math.div($containerWidth - 2 * $containerPadding, 4);
 
 .content {
-  padding: 96px 0px 48px 0px;
-  background: $white;
+  padding: $toolbar-height 0px 48px 0px;
+  background: var(--color-bg-primary);
   min-height: 100vh; //to remove the purple background from bleeding through on tall sizes
 }
 
@@ -89,11 +89,11 @@ h2{
 }
 
 .upArrow {
-  @include arrow('up', 12px, 9px, #00db7c);
+  @include arrow('up', 12px, 9px, var(--color-accent-green));
 }
 
 .downArrow {
-  @include arrow('down', 12px, 9px, #ff395e);
+  @include arrow('down', 12px, 9px, var(--color-accent-red));
 }
 
 .upArrow, .downArrow {

--- a/src/dashboard/Analytics/Performance/Performance.scss
+++ b/src/dashboard/Analytics/Performance/Performance.scss
@@ -8,7 +8,7 @@
 @import 'stylesheets/globals.scss';
 
 .content {
-  padding: 96px 0px 0px 0px;
+  padding: $toolbar-height 0px 0px 0px;
   min-height: 100vh;
   position: relative;
 }
@@ -22,7 +22,7 @@
 }
 
 .header {
-  top: 96px;
+  top: $toolbar-height;
   border-bottom: 1px solid $translucentGrey;
 }
 
@@ -38,7 +38,7 @@
   overflow: auto;
   left: 0px;
   right: 0px;
-  top: 146px;
+  top: calc($toolbar-height + 50px);
   bottom: 50px;
 }
 

--- a/src/dashboard/Analytics/Retention/Retention.scss
+++ b/src/dashboard/Analytics/Retention/Retention.scss
@@ -11,15 +11,15 @@ $retentionCellHeight: 40px;
 $contentPadding: 10px;
 
 .content {
-  padding: (96px + $contentPadding) $contentPadding $contentPadding $contentPadding;
+  padding: ($toolbar-height + $contentPadding) $contentPadding $contentPadding $contentPadding;
   min-height: 100vh;
   position: relative;
-  background: $white;
+  background: var(--color-bg-primary);
 }
 
 .average {
   @include DosisFont;
-  color: $mainTextColor;
+  color: var(--color-text-primary);
   opacity: 0.5;
   font-size: 14px;
   line-height: 15px;
@@ -86,7 +86,7 @@ table tr:first-of-type {
   @include DosisFont;
   font-size: 13px;
   font-weight: 600;
-  color: white;
+  color: var(--color-text-on-dark);
   border-radius: 5px;
   text-align: center;
   vertical-align: middle;

--- a/src/dashboard/Analytics/SlowQueries/SlowQueries.react.js
+++ b/src/dashboard/Analytics/SlowQueries/SlowQueries.react.js
@@ -192,7 +192,7 @@ class SlowQueries extends TableView {
             onClick={this.handleDownload.bind(this)}
             className={styles.toolbarAction}
           >
-            <Icon name="download" width={14} height={14} fill="#66637a" />
+            <Icon name="download" width={14} height={14} fill="var(--color-text-secondary)" />
             Download
           </button>
         </div>

--- a/src/dashboard/Analytics/SlowQueries/SlowQueries.scss
+++ b/src/dashboard/Analytics/SlowQueries/SlowQueries.scss
@@ -9,7 +9,7 @@
 
 .toolbarAction {
   @include buttonReset($padding: 0px 20px);
-  color: white;
+  color: var(--color-text-on-dark);
 
   > *:not(svg) {
     margin: 5px;

--- a/src/dashboard/Apps/AppsIndex.react.js
+++ b/src/dashboard/Apps/AppsIndex.react.js
@@ -87,7 +87,7 @@ const AppCard = ({ app, icon }) => {
           {icon ? (
             <img src={'appicons/' + icon} width={56} height={56} />
           ) : (
-            <Icon width={56} height={56} name="blank-app-outline" fill="#1E384D" />
+            <Icon width={56} height={56} name="blank-app-outline" fill="var(--color-text-primary)" />
           )}
         </a>
         <div className={styles.details}>
@@ -150,7 +150,7 @@ class AppsIndex extends React.Component {
         <div className={styles.empty}>
           <div className={baseStyles.center}>
             <div className={styles.cloud}>
-              <Icon width={110} height={110} name="cloud-surprise" fill="#1e3b4d" />
+              <Icon width={110} height={110} name="cloud-surprise" fill="var(--color-text-secondary)" />
             </div>
             <div className={styles.alert}>You don&apos;t have any apps</div>
           </div>
@@ -175,7 +175,7 @@ class AppsIndex extends React.Component {
     return (
       <div className={styles.index}>
         <div className={styles.header}>
-          <Icon width={18} height={18} name="search-outline" fill="#788c97" />
+          <Icon width={18} height={18} name="search-outline" fill="var(--color-text-secondary)" />
           <input
             ref={this.searchRef}
             className={styles.search}

--- a/src/dashboard/Apps/AppsIndex.scss
+++ b/src/dashboard/Apps/AppsIndex.scss
@@ -9,18 +9,18 @@
 
 .loadingError {
   font-size: 58px;
-  color: #ffffff;
+  color: var(--color-text-on-dark);
 }
 
 .index {
   padding: 38px 30px;
-  background: #1e3b4d;
+  background: var(--color-bg-sidebar);
   min-height: 100vh;
 }
 
 .empty {
   position: relative;
-  background: #1e3b4d;
+  background: var(--color-bg-sidebar);
   min-height: 100vh;
   text-align: center;
 }
@@ -30,13 +30,13 @@
   height: 170px;
   border-radius: 100%;
   padding-top: 30px;
-  background: #3E5566;
+  background: var(--color-bg-sidebar-hover);
   margin: 0 auto 14px auto;
 }
 
 .alert {
   font-size: 58px;
-  color: #ffffff;
+  color: var(--color-text-on-dark);
   white-space: nowrap;
 }
 
@@ -45,9 +45,9 @@
   height: 32px;
   line-height: 32px;
   width: 128px;
-  background: #ffffff;
+  background: var(--color-bg-primary);
   border-radius: 5px;
-  color: $blue;
+  color: var(--color-accent-blue);
   font-size: 12px;
   margin: 50px auto 0 auto;
 }
@@ -69,14 +69,14 @@
   @include DosisFont;
   background: transparent;
   border: none;
-  color: white;
+  color: var(--color-text-on-dark);
   outline: none;
   font-size: 14px;
   vertical-align: top;
   margin-left: 10px;
 
   @include placeholder {
-    color: #788c97;
+    color: var(--color-text-on-dark-muted);
   }
 }
 
@@ -90,11 +90,11 @@
   padding: 0 14px;
   font-size: 14px;
   border-radius: 5px;
-  color: white;
-  background: $blue;
+  color: var(--color-text-on-dark);
+  background: var(--color-accent-blue);
   &:hover{
-    background: white;
-    color: $blue;
+    background: var(--color-bg-primary);
+    color: var(--color-accent-blue);
   }
 }
 
@@ -104,13 +104,13 @@
 
   li {
     cursor: pointer;
-    background: #193040;
+    background: var(--color-bg-sidebar-active);
     border-radius: 5px;
     margin: 14px 0;
     min-height: 74px;
 
     &:hover{
-      background: #172C3B;
+      background: var(--color-bg-sidebar-hover);
     }
   }
 }
@@ -139,14 +139,14 @@
   width: 100%;
   display: inline-block;
   font-size: 22px;
-  color: white;
+  color: var(--color-text-on-dark);
 }
 
 .details {
   flex: auto;
   overflow: hidden;
   padding: 9px 0;
-  color: #788c97;
+  color: var(--color-text-on-dark-muted);
   font-size: 12px;
 
   > div:first-of-type {
@@ -159,19 +159,19 @@
 }
 
 .ago {
-  color: white;
+  color: var(--color-text-on-dark);
   padding-right: 10px;
 }
 
 .glance {
   flex: 0 0 auto;
   padding: 10px 12px;
-  border-left: 1px solid #1e3b4d;
+  border-left: 1px solid var(--color-bg-sidebar);
 }
 
 .section {
   font-size: 12px;
-  color: #ffffff;
+  color: var(--color-text-on-dark);
 }
 
 .count {
@@ -181,12 +181,12 @@
 
 .number {
   @include DosisFont;
-  color: white;
+  color: var(--color-text-on-dark);
   font-size: 18px;
 }
 
 .label {
-  color: #788c97;
+  color: var(--color-text-on-dark-muted);
   font-size: 11px;
 }
 
@@ -195,9 +195,9 @@
 }
 
 .versionWarning {
-  background: rgba(255, 152, 0, 0.15);
-  border-top: 1px solid rgba(255, 152, 0, 0.3);
-  color: #ff9800;
+  background: var(--color-accent-orange-light);
+  border-top: 1px solid var(--color-accent-orange);
+  color: var(--color-accent-orange);
   font-size: 11px;
   padding: 8px 12px;
   line-height: 1.4;
@@ -210,15 +210,15 @@
   position: absolute;
   top: 7px;
   left: 86px;
-  background: #29475D;
+  background: var(--color-bg-sidebar-hover);
   border-radius: 3px;
   height: 17px;
   line-height: 18px;
-  color: white;
+  color: var(--color-text-on-dark);
   font-size: 10px;
   padding: 0 8px;
 
   &:hover {
-    background: $blue;
+    background: var(--color-accent-blue);
   }
 }

--- a/src/dashboard/Dashboard.js
+++ b/src/dashboard/Dashboard.js
@@ -217,7 +217,7 @@ export default class Dashboard extends React.Component {
         <div className={styles.empty}>
           <div className={baseStyles.center}>
             <div className={styles.cloud}>
-              <Icon width={110} height={110} name="cloud-surprise" fill="#1e3b4d" />
+              <Icon width={110} height={110} name="cloud-surprise" fill="var(--color-text-secondary)" />
             </div>
             {/* use non-breaking hyphen for the error message to keep the filename on one line */}
             <div className={styles.loadingError}>

--- a/src/dashboard/Dashboard.scss
+++ b/src/dashboard/Dashboard.scss
@@ -8,7 +8,7 @@
 @import 'stylesheets/globals.scss';
 
 .content {
-  margin-left: 300px;
+  margin-left: $sidebar-width;
   overflow: auto;
   max-height: 100vh;
 }
@@ -21,12 +21,12 @@ body:global(.expanded) {
 
 .loadingError {
   font-size: 58px;
-  color: #ffffff;
+  color: var(--color-text-on-dark);
 }
 
 .empty {
   position: relative;
-  background: #1e3b4d;
+  background: var(--color-bg-sidebar);
   min-height: 100vh;
   text-align: center;
 }
@@ -36,6 +36,13 @@ body:global(.expanded) {
   height: 170px;
   border-radius: 100%;
   padding-top: 30px;
-  background: #3E5566;
+  background: var(--color-bg-sidebar-hover);
   margin: 0 auto 14px auto;
+}
+
+@media (max-width: $bp-md - 1) {
+  .content {
+    margin-left: 0;
+    padding-top: $mobile-header-height;
+  }
 }

--- a/src/dashboard/DashboardView.react.js
+++ b/src/dashboard/DashboardView.react.js
@@ -7,6 +7,7 @@
  */
 import React from 'react';
 import Sidebar from 'components/Sidebar/Sidebar.react';
+import MobileNav from 'components/Sidebar/MobileNav.react';
 import styles from 'dashboard/Dashboard.scss';
 import Icon from 'components/Icon/Icon.react';
 import baseStyles from 'stylesheets/base.scss';
@@ -21,7 +22,18 @@ export default class DashboardView extends React.Component {
     super();
     this.state = {
       route: '',
+      mobileNavOpen: false,
     };
+    this.toggleMobileNav = this.toggleMobileNav.bind(this);
+    this.closeMobileNav = this.closeMobileNav.bind(this);
+  }
+
+  toggleMobileNav() {
+    this.setState(prev => ({ mobileNavOpen: !prev.mobileNavOpen }));
+  }
+
+  closeMobileNav() {
+    this.setState({ mobileNavOpen: false });
   }
 
   componentDidUpdate() {
@@ -298,9 +310,8 @@ export default class DashboardView extends React.Component {
     if (pushSubsections.length > 0) {
       appSidebarSections.push({
         name: 'Push',
-        icon: 'push-outline',
+        icon: 'send-outline',
         link: '/push',
-        style: { paddingLeft: '16px' },
         subsections: pushSubsections,
       });
     }
@@ -317,7 +328,7 @@ export default class DashboardView extends React.Component {
     if (settingsSections.length > 0) {
       appSidebarSections.push({
         name: 'App Settings',
-        icon: 'gear-solid',
+        icon: 'gear-outline',
         link: '/settings',
         subsections: settingsSections,
       });
@@ -333,6 +344,8 @@ export default class DashboardView extends React.Component {
         action={this.action}
         primaryBackgroundColor={this.context.primaryBackgroundColor}
         secondaryBackgroundColor={this.context.secondaryBackgroundColor}
+        mobileOpen={this.state.mobileNavOpen}
+        onMobileClose={this.closeMobileNav}
       >
         {sidebarChildren}
       </Sidebar>
@@ -349,7 +362,7 @@ export default class DashboardView extends React.Component {
         <div className={styles.empty}>
           <div className={baseStyles.center}>
             <div className={styles.cloud}>
-              <Icon width={110} height={110} name="cloud-surprise" fill="#1e3b4d" />
+              <Icon width={110} height={110} name="cloud-surprise" fill="var(--color-text-secondary)" />
             </div>
             <div className={styles.loadingError}>Feature unavailable</div>
           </div>
@@ -362,7 +375,7 @@ export default class DashboardView extends React.Component {
         <div className={styles.empty}>
           <div className={baseStyles.center}>
             <div className={styles.cloud}>
-              <Icon width={110} height={110} name="cloud-surprise" fill="#1e3b4d" />
+              <Icon width={110} height={110} name="cloud-surprise" fill="var(--color-text-secondary)" />
             </div>
             <div className={styles.loadingError}>
               {this.context.serverInfo.error.replace(/-/g, '\u2011')}
@@ -375,6 +388,11 @@ export default class DashboardView extends React.Component {
 
     return (
       <div className={styles.dashboard}>
+        <MobileNav
+          appName={this.context ? this.context.name : ''}
+          isOpen={this.state.mobileNavOpen}
+          onToggle={this.toggleMobileNav}
+        />
         {content}
         {sidebar}
       </div>

--- a/src/dashboard/Data/Agent/Agent.scss
+++ b/src/dashboard/Data/Agent/Agent.scss
@@ -26,9 +26,9 @@
   flex: 1;
   overflow-y: auto;
   padding: 20px;
-  padding-top: 116px; /* Add top padding to account for the 96px fixed toolbar + some extra spacing */
+  padding-top: calc($toolbar-height + 20px); /* Add top padding to account for the fixed toolbar + some extra spacing */
   padding-bottom: 80px; /* Add bottom padding to account for the fixed chat form */
-  background-color: #f8f9fa;
+  background-color: var(--color-bg-secondary);
   scroll-behavior: smooth;
   height: calc(100vh - 60px); /* Explicit height constraint */
   max-height: calc(100vh - 60px); /* Prevent expansion beyond viewport */
@@ -37,8 +37,8 @@
 
 .emptyStateOverlay {
   position: fixed;
-  left: 300px;
-  top: 116px; /* Account for toolbar height */
+  left: $sidebar-width;
+  top: calc($toolbar-height + 20px); /* Account for toolbar height */
   bottom: 0;
   right: 0;
   display: flex;
@@ -83,28 +83,28 @@ body:global(.expanded) {
 
 .message.user {
   align-self: flex-end;
-  background-color: #007bff;
-  color: white;
+  background-color: var(--color-accent-blue);
+  color: var(--color-text-on-dark);
   margin-left: auto;
   
   code {
     background-color: rgba(255, 255, 255, 0.2);
-    color: white;
+    color: var(--color-text-on-dark);
   }
 }
 
 .message.agent {
   align-self: flex-start;
-  background-color: white;
-  color: #333;
-  border: 1px solid #e1e5e9;
+  background-color: var(--color-bg-elevated);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border-primary);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
 
 .message.agent.error {
-  background-color: #f8d7da;
-  color: #721c24;
-  border-color: #f5c6cb;
+  background-color: var(--color-accent-red-light);
+  color: var(--color-accent-red);
+  border-color: var(--color-accent-red-light);
 }
 
 .messageContent {
@@ -136,7 +136,7 @@ body:global(.expanded) {
   }
   
   code {
-    background-color: rgba(0, 0, 0, 0.1);
+    background-color: var(--color-interactive-hover);
     padding: 2px 4px;
     border-radius: 3px;
     font-family: 'Monaco', 'Menlo', monospace;
@@ -144,7 +144,7 @@ body:global(.expanded) {
   }
   
   pre {
-    background-color: rgba(0, 0, 0, 0.05);
+    background-color: var(--color-interactive-hover);
     padding: 8px;
     border-radius: 4px;
     overflow-x: auto;
@@ -163,18 +163,18 @@ body:global(.expanded) {
   }
   
   th, td {
-    border: 1px solid #ddd;
+    border: 1px solid var(--color-border-primary);
     padding: 4px 8px;
     text-align: left;
   }
   
   th {
-    background-color: rgba(0, 0, 0, 0.05);
+    background-color: var(--color-interactive-hover);
     font-weight: 600;
   }
   
   blockquote {
-    border-left: 3px solid #ddd;
+    border-left: 3px solid var(--color-border-primary);
     padding-left: 8px;
     margin: 4px 0;
     font-style: italic;
@@ -206,7 +206,7 @@ body:global(.expanded) {
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background-color: #999;
+  background-color: var(--color-text-tertiary);
   animation: typing 1.4s infinite ease-in-out;
 }
 
@@ -230,12 +230,12 @@ body:global(.expanded) {
 }
 
 .chatForm {
-  background-color: white;
-  border-top: 1px solid #e1e5e9;
+  background-color: var(--color-bg-elevated);
+  border-top: 1px solid var(--color-border-primary);
   padding: 16px 20px;
   position: fixed;
   bottom: 0;
-  left: 300px;
+  left: $sidebar-width;
   right: 0;
   z-index: 20;
 }
@@ -249,7 +249,7 @@ body:global(.expanded) {
 .chatInput {
   flex: 1;
   padding: 12px 16px;
-  border: 1px solid #e1e5e9;
+  border: 1px solid var(--color-border-primary);
   border-radius: 24px;
   font-size: 14px;
   outline: none;
@@ -258,19 +258,19 @@ body:global(.expanded) {
 }
 
 .chatInput:focus {
-  border-color: #007bff;
+  border-color: var(--color-accent-blue);
   box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25);
 }
 
 .chatInput:disabled {
-  background-color: #f8f9fa;
-  color: #6c757d;
+  background-color: var(--color-bg-secondary);
+  color: var(--color-text-secondary);
 }
 
 .sendButton {
   padding: 12px 24px;
-  background-color: #007bff;
-  color: white;
+  background-color: var(--color-accent-blue);
+  color: var(--color-text-on-dark);
   border: none;
   border-radius: 24px;
   font-size: 14px;
@@ -281,11 +281,11 @@ body:global(.expanded) {
 }
 
 .sendButton:hover:not(:disabled) {
-  background-color: #0056b3;
+  background-color: var(--color-accent-blue-hover);
 }
 
 .sendButton:disabled {
-  background-color: #6c757d;
+  background-color: var(--color-text-secondary);
   cursor: not-allowed;
 }
 
@@ -304,7 +304,7 @@ body:global(.expanded) {
   width: 100%;
   
   h4 {
-    color: #6c757d;
+    color: var(--color-text-secondary);
     font-size: 14px;
     font-weight: 500;
     margin-bottom: 16px;
@@ -319,9 +319,9 @@ body:global(.expanded) {
 }
 
 .exampleButton {
-  background: white;
-  border: 1px solid #007bff;
-  color: #007bff;
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-accent-blue);
+  color: var(--color-accent-blue);
   padding: 10px 16px;
   border-radius: 20px;
   font-size: 13px;
@@ -331,8 +331,8 @@ body:global(.expanded) {
   text-align: center;
   
   &:hover {
-    background-color: #007bff;
-    color: white;
+    background-color: var(--color-accent-blue);
+    color: var(--color-text-on-dark);
     transform: translateY(-1px);
     box-shadow: 0 2px 8px rgba(0, 123, 255, 0.3);
   }
@@ -343,9 +343,9 @@ body:global(.expanded) {
 }
 
 .warningMessage {
-  background-color: #fff3cd;
-  border: 1px solid #ffeaa7;
-  color: #856404;
+  background-color: var(--color-accent-orange-light);
+  border: 1px solid var(--color-accent-orange-light);
+  color: var(--color-accent-orange);
   padding: 12px 16px;
   border-radius: 8px;
   margin-bottom: 16px;

--- a/src/dashboard/Data/ApiConsole/ApiConsole.scss
+++ b/src/dashboard/Data/ApiConsole/ApiConsole.scss
@@ -10,28 +10,92 @@
 .curl {
   @include MonospaceFont;
   white-space: pre;
-  font-size: 12px;
-  padding: 20px;
-  line-height: 18px;
+  font-size: var(--text-sm);
+  padding: var(--space-5);
+  line-height: 1.6;
+  color: var(--color-text-primary);
+  background: var(--color-bg-secondary);
 }
 
 .footer {
-  border-top: 1px solid #e3e3ea;
-  padding: 10px 0;
+  border-top: 1px solid var(--color-border-primary);
+  padding: var(--space-3) 0;
   text-align: center;
 }
 
 .content {
   position: relative;
-  height: calc(100vh - 96px);
-  margin-top: 96px;
+  height: calc(100vh - $toolbar-height);
+  margin-top: $toolbar-height;
   overflow: hidden;
 }
 
 .empty {
   position: absolute;
-  top: 96px;
+  top: $toolbar-height;
   left: 0;
   right: 0;
   bottom: 0;
+}
+
+// Grid row: Method (compact) + Endpoint (flex)
+.requestRow {
+  display: grid;
+  grid-template-columns: 140px 1fr;
+  gap: var(--space-4);
+  align-items: end;
+}
+
+// Inline toggle: label left, switch right
+.inlineToggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--color-border-primary);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-primary);
+}
+
+.inlineToggleLabel {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.inlineToggleLabelText {
+  @include UIFont;
+  font-size: var(--text-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+}
+
+.inlineToggleDesc {
+  @include UIFont;
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+}
+
+// Results section
+.resultsSection {
+  margin-top: var(--space-8);
+}
+
+.resultsLabel {
+  @include UIFont;
+  font-size: var(--text-xs);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: var(--space-2);
+}
+
+.resultsBlock {
+  border: 1px solid var(--color-border-primary);
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-secondary);
+  padding: var(--space-4);
+  overflow: auto;
+  max-height: 400px;
 }

--- a/src/dashboard/Data/ApiConsole/RestConsole.react.js
+++ b/src/dashboard/Data/ApiConsole/RestConsole.react.js
@@ -189,51 +189,41 @@ export default class RestConsole extends Component {
     }
 
     return (
-      <div style={{ padding: '120px 0 60px 0' }}>
+      <div style={{ padding: `${56 + 12}px 40px 40px 40px`, maxWidth: 720 }}>
         <Fieldset
           legend="Send a test query"
           description="Try out some queries, and take a look at what they return."
         >
-          <Field label={<Label text="What type of request?" />} input={methodDropdown} />
+          <div className={styles.requestRow}>
+            <Field label={<Label text="Method" />} input={methodDropdown} />
+            <Field
+              label={<Label text="Endpoint" />}
+              input={
+                <TextInput
+                  value={this.state.endpoint}
+                  monospace={true}
+                  placeholder={'classes/_User'}
+                  onChange={endpoint => this.setState({ endpoint })}
+                />
+              }
+            />
+          </div>
+          <div className={styles.inlineToggle}>
+            <div className={styles.inlineToggleLabel}>
+              <span className={styles.inlineToggleLabelText}>Use Master Key</span>
+              <span className={styles.inlineToggleDesc}>Bypass ACL/CLPs</span>
+            </div>
+            <Toggle
+              value={this.state.useMasterKey}
+              type={Toggle.Types.HIDE_LABELS}
+              onChange={useMasterKey => this.setState({ useMasterKey })}
+            />
+          </div>
           <Field
             label={
               <Label
-                text="Which endpoint?"
-                description={
-                  <span>
-                    Not sure what endpoint you need?
-                    <br />
-                    Take a look at our{' '}
-                    <a href="http://docs.parseplatform.org/rest/guide/">REST API guide</a>.
-                  </span>
-                }
-              />
-            }
-            input={
-              <TextInput
-                value={this.state.endpoint}
-                monospace={true}
-                placeholder={'classes/_User'}
-                onChange={endpoint => this.setState({ endpoint })}
-              />
-            }
-          />
-          <Field
-            label={<Label text="Use Master Key?" description={'This will bypass any ACL/CLPs.'} />}
-            input={
-              <Toggle
-                value={this.state.useMasterKey}
-                onChange={useMasterKey => this.setState({ useMasterKey })}
-              />
-            }
-          />
-          <Field
-            label={
-              <Label
-                text="Run as..."
-                description={
-                  'Send your query as a specific user. You can use their username or Object ID.'
-                }
+                text="Run as"
+                description={'Username or Object ID of a specific user.'}
               />
             }
             input={
@@ -255,8 +245,9 @@ export default class RestConsole extends Component {
                 text="Query parameters"
                 description={
                   <span>
-                    Learn more about query parameters in our{' '}
-                    <a href="http://docs.parseplatform.org/rest/guide/#queries">REST API guide</a>.
+                    See{' '}
+                    <a href="http://docs.parseplatform.org/rest/guide/#queries" style={{ color: 'inherit', textDecoration: 'underline' }}>REST API guide</a>{' '}
+                    for details.
                   </span>
                 }
               />
@@ -272,11 +263,12 @@ export default class RestConsole extends Component {
             }
           />
         </Fieldset>
-        <Fieldset legend="Results" description="">
-          <div className={fieldStyle.field}>
+        <div className={styles.resultsSection}>
+          <div className={styles.resultsLabel}>Response</div>
+          <div className={styles.resultsBlock}>
             <JsonPrinter object={this.state.response} />
           </div>
-        </Fieldset>
+        </div>
         <Toolbar section="Core" subsection="API Console" />
         <FlowFooter
           primary={

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -2782,8 +2782,11 @@ class Browser extends DashboardView {
     });
     special.sort((a, b) => stringCompare(a.name, b.name));
     categories.sort((a, b) => stringCompare(a.name, b.name));
-    if (special.length > 0 && categories.length > 0) {
-      special.push({ type: 'separator', id: 'classSeparator' });
+    if (special.length > 0) {
+      special.unshift({ type: 'sectionHeader', id: 'coreHeader', name: 'Core' });
+    }
+    if (categories.length > 0) {
+      categories.unshift({ type: 'sectionHeader', id: 'classesHeader', name: 'Classes' });
     }
     const allCategories = [];
     for (const row of [...special, ...categories]) {

--- a/src/dashboard/Data/Browser/Browser.scss
+++ b/src/dashboard/Data/Browser/Browser.scss
@@ -9,8 +9,8 @@
 
 .browser {
   position: fixed;
-  top: 96px;
-  left: 300px;
+  top: $toolbar-height;
+  left: $sidebar-width;
   right: 0;
   bottom: 36px;
   overflow: auto;
@@ -24,7 +24,7 @@ body:global(.expanded) {
 
 .empty {
   position: fixed;
-  left: 300px;
+  left: $sidebar-width;
   top: 0;
   bottom: 0;
   right: 0;
@@ -32,54 +32,199 @@ body:global(.expanded) {
 
 .toolbarSeparator {
   display: inline-block;
-  height: 18px;
+  height: 16px;
   width: 1px;
-  background: #66637a;
-  vertical-align: bottom;
-  margin: 0 4px;
+  background: rgba(255, 255, 255, 0.12);
+  vertical-align: middle;
+  margin: 0 var(--space-1);
+  flex-shrink: 0;
 }
 
 .toolbarButton {
-  @include NotoSansFont;
-  display: inline-block;
-  font-size: 14px;
-  color: #ffffff;
+  @include UIFont;
+  display: inline-flex;
+  align-items: center;
+  font-size: var(--text-sm);
+  color: var(--color-text-on-dark-muted);
   cursor: pointer;
-  height: 14px;
-  padding: 0 12px;
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-md);
+  transition: background var(--transition-fast), color var(--transition-fast);
+  white-space: nowrap;
 
   svg {
     vertical-align: middle;
     margin-right: 4px;
-    fill: #66637a;
+    fill: var(--color-text-on-dark-muted);
+    transition: fill var(--transition-fast);
   }
 
   &:hover {
+    background: rgba(255, 255, 255, 0.1);
+    color: var(--color-text-on-dark);
+
     svg {
-      fill: white;
+      fill: var(--color-text-on-dark);
     }
   }
 
   span {
     vertical-align: middle;
-    height: 14px;
-    line-height: 14px;
+    line-height: 1;
   }
 }
 
 .toolbarButtonDisabled {
   cursor: not-allowed;
-  color: #66637a;
+  color: var(--color-text-on-dark-muted);
+  opacity: 0.5;
 
-  &:hover svg {
-    fill: #66637a;
+  &:hover {
+    background: none;
+    color: var(--color-text-on-dark-muted);
+
+    svg {
+      fill: var(--color-text-on-dark-muted);
+    }
+  }
+}
+
+@media (max-width: $bp-md - 1) {
+  .browser {
+    left: 0;
+    top: calc(#{$toolbar-height} + #{$mobile-header-height});
+  }
+
+  .empty {
+    left: 0;
+  }
+
+  .toolbarButton span {
+    display: none;
+  }
+
+  // Hide secondary toolbar items on mobile — they go into overflow
+  .toolbarSecondary {
+    display: none;
+  }
+}
+
+.toolbarPrimary {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  flex-shrink: 0;
+}
+
+.toolbarSecondary {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.overflowMenuButton {
+  @include UIFont;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: none;
+  cursor: pointer;
+  border-radius: var(--radius-md);
+  color: var(--color-text-secondary);
+  transition: background var(--transition-fast);
+  padding: 0;
+  flex-shrink: 0;
+
+  &:hover {
+    background: var(--color-interactive-hover);
+    color: var(--color-text-primary);
+  }
+}
+
+@media (max-width: $bp-md - 1) {
+  .overflowMenuButton {
+    display: flex;
+  }
+}
+
+.overflowMenu {
+  position: absolute;
+  top: $toolbar-height;
+  right: 0;
+  background: var(--color-bg-elevated);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-overlay);
+  border: 1px solid var(--color-border-secondary);
+  min-width: 220px;
+  max-height: 70vh;
+  overflow-y: auto;
+  z-index: 50;
+  padding: var(--space-1) 0;
+}
+
+.overflowMenuBackdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 49;
+}
+
+.overflowSection {
+  padding: var(--space-1) 0;
+
+  &:not(:last-child) {
+    border-bottom: 1px solid var(--color-border-secondary);
+  }
+}
+
+.overflowSectionTitle {
+  @include UIFont;
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: var(--space-1) var(--space-3);
+  font-weight: var(--font-weight-medium);
+}
+
+.overflowItem {
+  @include UIFont;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-sm);
+  color: var(--color-text-primary);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  white-space: nowrap;
+
+  svg {
+    fill: var(--color-text-tertiary);
+    flex-shrink: 0;
+  }
+
+  &:hover {
+    background: var(--color-interactive-hover);
+  }
+
+  &.disabled {
+    color: var(--color-text-tertiary);
+    cursor: not-allowed;
+    opacity: 0.5;
+
+    &:hover {
+      background: none;
+    }
   }
 }
 
 .table {
-  position: absolute;
-  top: 30px;
-  bottom: 0;
   left: 0;
   width: 100%;
 }
@@ -89,15 +234,22 @@ body:global(.expanded) {
 }
 
 .tableRow {
-  @include MonospaceFont;
+  font-family: var(--font-data-browser);
   font-size: 12px;
+  font-variant-numeric: tabular-nums;
   white-space: nowrap;
   height: 30px;
-  border-bottom: 1px solid #e3e3ea;
+  border-bottom: 1px solid var(--color-border-secondary);
   will-change: transform;
+  transition: background 80ms ease;
+  background: var(--color-bg-primary);
 
   &:nth-child(odd) {
-    background: #f4f5f7;
+    background: var(--color-row-stripe);
+  }
+
+  &:hover {
+    background: var(--color-row-hover);
   }
 }
 
@@ -107,7 +259,7 @@ body:global(.expanded) {
   height: 30px;
   line-height: 31px;
   vertical-align: top;
-  border-right: 1px solid #e3e3ea;
+  border-right: 1px solid var(--color-border-primary);
   text-align: center;
 }
 
@@ -116,7 +268,7 @@ body:global(.expanded) {
   height: 30px;
   line-height: 31px;
   vertical-align: top;
-  border-right: 1px solid #e3e3ea;
+  border-right: 1px solid var(--color-border-primary);
   text-align: center;
   padding: 0 4px;
   box-sizing: border-box;
@@ -132,10 +284,10 @@ body:global(.expanded) {
   }
 
   svg {
-    fill: $blue;
+    fill: var(--color-accent-blue);
 
     &:hover {
-      fill: $darkBlue;
+      fill: var(--color-accent-blue-hover);
     }
   }
 }
@@ -146,56 +298,84 @@ body:global(.expanded) {
     align-items: center;
     justify-content: center;
     width: 50%;
-    background: #f6fafb;
+    background: var(--color-bg-secondary);
   }
 }
 
 .notificationMessage,
 .notificationError {
-  @include animation('fade-in 0.2s ease-out');
-  position: absolute;
-  bottom: 20px;
-  right: 20px;
+  @include UIFont;
+  @include animation('toast-in 0.3s cubic-bezier(0.4, 0, 0.2, 1)');
+  position: fixed;
+  bottom: var(--space-6);
+  right: var(--space-6);
   opacity: 1;
-  background: white;
-  padding: 10px;
-  font-size: 14px;
-  border-radius: 5px;
-  width: 260px;
+  background: var(--color-bg-elevated);
+  padding: var(--space-3) var(--space-4);
+  font-size: var(--text-sm);
+  border-radius: var(--radius-lg);
+  min-width: 280px;
+  max-width: 400px;
+  box-shadow: var(--shadow-overlay);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  line-height: 1.4;
 }
 
 .notificationError {
-  border: 2px solid $red;
-  color: $red;
+  border-left: 4px solid var(--color-accent-red);
+  color: var(--color-text-primary);
+
+  &::before {
+    content: '';
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--color-accent-red);
+    flex-shrink: 0;
+  }
 }
 
 .notificationMessage {
-  border: 2px solid $blue;
-  color: $blue;
+  border-left: 4px solid var(--color-accent-blue);
+  color: var(--color-text-primary);
+
+  &::before {
+    content: '';
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--color-accent-blue);
+    flex-shrink: 0;
+  }
 }
 
 .notificationHide {
-  @include animation('fade-out 0.2s ease-out');
+  @include animation('toast-out 0.2s cubic-bezier(0.4, 0, 0.2, 1)');
 }
 
-@include keyframes(fade-in) {
+@include keyframes(toast-in) {
   0% {
-    @include transform(scale(0.9));
+    @include transform(translateY(16px));
     opacity: 0;
   }
   100% {
-    @include transform(scale(1));
+    @include transform(translateY(0));
     opacity: 1;
   }
 }
 
-@include keyframes(fade-out) {
+@include keyframes(toast-out) {
   0% {
-    @include transform(scale(1));
+    @include transform(translateY(0));
     opacity: 1;
   }
   100% {
-    @include transform(scale(0.9));
+    @include transform(translateY(16px));
     opacity: 0;
   }
 }
@@ -223,11 +403,11 @@ body:global(.expanded) {
   }
 
   .toolbarButton svg {
-    fill: rgba(0, 0, 0, 0.3);
+    fill: var(--color-text-tertiary);
   }
 
   .toolbarSeparator {
-    background: rgba(0, 0, 0, 0.3);
+    background: var(--color-text-tertiary);
   }
 
   .selectionSection {
@@ -235,13 +415,13 @@ body:global(.expanded) {
     right: 0;
     width: 142px;
     font-size: 12px;
-    color: #0e69a1;
-    background: #f4f5f7;
-    font-family: 'Source Code Pro', 'Courier New', monospace;
+    color: var(--color-accent-blue-hover);
+    background: var(--color-bg-secondary);
+    font-family: var(--font-data-browser);
 
     .selectionHeader {
-      background: rgb(102, 99, 122);
-      color: white;
+      background: var(--color-bg-tertiary);
+      color: var(--color-text-primary);
       height: 30px;
       padding-top: 5px;
       padding-left: 10px;

--- a/src/dashboard/Data/Browser/BrowserFooter.react.js
+++ b/src/dashboard/Data/Browser/BrowserFooter.react.js
@@ -1,4 +1,3 @@
-import Button from 'components/Button/Button.react';
 import React from 'react';
 import styles from './BrowserFooter.scss';
 import FooterStats from './FooterStats.react';
@@ -20,7 +19,6 @@ class BrowserFooter extends React.Component {
   }
 
   handleLimitChange = event => {
-    // Check if there are selected rows
     if (this.props.hasSelectedRows && !window.confirm(this.props.selectedRowsMessage)) {
       return;
     }
@@ -32,7 +30,6 @@ class BrowserFooter extends React.Component {
 
   handlePageChange = newSkip => {
     if (newSkip >= 0 && newSkip < this.props.count) {
-      // Check if there are selected rows
       if (this.props.hasSelectedRows && !window.confirm(this.props.selectedRowsMessage)) {
         return;
       }
@@ -71,57 +68,69 @@ class BrowserFooter extends React.Component {
   render() {
     const { skip, count, limit, selectedCellsCount, selectedData } = this.props;
     const totalPages = Math.ceil(count / limit);
+    const currentPage = Math.floor(skip / limit) + 1;
 
     return (
       <div className={styles.footer}>
-        <span><strong>{count?.toLocaleString() || 0}</strong> objects</span>
-        <span style={{ color: 'lightgray' }}>|</span>
-        <select value={limit} onChange={this.handleLimitChange}>
-          {[10, 20, 50, 100, 200, 500, 1000].map(size => (
-            <option key={size} value={size}>
-              {size}
-            </option>
-          ))}
-        </select>
-        <span>per page</span>
-        <span style={{ color: 'lightgray' }}>|</span>
-        <span>Objects {(skip + 1).toLocaleString()} to {Math.min(count ?? limit, skip + limit).toLocaleString()}</span>
-        {selectedCellsCount > 0 && (
-          <>
-            <span style={{ color: 'lightgray' }}>|</span>
-            <span><strong>{selectedCellsCount.toLocaleString()}</strong> cells selected</span>
-          </>
-        )}
-        {selectedData?.length > 0 && (
-          <>
-            <span style={{ color: 'lightgray' }}>|</span>
-            <FooterStats data={selectedData} />
-          </>
-        )}
-        <span style={{ marginLeft: 'auto' }}></span>
-        <span>Page</span>
-        <input
-          type="text"
-          style={{ width: `${Math.max(this.state.pageInput.length + 1, 3)}ch` }}
-          value={this.state.pageInput}
-          onChange={this.handleInputChange}
-          onBlur={this.validateAndApplyPage}
-          onKeyDown={this.handleKeyDown}
-        />
-        <span>of {totalPages.toLocaleString()}</span>
-        <span style={{ color: 'lightgray' }}>|</span>
-        <Button
-          value="⬅︎"
-          width="80px"
-          onClick={() => this.handlePageChange(skip - limit)}
-          disabled={skip === 0}
-        />
-        <Button
-          value="⮕"
-          width="80px"
-          onClick={() => this.handlePageChange(skip + limit)}
-          disabled={skip + limit >= count}
-        />
+        <div className={styles.footerLeft}>
+          <span><strong>{count?.toLocaleString() || 0}</strong> objects</span>
+          <span className={styles.sep} />
+          <select className={styles.pageSelect} value={limit} onChange={this.handleLimitChange}>
+            {[10, 20, 50, 100, 200, 500, 1000].map(size => (
+              <option key={size} value={size}>
+                {size}
+              </option>
+            ))}
+          </select>
+          <span>per page</span>
+          <span className={styles.sep} />
+          <span>Objects {(skip + 1).toLocaleString()} to {Math.min(count ?? limit, skip + limit).toLocaleString()}</span>
+          {selectedCellsCount > 0 && (
+            <>
+              <span className={styles.sep} />
+              <span><strong>{selectedCellsCount.toLocaleString()}</strong> cells selected</span>
+            </>
+          )}
+          {selectedData?.length > 0 && (
+            <>
+              <span className={styles.sep} />
+              <FooterStats data={selectedData} />
+            </>
+          )}
+        </div>
+        <div className={styles.footerRight}>
+          <span className={styles.pageLabel}>Page</span>
+          <input
+            className={styles.pageInput}
+            type="text"
+            style={{ width: `${Math.max(this.state.pageInput.length + 1, 3)}ch` }}
+            value={this.state.pageInput}
+            onChange={this.handleInputChange}
+            onBlur={this.validateAndApplyPage}
+            onKeyDown={this.handleKeyDown}
+          />
+          <span className={styles.pageLabel}>of {totalPages.toLocaleString()}</span>
+          <button
+            className={styles.navBtn}
+            onClick={() => this.handlePageChange(skip - limit)}
+            disabled={skip === 0}
+            title="Previous page"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="15 18 9 12 15 6" />
+            </svg>
+          </button>
+          <button
+            className={styles.navBtn}
+            onClick={() => this.handlePageChange(skip + limit)}
+            disabled={skip + limit >= count}
+            title="Next page"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="9 6 15 12 9 18" />
+            </svg>
+          </button>
+        </div>
       </div>
     );
   }

--- a/src/dashboard/Data/Browser/BrowserFooter.scss
+++ b/src/dashboard/Data/Browser/BrowserFooter.scss
@@ -1,18 +1,132 @@
 @import 'stylesheets/globals.scss';
 
 .footer {
+  @include UIFont;
   position: absolute;
-  width: calc(100% - 300px);
+  width: calc(100% - $sidebar-width);
   bottom: 0;
-  gap: 10px;
-  padding: 0px 15px;
+  padding: 0 var(--space-4);
   height: 36px;
   display: flex;
   flex-direction: row;
   flex-wrap: nowrap;
   align-items: center;
-  font-size: 12px;
-  font-family: "Noto Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
-  border-top: 1px solid lightgrey;
-  background-color: #f1f5f9;
+  justify-content: space-between;
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  border-top: 1px solid var(--color-border-primary);
+  background-color: var(--color-bg-primary);
+}
+
+body:global(.expanded) {
+  .footer {
+    width: calc(100% - $sidebarCollapsedWidth);
+  }
+}
+
+@media (max-width: $bp-md - 1) {
+  .footer {
+    width: 100%;
+  }
+}
+
+.footerLeft {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+  overflow: hidden;
+}
+
+.footerRight {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-shrink: 0;
+}
+
+.sep {
+  width: 1px;
+  height: 14px;
+  background: var(--color-border-primary);
+  flex-shrink: 0;
+}
+
+.pageSelect {
+  @include UIFont;
+  appearance: none;
+  -webkit-appearance: none;
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-primary);
+  border-radius: var(--radius-sm);
+  padding: 2px 20px 2px 6px;
+  font-size: var(--text-xs);
+  color: var(--color-text-primary);
+  cursor: pointer;
+  height: 24px;
+  background-image: url("data:image/svg+xml,%3Csvg width='10' height='6' viewBox='0 0 10 6' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1L5 5L9 1' stroke='%239ca3af' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 6px center;
+  transition: border-color var(--transition-fast);
+
+  &:hover {
+    border-color: var(--color-text-tertiary);
+  }
+
+  &:focus {
+    outline: none;
+    border-color: var(--color-border-focus);
+  }
+}
+
+.pageLabel {
+  color: var(--color-text-tertiary);
+}
+
+.pageInput {
+  @include UIFont;
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-primary);
+  border-radius: var(--radius-sm);
+  padding: 2px 4px;
+  font-size: var(--text-xs);
+  color: var(--color-text-primary);
+  text-align: center;
+  height: 24px;
+  transition: border-color var(--transition-fast);
+
+  &:focus {
+    outline: none;
+    border-color: var(--color-border-focus);
+  }
+}
+
+.navBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--color-border-primary);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-primary);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
+  padding: 0;
+
+  &:hover:not(:disabled) {
+    background: var(--color-bg-secondary);
+    border-color: var(--color-text-tertiary);
+    color: var(--color-text-primary);
+  }
+
+  &:disabled {
+    opacity: 0.3;
+    cursor: not-allowed;
+  }
+
+  svg {
+    flex-shrink: 0;
+  }
 }

--- a/src/dashboard/Data/Browser/BrowserTable.react.js
+++ b/src/dashboard/Data/Browser/BrowserTable.react.js
@@ -155,7 +155,7 @@ export default class BrowserTable extends React.Component {
               const isEditingRow =
                 this.props.current && this.props.current.row === index && !!this.props.editing;
               return (
-                <div key={index} style={{ borderBottom: '1px solid #169CEE' }}>
+                <div key={index} style={{ borderBottom: '1px solid var(--color-accent-blue)' }}>
                   <BrowserRow
                     appId={this.props.appId}
                     key={index}
@@ -251,7 +251,7 @@ export default class BrowserTable extends React.Component {
         const currentCol =
           this.props.current && this.props.current.row === -1 ? this.props.current.col : undefined;
         newRow = (
-          <div style={{ borderBottom: '1px solid #169CEE' }}>
+          <div style={{ borderBottom: '1px solid var(--color-accent-blue)' }}>
             <BrowserRow
               appId={this.props.appId}
               key={-1}

--- a/src/dashboard/Data/Browser/BrowserToolbar.react.js
+++ b/src/dashboard/Data/Browser/BrowserToolbar.react.js
@@ -18,7 +18,7 @@ import LoginDialog from 'dashboard/Data/Browser/LoginDialog.react';
 import SecureFieldsDialog from 'dashboard/Data/Browser/SecureFieldsDialog.react';
 import SecurityDialog from 'dashboard/Data/Browser/SecurityDialog.react';
 import prettyNumber from 'lib/prettyNumber';
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 
 const BrowserToolbar = ({
   className,
@@ -288,6 +288,7 @@ const BrowserToolbar = ({
   const clpDialogRef = useRef(null);
   const protectedDialogRef = useRef(null);
   const loginDialogRef = useRef(null);
+  const [overflowOpen, setOverflowOpen] = useState(false);
 
   const showCLP = () => clpDialogRef.current.handleOpen();
   const showProtected = () => protectedDialogRef.current.handleOpen();
@@ -311,277 +312,10 @@ const BrowserToolbar = ({
       isAutoScrolling={isAutoScrolling}
       stopAutoScroll={stopAutoScroll}
     >
-      {onAddRow && (
-        <a className={classes.join(' ')} onClick={onClick}>
-          <Icon name="plus-solid" width={14} height={14} />
-          <span>Add Row</span>
-        </a>
-      )}
-      {onAddRow && <div className={styles.toolbarSeparator} />}
-      <ColumnsConfiguration
-        handleColumnsOrder={handleColumnsOrder}
-        handleColumnDragDrop={handleColumnDragDrop}
-        order={order}
-        disabled={isPendingEditCloneRows}
-        className={classNameForEditors}
-      />
-      <div className={styles.toolbarSeparator} />
+      {/* Hidden dialog containers */}
       {onAddRow && (
         <LoginDialog ref={loginDialogRef} currentUser={currentUser} login={login} logout={logout} />
       )}
-      {onAddRow && (
-        <BrowserMenu
-          setCurrent={setCurrent}
-          title={currentUser ? 'Browsing' : 'Browse'}
-          icon="users-solid"
-          active={!!currentUser}
-          disabled={isPendingEditCloneRows}
-        >
-          <MenuItem text={currentUser ? 'Switch User' : 'As User'} onClick={showLogin} />
-          {currentUser ? (
-            <MenuItem
-              text={
-                <span>
-                  Use Master Key{' '}
-                  <Toggle
-                    type={Toggle.Types.HIDE_LABELS}
-                    value={useMasterKey}
-                    onChange={toggleMasterKeyUsage}
-                    switchNoMargin={true}
-                    additionalStyles={{
-                      display: 'inline',
-                      lineHeight: 0,
-                      margin: 0,
-                      paddingLeft: 5,
-                    }}
-                  />
-                </span>
-              }
-              onClick={toggleMasterKeyUsage}
-            />
-          ) : (
-            <noscript />
-          )}
-          {currentUser ? (
-            <MenuItem
-              text={
-                <span>
-                  Stop browsing (<b>{currentUser.get('username')}</b>)
-                </span>
-              }
-              onClick={logout}
-            />
-          ) : (
-            <noscript />
-          )}
-        </BrowserMenu>
-      )}
-      {onAddRow && <div className={styles.toolbarSeparator} />}
-      {onAddRow && (
-        <BrowserMenu
-          title="Data"
-          icon="down-solid"
-          disabled={isUnique || isPendingEditCloneRows}
-          setCurrent={setCurrent}
-        >
-          <MenuItem
-            disabled={!selectionLength}
-            text={`Export ${selectionLength} selected ${selectionLength <= 1 ? 'row' : 'rows'}`}
-            onClick={() => onExportSelectedRows(selection)}
-          />
-          <MenuItem text={'Export all rows'} onClick={() => onExportSelectedRows({ '*': true })} />
-          <MenuItem text={'Export schema'} onClick={() => onExportSchema()} />
-          {!relation && (
-            <>
-              <Separator />
-              <MenuItem text={'Import'} onClick={() => onImport()} />
-            </>
-          )}
-        </BrowserMenu>
-      )}
-      {onAddRow && <div className={styles.toolbarSeparator} />}
-      <BrowserMenu setCurrent={setCurrent} title="Settings" icon="gear-solid">
-        <BrowserMenu title="Info Panel" setCurrent={setCurrent}>
-          <MenuItem
-            text={
-              <span>
-                {autoLoadFirstRow && (
-                  <Icon
-                    name="check"
-                    width={12}
-                    height={12}
-                    fill="#ffffffff"
-                    className="menuCheck"
-                  />
-                )}
-                Auto-load first row
-              </span>
-            }
-            onClick={() => {
-              toggleAutoLoadFirstRow();
-            }}
-          />
-          <MenuItem
-            text={
-              <span>
-                {batchNavigate && (
-                  <Icon
-                    name="check"
-                    width={12}
-                    height={12}
-                    fill="#ffffffff"
-                    className="menuCheck"
-                  />
-                )}
-                Batch-navigate panels
-              </span>
-            }
-            onClick={() => {
-              toggleBatchNavigate();
-            }}
-          />
-          <MenuItem
-            text={
-              <span>
-                {showPanelCheckbox && (
-                  <Icon
-                    name="check"
-                    width={12}
-                    height={12}
-                    fill="#ffffffff"
-                    className="menuCheck"
-                  />
-                )}
-                Show panel selection
-              </span>
-            }
-            onClick={() => {
-              toggleShowPanelCheckbox();
-            }}
-          />
-          <Separator />
-          <MenuItem
-            text={
-              <span>
-                {scrollToTop && (
-                  <Icon
-                    name="check"
-                    width={12}
-                    height={12}
-                    fill="#ffffffff"
-                    className="menuCheck"
-                  />
-                )}
-                Scroll to top
-              </span>
-            }
-            onClick={() => {
-              toggleScrollToTop();
-            }}
-          />
-          <MenuItem
-            text={
-              <span>
-                {syncPanelScroll && (
-                  <Icon
-                    name="check"
-                    width={12}
-                    height={12}
-                    fill="#ffffffff"
-                    className="menuCheck"
-                  />
-                )}
-                Sync panel scrolling
-              </span>
-            }
-            onClick={() => {
-              toggleSyncPanelScroll();
-            }}
-          />
-          <BrowserMenu title="Auto-scroll" setCurrent={setCurrent}>
-            <MenuItem
-              text={
-                <span>
-                  {autoScrollEnabled && (
-                    <Icon
-                      name="check"
-                      width={12}
-                      height={12}
-                      fill="#ffffffff"
-                      className="menuCheck"
-                    />
-                  )}
-                  Enabled
-                </span>
-              }
-              onClick={() => {
-                toggleAutoScroll();
-              }}
-            />
-            <MenuItem
-              text={
-                <span>
-                  {autoScrollRequireHover && (
-                    <Icon
-                      name="check"
-                      width={12}
-                      height={12}
-                      fill="#ffffffff"
-                      className="menuCheck"
-                    />
-                  )}
-                  Require hover
-                </span>
-              }
-              onClick={() => {
-                toggleAutoScrollRequireHover();
-              }}
-            />
-          </BrowserMenu>
-        </BrowserMenu>
-      </BrowserMenu>
-      <div className={styles.toolbarSeparator} />
-      <BrowserMenu setCurrent={setCurrent} title="Graph" icon="analytics-solid">
-        <MenuItem
-          text={
-            <span>
-              {isGraphPanelVisible && (
-                <Icon
-                  name="check"
-                  width={12}
-                  height={12}
-                  fill="#ffffffff"
-                  className="menuCheck"
-                />
-              )}
-              Show Graph Panel
-            </span>
-          }
-          onClick={toggleGraphPanel}
-          disableMouseDown={true}
-        />
-      </BrowserMenu>
-      <div className={styles.toolbarSeparator} />
-      <a className={classes.join(' ')} onClick={isPendingEditCloneRows ? null : onRefresh}>
-        <Icon name="refresh-solid" width={14} height={14} />
-        <span>Refresh</span>
-      </a>
-      <div className={styles.toolbarSeparator} />
-      <BrowserFilter
-        setCurrent={setCurrent}
-        schema={schemaSimplifiedData}
-        filters={filters}
-        savedFilters={savedFilters}
-        onChange={onFilterChange}
-        onSaveFilter={onFilterSave}
-        onDeleteFilter={onDeleteFilter}
-        className={classNameForEditors}
-        blacklistedFilters={onAddRow ? [] : ['unique']}
-        disabled={isPendingEditCloneRows}
-        allClasses={allClasses}
-        allClassesSchema={allClassesSchema}
-      />
-      {onAddRow && <div className={styles.toolbarSeparator} />}
       {enableSecurityDialog ? (
         <SecurityDialog
           ref={clpDialogRef}
@@ -610,50 +344,184 @@ const BrowserToolbar = ({
         icon="locked-solid"
         onEditPermissions={onEditPermissions}
       />
-      {enableSecurityDialog ? (
-        <BrowserMenu
-          setCurrent={setCurrent}
-          title="Security"
-          icon="locked-solid"
-          disabled={!!relation || !!isUnique || isPendingEditCloneRows}
-        >
-          <MenuItem text={'Class Level Permissions'} onClick={showCLP} />
-          <MenuItem text={'Protected Fields'} onClick={showProtected} />
-        </BrowserMenu>
-      ) : (
-        <noscript />
+
+      {/* Primary actions — always visible, single row */}
+      {onAddRow && (
+        <a className={classes.join(' ')} onClick={onClick}>
+          <Icon name="plus-solid" width={14} height={14} />
+          <span>Add Row</span>
+        </a>
       )}
-      {enableSecurityDialog ? <div className={styles.toolbarSeparator} /> : <noscript />}
-      <BrowserMenu setCurrent={setCurrent} title="Script" icon="script-solid">
-        <MenuItem
-          disabled={selectionLength === 0}
-          text={
-            selectionLength === 1 && !selection['*']
-              ? 'Run script on selected row...'
-              : `Run script on ${selectionLength} selected rows...`
-          }
-          onClick={() => onExecuteScriptRows(selection)}
-          shortcut={runScriptShortcut}
-        />
+      {onAddRow && <div className={styles.toolbarSeparator} />}
+      <ColumnsConfiguration
+        handleColumnsOrder={handleColumnsOrder}
+        handleColumnDragDrop={handleColumnDragDrop}
+        order={order}
+        disabled={isPendingEditCloneRows}
+        className={classNameForEditors}
+      />
+      <div className={styles.toolbarSeparator} />
+      <BrowserFilter
+        setCurrent={setCurrent}
+        schema={schemaSimplifiedData}
+        filters={filters}
+        savedFilters={savedFilters}
+        onChange={onFilterChange}
+        onSaveFilter={onFilterSave}
+        onDeleteFilter={onDeleteFilter}
+        className={classNameForEditors}
+        blacklistedFilters={onAddRow ? [] : ['unique']}
+        disabled={isPendingEditCloneRows}
+        allClasses={allClasses}
+        allClassesSchema={allClassesSchema}
+      />
+      <div className={styles.toolbarSeparator} />
+      <a className={classes.join(' ')} onClick={isPendingEditCloneRows ? null : onRefresh}>
+        <Icon name="refresh-solid" width={14} height={14} />
+        <span>Refresh</span>
+      </a>
+      <div className={styles.toolbarSeparator} />
+
+      {/* Consolidated "More" menu — Browse, Data, Security, Script, Edit, Settings, Graph */}
+      <BrowserMenu setCurrent={setCurrent} title="More" icon="ellipses">
+        {onAddRow && (
+          <BrowserMenu
+            setCurrent={setCurrent}
+            title={currentUser ? 'Browsing' : 'Browse As'}
+            icon="users-solid"
+            active={!!currentUser}
+            disabled={isPendingEditCloneRows}
+          >
+            <MenuItem text={currentUser ? 'Switch User' : 'As User'} onClick={showLogin} />
+            {currentUser ? (
+              <MenuItem
+                text={
+                  <span>
+                    Use Master Key{' '}
+                    <Toggle
+                      type={Toggle.Types.HIDE_LABELS}
+                      value={useMasterKey}
+                      onChange={toggleMasterKeyUsage}
+                      switchNoMargin={true}
+                      additionalStyles={{
+                        display: 'inline',
+                        lineHeight: 0,
+                        margin: 0,
+                        paddingLeft: 5,
+                      }}
+                    />
+                  </span>
+                }
+                onClick={toggleMasterKeyUsage}
+              />
+            ) : (
+              <noscript />
+            )}
+            {currentUser ? (
+              <MenuItem
+                text={<span>Stop browsing (<b>{currentUser.get('username')}</b>)</span>}
+                onClick={logout}
+              />
+            ) : (
+              <noscript />
+            )}
+          </BrowserMenu>
+        )}
+        {onAddRow && <Separator />}
+        {onAddRow && (
+          <BrowserMenu
+            title="Import / Export"
+            icon="down-solid"
+            disabled={isUnique || isPendingEditCloneRows}
+            setCurrent={setCurrent}
+          >
+            <MenuItem
+              disabled={!selectionLength}
+              text={`Export ${selectionLength} selected ${selectionLength <= 1 ? 'row' : 'rows'}`}
+              onClick={() => onExportSelectedRows(selection)}
+            />
+            <MenuItem text={'Export all rows'} onClick={() => onExportSelectedRows({ '*': true })} />
+            <MenuItem text={'Export schema'} onClick={() => onExportSchema()} />
+            {!relation && (
+              <>
+                <Separator />
+                <MenuItem text={'Import'} onClick={() => onImport()} />
+              </>
+            )}
+          </BrowserMenu>
+        )}
         <Separator />
         <MenuItem
+          text={<span>{isGraphPanelVisible && <Icon name="check" width={12} height={12} fill="currentColor" className="menuCheck" />}Graph Panel</span>}
+          onClick={toggleGraphPanel}
           disableMouseDown={true}
-          text={
-            <span>
-              {reloadDataTableAfterScript && (
-                <Icon
-                  name="check"
-                  width={12}
-                  height={12}
-                  fill="#ffffffff"
-                  className="menuCheck"
-                />
-              )}
-              Reload all rows after run
-            </span>
-          }
-          onClick={() => toggleReloadDataTableAfterScript()}
         />
+        <Separator />
+        {enableSecurityDialog ? (
+          <BrowserMenu
+            setCurrent={setCurrent}
+            title="Security"
+            icon="locked-solid"
+            disabled={!!relation || !!isUnique || isPendingEditCloneRows}
+          >
+            <MenuItem text={'Class Level Permissions'} onClick={showCLP} />
+            <MenuItem text={'Protected Fields'} onClick={showProtected} />
+          </BrowserMenu>
+        ) : (
+          <noscript />
+        )}
+        <BrowserMenu setCurrent={setCurrent} title="Script" icon="script-solid">
+          <MenuItem
+            disabled={selectionLength === 0}
+            text={
+              selectionLength === 1 && !selection['*']
+                ? 'Run script on selected row...'
+                : `Run script on ${selectionLength} selected rows...`
+            }
+            onClick={() => onExecuteScriptRows(selection)}
+            shortcut={runScriptShortcut}
+          />
+          <Separator />
+          <MenuItem
+            disableMouseDown={true}
+            text={<span>{reloadDataTableAfterScript && <Icon name="check" width={12} height={12} fill="currentColor" className="menuCheck" />}Reload all rows after run</span>}
+            onClick={() => toggleReloadDataTableAfterScript()}
+          />
+        </BrowserMenu>
+        <Separator />
+        <BrowserMenu setCurrent={setCurrent} title="Info Panel" icon="gear-solid">
+          <MenuItem
+            text={<span>{autoLoadFirstRow && <Icon name="check" width={12} height={12} fill="currentColor" className="menuCheck" />}Auto-load first row</span>}
+            onClick={() => toggleAutoLoadFirstRow()}
+          />
+          <MenuItem
+            text={<span>{batchNavigate && <Icon name="check" width={12} height={12} fill="currentColor" className="menuCheck" />}Batch-navigate panels</span>}
+            onClick={() => toggleBatchNavigate()}
+          />
+          <MenuItem
+            text={<span>{showPanelCheckbox && <Icon name="check" width={12} height={12} fill="currentColor" className="menuCheck" />}Show panel selection</span>}
+            onClick={() => toggleShowPanelCheckbox()}
+          />
+          <Separator />
+          <MenuItem
+            text={<span>{scrollToTop && <Icon name="check" width={12} height={12} fill="currentColor" className="menuCheck" />}Scroll to top</span>}
+            onClick={() => toggleScrollToTop()}
+          />
+          <MenuItem
+            text={<span>{syncPanelScroll && <Icon name="check" width={12} height={12} fill="currentColor" className="menuCheck" />}Sync panel scrolling</span>}
+            onClick={() => toggleSyncPanelScroll()}
+          />
+          <BrowserMenu title="Auto-scroll" setCurrent={setCurrent}>
+            <MenuItem
+              text={<span>{autoScrollEnabled && <Icon name="check" width={12} height={12} fill="currentColor" className="menuCheck" />}Enabled</span>}
+              onClick={() => toggleAutoScroll()}
+            />
+            <MenuItem
+              text={<span>{autoScrollRequireHover && <Icon name="check" width={12} height={12} fill="currentColor" className="menuCheck" />}Require hover</span>}
+              onClick={() => toggleAutoScrollRequireHover()}
+            />
+          </BrowserMenu>
+        </BrowserMenu>
       </BrowserMenu>
       <div className={styles.toolbarSeparator} />
       {menu}

--- a/src/dashboard/Data/Browser/CreateClassDialog.react.js
+++ b/src/dashboard/Data/Browser/CreateClassDialog.react.js
@@ -65,10 +65,8 @@ class CreateClassDialog extends React.Component {
     return (
       <Modal
         type={Modal.Types.INFO}
-        icon="plus"
-        iconSize={40}
-        title="Create a new class?"
-        subtitle="This creates a new class to hold objects."
+        title="Create class"
+        subtitle="Add a new class to store objects."
         disabled={!this.valid()}
         confirmText="Create"
         cancelText="Cancel"
@@ -89,21 +87,19 @@ class CreateClassDialog extends React.Component {
         }}
       >
         {availableClasses.length > 1 ? (
-          <Field label={<Label text="What type of class do you need?" />} input={typeDropdown} />
+          <Field label={<Label text="Class type" />} input={typeDropdown} />
         ) : null}
         {this.state.type === 'Custom' ? (
           <Field
             label={
               <Label
-                text="What should we call it?"
-                description={
-                  'Don\u2019t use any special characters, and start your name with a letter.'
-                }
+                text="Class name"
+                description='Start with a letter. Use only letters, numbers, and underscores.'
               />
             }
             input={
               <TextInput
-                placeholder="Give it a good name..."
+                placeholder="e.g., MyNewClass"
                 value={this.state.name}
                 onChange={name => this.setState({ name })}
               />

--- a/src/dashboard/Data/Browser/Databrowser.scss
+++ b/src/dashboard/Data/Browser/Databrowser.scss
@@ -1,6 +1,8 @@
+@import 'stylesheets/globals.scss';
+
 .resizablePanel{
     position: fixed;
-    top: 96px;
+    top: $toolbar-height;
     right: 0;
     bottom: 36px;
     :global(.react-resizable-handle) {
@@ -10,7 +12,7 @@
         bottom: 0;
         width: 10px;
         cursor: col-resize;
-        box-shadow: -3px 0 3px -1px rgba(203, 203, 203, 0.2);
+        box-shadow: var(--shadow-xs);
         user-select: none;
         -webkit-user-select: none;
         -moz-user-select: none;
@@ -21,13 +23,13 @@
 .aggregationPanelContainer{
     height: 100%;
     overflow: auto;
-    background-color: #fefafb;
+    background-color: var(--color-bg-secondary);
 }
 
 .graphPanelContainer{
     height: 100%;
     overflow: auto;
-    background-color: #fefafb;
+    background-color: var(--color-bg-secondary);
 }
 
 .multiPanelWrapper {
@@ -58,22 +60,22 @@
     }
 
     &::-webkit-scrollbar-thumb {
-        background: rgba(0, 0, 0, 0.2);
+        background: var(--color-text-tertiary);
         border-radius: 3px;
     }
 
     &::-webkit-scrollbar-thumb:hover {
-        background: rgba(0, 0, 0, 0.4);
+        background: var(--color-text-secondary);
     }
 
     /* Firefox scrollbar support */
     scrollbar-width: thin;
-    scrollbar-color: rgba(0, 0, 0, 0.2) transparent;
+    scrollbar-color: var(--color-text-tertiary) transparent;
 }
 
 .panelSeparator {
     width: 0px;
-    background-color: #ebebeb;
+    background-color: var(--color-border-secondary);
     flex-shrink: 0;
 }
 
@@ -81,8 +83,8 @@
     position: sticky;
     top: 0;
     z-index: 10;
-    background-color: #67637a;
-    border-left: 1px solid #878396;
+    background-color: var(--color-bg-tertiary);
+    border-left: 1px solid var(--color-border-primary);
     padding: 8px 8px 6px 8px;
     display: flex;
     align-items: center;

--- a/src/dashboard/Data/Browser/EditRowDialog.react.js
+++ b/src/dashboard/Data/Browser/EditRowDialog.react.js
@@ -446,7 +446,7 @@ export default class EditRowDialog extends React.Component {
           {targetClass ? `${type} <${targetClass}>` : type}
           <div style={{ marginTop: '2px' }}>
             {expandedTextAreas[name] && expandedTextAreas[name].rows > 3 && (
-              <a style={{ color: '#169cee' }} onClick={() => this.toggleExpandTextArea(name)}>
+              <a style={{ color: 'var(--color-accent-blue)' }} onClick={() => this.toggleExpandTextArea(name)}>
                 {expandedTextAreas[name].expanded ? 'collapse' : 'expand'}
               </a>
             )}

--- a/src/dashboard/Data/Browser/ExportSelectedRowsDialog.scss
+++ b/src/dashboard/Data/Browser/ExportSelectedRowsDialog.scss
@@ -2,7 +2,7 @@
   display: block;
   position: relative;
   height: 100px;
-  border-bottom: 1px solid #e0e0e1;
+  border-bottom: 1px solid var(--color-border-primary);
 }
 .label {
   line-height: 16px;

--- a/src/dashboard/Data/Browser/FooterStats.scss
+++ b/src/dashboard/Data/Browser/FooterStats.scss
@@ -12,8 +12,8 @@
   height: 26px;
   line-height: 26px;
   font-size: 12px;
-  color: #555;
-  border: 1px solid #ccc;
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border-primary);
   cursor: pointer;
   position: relative;
   white-space: nowrap;
@@ -25,15 +25,15 @@
     top: 10px;
     border-style: solid;
     border-width: 5px 4px 0 4px;
-    border-top-color: #999;
+    border-top-color: var(--color-text-tertiary);
     border-right-color: transparent;
     border-bottom-color: transparent;
     border-left-color: transparent;
   }
 
   &:hover {
-    background: rgba(0, 0, 0, 0.05);
-    border-color: #aaa;
+    background: var(--color-interactive-hover);
+    border-color: var(--color-text-tertiary);
   }
 }
 
@@ -44,13 +44,13 @@
   margin-bottom: 4px;
   display: flex;
   flex-direction: column;
-  background: #fff;
+  background: var(--color-bg-elevated);
   border-radius: 5px;
   padding: 8px 0;
   font-size: 14px;
-  color: #333;
+  color: var(--color-text-primary);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-border-primary);
   animation: stats-fade-in 0.15s ease-out;
   min-width: 140px;
 }
@@ -76,20 +76,20 @@
   white-space: nowrap;
 
   &:hover {
-    background: #f0f0f0;
+    background: var(--color-bg-tertiary);
   }
 
   .stats_label {
     font-weight: 500;
-    color: #333;
+    color: var(--color-text-primary);
   }
 
   .stats_value {
-    color: #888;
+    color: var(--color-text-secondary);
     font-size: 12px;
   }
 }
 
 .stats_popover_item.active {
-  background: #e8f4fc;
+  background: var(--color-accent-blue-light);
 }

--- a/src/dashboard/Data/Browser/GraphDialog.react.js
+++ b/src/dashboard/Data/Browser/GraphDialog.react.js
@@ -466,7 +466,7 @@ export default class GraphDialog extends React.Component {
     const effectiveType = s.chartType || chartType;
 
     return (
-      <div key={index} style={{ paddingTop: '10px', paddingLeft: '10px', paddingRight: '10px', paddingBottom: isExpanded ? '0' : '10px', borderTop: '1px solid #e3e3e3', borderLeft: '1px solid #e3e3e3', borderRight: '1px solid #e3e3e3', borderBottom: 'none' }}>
+      <div key={index} style={{ paddingTop: '10px', paddingLeft: '10px', paddingRight: '10px', paddingBottom: isExpanded ? '0' : '10px', borderTop: '1px solid var(--color-border-secondary)', borderLeft: '1px solid var(--color-border-secondary)', borderRight: '1px solid var(--color-border-secondary)', borderBottom: 'none' }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: isExpanded ? '8px' : '0', cursor: 'pointer' }} onClick={() => this.toggleSeries(index)}>
           <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
             <span style={{ fontSize: '12px' }}>{isExpanded ? '▼' : '▶'}</span>
@@ -476,7 +476,7 @@ export default class GraphDialog extends React.Component {
         </div>
         {isExpanded && (
           <div style={{ paddingBottom: '8px' }}>
-            <div style={{ borderTop: '1px solid #e3e3e3', borderLeft: '1px solid #e3e3e3', borderRight: '1px solid #e3e3e3', borderBottom: '1px solid #e3e3e3' }}>
+            <div style={{ borderTop: '1px solid var(--color-border-secondary)', borderLeft: '1px solid var(--color-border-secondary)', borderRight: '1px solid var(--color-border-secondary)', borderBottom: '1px solid var(--color-border-secondary)' }}>
               <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr' }}>
                 <div style={{ display: 'flex', alignItems: 'center' }}>
                   <Label text="Title" description="Optional custom name" />
@@ -489,7 +489,7 @@ export default class GraphDialog extends React.Component {
                   />
                 </div>
               </div>
-              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid #e3e3e3' }}>
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid var(--color-border-secondary)' }}>
                 <div style={{ display: 'flex', alignItems: 'center' }}>
                   <Label text="Fields" />
                 </div>
@@ -508,7 +508,7 @@ export default class GraphDialog extends React.Component {
                   </MultiSelect>
                 </div>
               </div>
-              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid #e3e3e3' }}>
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid var(--color-border-secondary)' }}>
                 <div style={{ display: 'flex', alignItems: 'center' }}>
                   <Label text="Aggregation" />
                 </div>
@@ -526,7 +526,7 @@ export default class GraphDialog extends React.Component {
                 </div>
               </div>
               {(chartType === 'bar' || chartType === 'line') && (
-                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid #e3e3e3' }}>
+                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid var(--color-border-secondary)' }}>
                   <div style={{ display: 'flex', alignItems: 'center' }}>
                     <Label text="Chart Type" />
                   </div>
@@ -547,11 +547,11 @@ export default class GraphDialog extends React.Component {
                 </div>
               )}
               {(chartType === 'bar' || chartType === 'line') && (
-                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid #e3e3e3' }}>
+                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid var(--color-border-secondary)' }}>
                   <div style={{ display: 'flex', alignItems: 'center' }}>
                     <Label text="Secondary Y Axis" description="Display on right axis" />
                   </div>
-                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', background: '#f6fafb', minHeight: '80px' }}>
+                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'var(--color-bg-secondary)', minHeight: '80px' }}>
                     <Toggle
                       type={Toggle.Types.YES_NO}
                       value={s.useSecondaryYAxis || false}
@@ -560,11 +560,11 @@ export default class GraphDialog extends React.Component {
                   </div>
                 </div>
               )}
-              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid #e3e3e3' }}>
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid var(--color-border-secondary)' }}>
                 <div style={{ display: 'flex', alignItems: 'center' }}>
                   <Label text="Color" description="Preset or custom HEX" />
                 </div>
-                <div style={{ display: 'flex', alignItems: 'center', background: '#f6fafb' }}>
+                <div style={{ display: 'flex', alignItems: 'center', background: 'var(--color-bg-secondary)' }}>
                   <div style={{ display: 'flex', alignItems: 'center', marginLeft: '20px' }}>
                     <span style={{ fontSize: '14px', fontFamily: 'monospace' }}>#</span>
                     <div style={{ width: '70px' }}>
@@ -588,8 +588,8 @@ export default class GraphDialog extends React.Component {
                       <Option value=""><span style={{ display: 'flex' }}>Auto</span></Option>
                       {s.color && !PREDEFINED_COLORS.find(c => c.value === s.color) && !isValidHexColor(s.color) && (
                         <Option value="invalid">
-                          <span style={{ display: 'flex', alignItems: 'center', gap: '8px', color: '#c62828' }}>
-                            <span style={{ width: '14px', height: '14px', backgroundColor: '#ffebee', borderRadius: '2px', border: '1px solid #c62828', flexShrink: 0 }} />
+                          <span style={{ display: 'flex', alignItems: 'center', gap: '8px', color: 'var(--color-accent-red)' }}>
+                            <span style={{ width: '14px', height: '14px', backgroundColor: 'var(--color-accent-red-light, #ffebee)', borderRadius: '2px', border: '1px solid var(--color-accent-red)', flexShrink: 0 }} />
                             Invalid
                           </span>
                         </Option>
@@ -597,7 +597,7 @@ export default class GraphDialog extends React.Component {
                       {s.color && !PREDEFINED_COLORS.find(c => c.value === s.color) && isValidHexColor(s.color) && (
                         <Option value="custom">
                           <span style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                            <span style={{ width: '14px', height: '14px', backgroundColor: s.color, borderRadius: '2px', border: '1px solid #ccc', flexShrink: 0 }} />
+                            <span style={{ width: '14px', height: '14px', backgroundColor: s.color, borderRadius: '2px', border: '1px solid var(--color-border-secondary)', flexShrink: 0 }} />
                             Custom
                           </span>
                         </Option>
@@ -605,7 +605,7 @@ export default class GraphDialog extends React.Component {
                       {PREDEFINED_COLORS.map(c => (
                         <Option key={c.value} value={c.value}>
                           <span style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                            <span style={{ width: '14px', height: '14px', backgroundColor: c.value, borderRadius: '2px', border: '1px solid #ccc', flexShrink: 0 }} />
+                            <span style={{ width: '14px', height: '14px', backgroundColor: c.value, borderRadius: '2px', border: '1px solid var(--color-border-secondary)', flexShrink: 0 }} />
                             {c.label}
                           </span>
                         </Option>
@@ -616,7 +616,7 @@ export default class GraphDialog extends React.Component {
               </div>
               {effectiveType === 'line' && (
                 <>
-                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid #e3e3e3' }}>
+                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid var(--color-border-secondary)' }}>
                     <div style={{ display: 'flex', alignItems: 'center' }}>
                       <Label text="Line Style" />
                     </div>
@@ -633,7 +633,7 @@ export default class GraphDialog extends React.Component {
                       </Dropdown>
                     </div>
                   </div>
-                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid #e3e3e3' }}>
+                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid var(--color-border-secondary)' }}>
                     <div style={{ display: 'flex', alignItems: 'center' }}>
                       <Label text="Stroke Width" />
                     </div>
@@ -653,7 +653,7 @@ export default class GraphDialog extends React.Component {
                 </>
               )}
               {effectiveType === 'bar' && (
-                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid #e3e3e3' }}>
+                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid var(--color-border-secondary)' }}>
                   <div style={{ display: 'flex', alignItems: 'center' }}>
                     <Label text="Bar Style" />
                   </div>
@@ -689,7 +689,7 @@ export default class GraphDialog extends React.Component {
     const effectiveType = calc.chartType || chartType;
 
     return (
-      <div key={`calc-${index}`} style={{ paddingTop: '10px', paddingLeft: '10px', paddingRight: '10px', paddingBottom: isExpanded ? '0' : '10px', borderTop: '1px solid #e3e3e3', borderLeft: '1px solid #e3e3e3', borderRight: '1px solid #e3e3e3', borderBottom: 'none' }}>
+      <div key={`calc-${index}`} style={{ paddingTop: '10px', paddingLeft: '10px', paddingRight: '10px', paddingBottom: isExpanded ? '0' : '10px', borderTop: '1px solid var(--color-border-secondary)', borderLeft: '1px solid var(--color-border-secondary)', borderRight: '1px solid var(--color-border-secondary)', borderBottom: 'none' }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: isExpanded ? '8px' : '0', cursor: 'pointer' }} onClick={() => this.toggleCalculatedValue(index)}>
           <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
             <span style={{ fontSize: '12px' }}>{isExpanded ? '▼' : '▶'}</span>
@@ -699,7 +699,7 @@ export default class GraphDialog extends React.Component {
         </div>
         {isExpanded && (
           <div style={{ paddingBottom: '8px' }}>
-            <div style={{ borderTop: '1px solid #e3e3e3', borderLeft: '1px solid #e3e3e3', borderRight: '1px solid #e3e3e3', borderBottom: '1px solid #e3e3e3' }}>
+            <div style={{ borderTop: '1px solid var(--color-border-secondary)', borderLeft: '1px solid var(--color-border-secondary)', borderRight: '1px solid var(--color-border-secondary)', borderBottom: '1px solid var(--color-border-secondary)' }}>
               <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr' }}>
                 <div style={{ display: 'flex', alignItems: 'center' }}>
                   <Label text="Name" />
@@ -712,7 +712,7 @@ export default class GraphDialog extends React.Component {
                   />
                 </div>
               </div>
-              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid #e3e3e3' }}>
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid var(--color-border-secondary)' }}>
                 <div style={{ display: 'flex', alignItems: 'center' }}>
                   <Label text="Operator" />
                 </div>
@@ -731,7 +731,7 @@ export default class GraphDialog extends React.Component {
               </div>
               {calc.operator === 'formula' ? (
                 <>
-                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid #e3e3e3' }}>
+                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid var(--color-border-secondary)' }}>
                     <div style={{ display: 'flex', alignItems: 'center' }}>
                       <Label text="Formula" description="e.g., price * quantity" />
                     </div>
@@ -744,7 +744,7 @@ export default class GraphDialog extends React.Component {
                     </div>
                   </div>
                   {formulaError && (
-                    <div style={{ borderTop: '1px solid #e3e3e3', padding: '12px', background: '#ffebee', color: '#c62828' }}>
+                    <div style={{ borderTop: '1px solid var(--color-border-secondary)', padding: '12px', background: 'var(--color-accent-red-light, #ffebee)', color: 'var(--color-accent-red)' }}>
                       <strong>Formula Error</strong>
                       <p style={{ margin: '4px 0 0 0', fontSize: '12px' }}>
                         {formulaError}
@@ -754,7 +754,7 @@ export default class GraphDialog extends React.Component {
                 </>
               ) : calc.operator === 'percent' ? (
                 <>
-                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid #e3e3e3' }}>
+                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid var(--color-border-secondary)' }}>
                     <div style={{ display: 'flex', alignItems: 'center' }}>
                       <Label text="Numerator" />
                     </div>
@@ -775,7 +775,7 @@ export default class GraphDialog extends React.Component {
                       </Dropdown>
                     </div>
                   </div>
-                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid #e3e3e3' }}>
+                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid var(--color-border-secondary)' }}>
                     <div style={{ display: 'flex', alignItems: 'center' }}>
                       <Label text="Denominator" />
                     </div>
@@ -798,7 +798,7 @@ export default class GraphDialog extends React.Component {
                   </div>
                 </>
               ) : (
-                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid #e3e3e3' }}>
+                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid var(--color-border-secondary)' }}>
                   <div style={{ display: 'flex', alignItems: 'center' }}>
                     <Label text="Fields" />
                   </div>
@@ -819,7 +819,7 @@ export default class GraphDialog extends React.Component {
                 </div>
               )}
               {(chartType === 'bar' || chartType === 'line') && (
-                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid #e3e3e3' }}>
+                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid var(--color-border-secondary)' }}>
                   <div style={{ display: 'flex', alignItems: 'center' }}>
                     <Label text="Chart Type" />
                   </div>
@@ -840,11 +840,11 @@ export default class GraphDialog extends React.Component {
                 </div>
               )}
               {(chartType === 'bar' || chartType === 'line') && (
-                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid #e3e3e3' }}>
+                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid var(--color-border-secondary)' }}>
                   <div style={{ display: 'flex', alignItems: 'center' }}>
                     <Label text="Secondary Y Axis" description="Display on right axis" />
                   </div>
-                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', background: '#f6fafb', minHeight: '80px' }}>
+                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'var(--color-bg-secondary)', minHeight: '80px' }}>
                     <Toggle
                       type={Toggle.Types.YES_NO}
                       value={calc.useSecondaryYAxis || false}
@@ -853,11 +853,11 @@ export default class GraphDialog extends React.Component {
                   </div>
                 </div>
               )}
-              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid #e3e3e3' }}>
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid var(--color-border-secondary)' }}>
                 <div style={{ display: 'flex', alignItems: 'center' }}>
                   <Label text="Color" description="Preset or custom HEX" />
                 </div>
-                <div style={{ display: 'flex', alignItems: 'center', background: '#f6fafb' }}>
+                <div style={{ display: 'flex', alignItems: 'center', background: 'var(--color-bg-secondary)' }}>
                   <div style={{ display: 'flex', alignItems: 'center', marginLeft: '20px' }}>
                     <span style={{ fontSize: '14px', fontFamily: 'monospace' }}>#</span>
                     <div style={{ width: '70px' }}>
@@ -881,8 +881,8 @@ export default class GraphDialog extends React.Component {
                       <Option value=""><span style={{ display: 'flex' }}>Auto</span></Option>
                       {calc.color && !PREDEFINED_COLORS.find(c => c.value === calc.color) && !isValidHexColor(calc.color) && (
                         <Option value="invalid">
-                          <span style={{ display: 'flex', alignItems: 'center', gap: '8px', color: '#c62828' }}>
-                            <span style={{ width: '14px', height: '14px', backgroundColor: '#ffebee', borderRadius: '2px', border: '1px solid #c62828', flexShrink: 0 }} />
+                          <span style={{ display: 'flex', alignItems: 'center', gap: '8px', color: 'var(--color-accent-red)' }}>
+                            <span style={{ width: '14px', height: '14px', backgroundColor: 'var(--color-accent-red-light, #ffebee)', borderRadius: '2px', border: '1px solid var(--color-accent-red)', flexShrink: 0 }} />
                             Invalid
                           </span>
                         </Option>
@@ -890,7 +890,7 @@ export default class GraphDialog extends React.Component {
                       {calc.color && !PREDEFINED_COLORS.find(c => c.value === calc.color) && isValidHexColor(calc.color) && (
                         <Option value="custom">
                           <span style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                            <span style={{ width: '14px', height: '14px', backgroundColor: calc.color, borderRadius: '2px', border: '1px solid #ccc', flexShrink: 0 }} />
+                            <span style={{ width: '14px', height: '14px', backgroundColor: calc.color, borderRadius: '2px', border: '1px solid var(--color-border-secondary)', flexShrink: 0 }} />
                             Custom
                           </span>
                         </Option>
@@ -898,7 +898,7 @@ export default class GraphDialog extends React.Component {
                       {PREDEFINED_COLORS.map(c => (
                         <Option key={c.value} value={c.value}>
                           <span style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                            <span style={{ width: '14px', height: '14px', backgroundColor: c.value, borderRadius: '2px', border: '1px solid #ccc', flexShrink: 0 }} />
+                            <span style={{ width: '14px', height: '14px', backgroundColor: c.value, borderRadius: '2px', border: '1px solid var(--color-border-secondary)', flexShrink: 0 }} />
                             {c.label}
                           </span>
                         </Option>
@@ -909,7 +909,7 @@ export default class GraphDialog extends React.Component {
               </div>
               {effectiveType === 'line' && (
                 <>
-                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid #e3e3e3' }}>
+                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid var(--color-border-secondary)' }}>
                     <div style={{ display: 'flex', alignItems: 'center' }}>
                       <Label text="Line Style" />
                     </div>
@@ -926,7 +926,7 @@ export default class GraphDialog extends React.Component {
                       </Dropdown>
                     </div>
                   </div>
-                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid #e3e3e3' }}>
+                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid var(--color-border-secondary)' }}>
                     <div style={{ display: 'flex', alignItems: 'center' }}>
                       <Label text="Stroke Width" />
                     </div>
@@ -946,7 +946,7 @@ export default class GraphDialog extends React.Component {
                 </>
               )}
               {effectiveType === 'bar' && (
-                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid #e3e3e3' }}>
+                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid var(--color-border-secondary)' }}>
                   <div style={{ display: 'flex', alignItems: 'center' }}>
                     <Label text="Bar Style" />
                   </div>
@@ -965,7 +965,7 @@ export default class GraphDialog extends React.Component {
                 </div>
               )}
               {hasCircular && (
-                <div style={{ borderTop: '1px solid #e3e3e3', padding: '12px', background: '#fff3cd', color: '#856404' }}>
+                <div style={{ borderTop: '1px solid var(--color-border-secondary)', padding: '12px', background: '#fff3cd', color: '#856404' }}>
                   <strong>Circular Reference Detected</strong>
                   <p style={{ margin: '4px 0 0 0', fontSize: '12px' }}>
                     This calculated value references another calculated value that references it back, creating a circular dependency. This will result in null values.
@@ -1026,7 +1026,7 @@ export default class GraphDialog extends React.Component {
             {this.state.calculatedValues.map((calc, index) => this.renderCalculatedValueBox(calc, index))}
 
             {/* Add buttons */}
-            <div style={{ borderTop: (this.state.series.length === 0 && this.state.calculatedValues.length === 0) ? '1px solid #e3e3e3' : 'none', borderLeft: '1px solid #e3e3e3', borderRight: '1px solid #e3e3e3', borderBottom: '1px solid #e3e3e3', minHeight: '80px', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '16px', background: '#f6fafb' }}>
+            <div style={{ borderTop: (this.state.series.length === 0 && this.state.calculatedValues.length === 0) ? '1px solid var(--color-border-secondary)' : 'none', borderLeft: '1px solid var(--color-border-secondary)', borderRight: '1px solid var(--color-border-secondary)', borderBottom: '1px solid var(--color-border-secondary)', minHeight: '80px', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '16px', background: 'var(--color-bg-secondary)' }}>
               <Button value="+ Add Series" onClick={this.addSeries} />
               <Button value="+ Add Calculated Value" onClick={this.addCalculatedValue} />
             </div>

--- a/src/dashboard/Data/Browser/ImportDataDialog.scss
+++ b/src/dashboard/Data/Browser/ImportDataDialog.scss
@@ -3,7 +3,7 @@
   position: relative;
   min-height: 50px;
   padding: 10px 24px;
-  border-bottom: 1px solid #e0e0e1;
+  border-bottom: 1px solid var(--color-border-primary);
 }
 
 .label {
@@ -11,13 +11,13 @@
 }
 
 .warning {
-  color: #F5A623;
+  color: var(--color-accent-orange);
   font-size: 12px;
   padding: 4px 24px 8px;
 }
 
 .error {
-  color: #FF395E;
+  color: var(--color-accent-red);
   font-size: 12px;
   padding: 4px 24px 8px;
 }
@@ -27,26 +27,26 @@
 }
 
 .resultSuccess {
-  color: #00DB7C;
+  color: var(--color-accent-green);
   font-size: 14px;
   padding: 2px 0;
 }
 
 .resultFail {
-  color: #FF395E;
+  color: var(--color-accent-red);
   font-size: 14px;
   padding: 2px 0;
 }
 
 .resultSkip {
-  color: #F5A623;
+  color: var(--color-accent-orange);
   font-size: 14px;
   padding: 2px 0;
 }
 
 .progressBarContainer {
   width: 100%;
-  background-color: #e0e0e1;
+  background-color: var(--color-border-primary);
   border-radius: 4px;
   margin: 16px 24px;
   overflow: hidden;
@@ -56,13 +56,13 @@
 
 .progressBar {
   height: 100%;
-  background-color: #169CEE;
+  background-color: var(--color-accent-blue);
   border-radius: 4px;
   transition: width 0.3s ease;
 }
 
 .fileInfo {
-  color: #8E9299;
+  color: var(--color-text-secondary);
   font-size: 12px;
   padding: 4px 24px 8px;
 }
@@ -75,6 +75,6 @@
 .tooltip {
   font-size: 12px;
   font-style: italic;
-  color: #8E9299;
+  color: var(--color-text-secondary);
   padding: 4px 24px 8px;
 }

--- a/src/dashboard/Data/CloudCode/CloudCode.scss
+++ b/src/dashboard/Data/CloudCode/CloudCode.scss
@@ -13,13 +13,13 @@
 }
 
 .content {
-  padding: 96px 0px 0px 0px;
+  padding: $toolbar-height 0px 0px 0px;
   min-height: 100vh;
 }
 
 .empty {
   position: absolute;
-  top: 96px;
+  top: $toolbar-height;
   left: 0;
   right: 0;
   bottom: 0;

--- a/src/dashboard/Data/Config/Config.react.js
+++ b/src/dashboard/Data/Config/Config.react.js
@@ -434,7 +434,7 @@ class Config extends TableView {
         </td>
         <td style={{ textAlign: 'center', width: '5%' }}>
           <a onClick={openDeleteParameterDialog}>
-            <Icon width={16} height={16} name="trash-solid" fill="#ff395e" />
+            <Icon width={16} height={16} name="trash-solid" fill="var(--color-accent-red)" />
           </a>
         </td>
       </tr>

--- a/src/dashboard/Data/Config/ConfigConflictDiff.scss
+++ b/src/dashboard/Data/Config/ConfigConflictDiff.scss
@@ -29,10 +29,10 @@
   min-width: 40px;
   padding: 0 8px;
   text-align: right;
-  color: rgba(27, 31, 36, 0.3);
+  color: var(--color-text-tertiary);
   vertical-align: top;
   user-select: none;
-  border-right: 1px solid #d1d5da;
+  border-right: 1px solid var(--color-border-primary);
 }
 
 .prefix {
@@ -49,11 +49,11 @@
 }
 
 .lineRemoved {
-  background-color: #ffeef0;
+  background-color: var(--color-accent-red-light);
 }
 
 .lineAdded {
-  background-color: #e6ffec;
+  background-color: var(--color-accent-green-light);
 }
 
 .lineContext {
@@ -61,18 +61,18 @@
 }
 
 .charRemoved {
-  background-color: #fdaeb7;
+  background-color: var(--color-accent-red-light);
   border-radius: 2px;
 }
 
 .charAdded {
-  background-color: #abf2bc;
+  background-color: var(--color-accent-green-light);
   border-radius: 2px;
 }
 
 .emptyDiff {
   padding: 16px 20px;
-  color: #586069;
+  color: var(--color-text-secondary);
   font-style: italic;
   text-align: center;
 }

--- a/src/dashboard/Data/Config/ConfigDialog.react.js
+++ b/src/dashboard/Data/Config/ConfigDialog.react.js
@@ -605,8 +605,8 @@ export default class ConfigDialog extends React.Component {
     const customFooter = (
       <div>
         {this.props.conflict && (
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '10px 28px', borderTop: '1px solid #e1e4e8', background: '#ffeef0' }}>
-            <span style={{ color: '#cb2431', fontSize: '13px' }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '10px 28px', borderTop: '1px solid var(--color-border-secondary)', background: 'var(--color-accent-red-light, #ffeef0)' }}>
+            <span style={{ color: 'var(--color-accent-red)', fontSize: '13px' }}>
               Server value changed while editing, see diff view - overwrite it?
             </span>
             <Toggle
@@ -632,7 +632,7 @@ export default class ConfigDialog extends React.Component {
                   disabled={!this.canFormatValue()}
                 />
                 {this.state.error && (
-                  <span style={{ color: '#d73a49', fontSize: '13px' }}>{this.state.error}</span>
+                  <span style={{ color: 'var(--color-accent-red)', fontSize: '13px' }}>{this.state.error}</span>
                 )}
               </>
             )}
@@ -653,26 +653,26 @@ export default class ConfigDialog extends React.Component {
                     position={this.state.optionsMenuPos}
                     onExternalClick={() => { document.activeElement?.blur(); this.setState({ optionsMenuOpen: false }); }}
                   >
-                    <div style={{ background: '#fff', border: '1px solid #e1e4e8', borderRadius: '4px', boxShadow: '0 3px 12px rgba(0,0,0,0.15)', padding: '4px 0', minWidth: '130px', transform: 'translateY(-100%)' }}>
+                    <div style={{ background: 'var(--color-bg-elevated)', border: '1px solid var(--color-border-secondary)', borderRadius: 'var(--radius-md)', boxShadow: 'var(--shadow-overlay)', padding: '4px 0', minWidth: '130px', transform: 'translateY(-100%)' }}>
                       {isJsonType && (
                         <div
                           onClick={() => { document.activeElement?.blur(); this.setState({ wordWrap: !this.state.wordWrap, optionsMenuOpen: false }); }}
-                          style={{ display: 'flex', alignItems: 'center', padding: '8px 12px', cursor: 'pointer', fontSize: '14px', color: '#333', gap: '8px' }}
-                          onMouseEnter={e => e.currentTarget.style.background = '#f6f8fa'}
+                          style={{ display: 'flex', alignItems: 'center', padding: '8px 12px', cursor: 'pointer', fontSize: '14px', color: 'var(--color-text-primary)', gap: '8px' }}
+                          onMouseEnter={e => e.currentTarget.style.background = 'var(--color-interactive-hover)'}
                           onMouseLeave={e => e.currentTarget.style.background = 'transparent'}
                         >
-                          <span style={{ width: '12px', display: 'inline-block' }}>{this.state.wordWrap && <Icon name="check" width={12} height={12} fill="#00db7c" />}</span>
+                          <span style={{ width: '12px', display: 'inline-block' }}>{this.state.wordWrap && <Icon name="check" width={12} height={12} fill="var(--color-accent-green)" />}</span>
                           <span>Word wrap</span>
                         </div>
                       )}
                       {isDiffableType && isExistingParam && (
                         <div
                           onClick={() => { document.activeElement?.blur(); this.setState({ showDiff: !this.state.showDiff, optionsMenuOpen: false }); }}
-                          style={{ display: 'flex', alignItems: 'center', padding: '8px 12px', cursor: 'pointer', fontSize: '14px', color: '#333', gap: '8px' }}
-                          onMouseEnter={e => e.currentTarget.style.background = '#f6f8fa'}
+                          style={{ display: 'flex', alignItems: 'center', padding: '8px 12px', cursor: 'pointer', fontSize: '14px', color: 'var(--color-text-primary)', gap: '8px' }}
+                          onMouseEnter={e => e.currentTarget.style.background = 'var(--color-interactive-hover)'}
                           onMouseLeave={e => e.currentTarget.style.background = 'transparent'}
                         >
-                          <span style={{ width: '12px', display: 'inline-block' }}>{this.state.showDiff && <Icon name="check" width={12} height={12} fill="#00db7c" />}</span>
+                          <span style={{ width: '12px', display: 'inline-block' }}>{this.state.showDiff && <Icon name="check" width={12} height={12} fill="var(--color-accent-green)" />}</span>
                           <span>Diff view</span>
                         </div>
                       )}

--- a/src/dashboard/Data/CustomDashboard/AddElementDialog.react.js
+++ b/src/dashboard/Data/CustomDashboard/AddElementDialog.react.js
@@ -62,7 +62,7 @@ const AddElementDialog = ({ onClose, onSelectType }) => {
             onClick={() => onSelectType(type)}
           >
             <div className={styles.elementIcon}>
-              <Icon name={icon} width={32} height={32} fill="#169cee" />
+              <Icon name={icon} width={32} height={32} fill="var(--color-accent-blue)" />
             </div>
             <div className={styles.elementInfo}>
               <div className={styles.elementTitle}>{title}</div>

--- a/src/dashboard/Data/CustomDashboard/AddElementDialog.scss
+++ b/src/dashboard/Data/CustomDashboard/AddElementDialog.scss
@@ -12,16 +12,16 @@
   align-items: center;
   gap: 16px;
   padding: 16px;
-  background-color: #ffffff;
-  border: 1px solid #e3e3ea;
+  background-color: var(--color-bg-primary);
+  border: 1px solid var(--color-border-primary);
   border-radius: 8px;
   cursor: pointer;
   text-align: left;
   transition: all 0.15s ease;
 
   &:hover {
-    background-color: #f6f6f9;
-    border-color: #169cee;
+    background-color: var(--color-bg-secondary);
+    border-color: var(--color-accent-blue);
   }
 }
 
@@ -31,7 +31,7 @@
   justify-content: center;
   width: 56px;
   height: 56px;
-  background-color: rgba(22, 156, 238, 0.1);
+  background-color: var(--color-accent-blue-light);
   border-radius: 8px;
   flex-shrink: 0;
 }
@@ -43,13 +43,13 @@
 .elementTitle {
   font-size: 16px;
   font-weight: 600;
-  color: #0e69a1;
+  color: var(--color-accent-blue-hover);
   margin-bottom: 4px;
 }
 
 .elementDescription {
   font-size: 14px;
-  color: #66637a;
+  color: var(--color-text-secondary);
 }
 
 .footer {

--- a/src/dashboard/Data/CustomDashboard/CanvasElement.scss
+++ b/src/dashboard/Data/CustomDashboard/CanvasElement.scss
@@ -27,16 +27,16 @@
   padding: 0 12px 12px;
   box-sizing: border-box;
   border-radius: 8px;
-  background-color: #ffffff;
-  border: 1px solid #d5d5dd;
+  background-color: var(--color-bg-primary);
+  border: 1px solid var(--color-border-primary);
   transition: border-color 0.15s ease;
 
   .canvasElement:hover & {
-    border-color: #c5c5d3;
+    border-color: var(--color-border-primary);
   }
 
   .canvasElement.selected & {
-    border-color: #169cee;
+    border-color: var(--color-accent-blue);
   }
 }
 
@@ -57,8 +57,8 @@
     bottom: 4px;
     width: 8px;
     height: 8px;
-    border-right: 2px solid #c5c5d3;
-    border-bottom: 2px solid #c5c5d3;
+    border-right: 2px solid var(--color-border-primary);
+    border-bottom: 2px solid var(--color-border-primary);
   }
 
   :global(.canvasElementWrapper):hover & {
@@ -66,6 +66,6 @@
   }
 
   &:hover::after {
-    border-color: #169cee;
+    border-color: var(--color-accent-blue);
   }
 }

--- a/src/dashboard/Data/CustomDashboard/CustomDashboard.scss
+++ b/src/dashboard/Data/CustomDashboard/CustomDashboard.scss
@@ -4,14 +4,14 @@
   position: relative;
   width: 100%;
   min-height: 100vh;
-  padding-top: 96px;
+  padding-top: $toolbar-height;
 }
 
 .canvas {
   position: relative;
   width: 100%;
-  min-height: calc(100vh - 96px);
-  background-color: #f5f5f7;
+  min-height: calc(100vh - $toolbar-height);
+  background-color: var(--color-bg-tertiary);
   overflow: auto;
   outline: none;
 }
@@ -20,7 +20,7 @@
   @include NotoSansFont;
   display: inline-block;
   font-size: 14px;
-  color: #ffffff;
+  color: var(--color-text-on-dark);
   cursor: pointer;
   height: 14px;
   padding: 0 12px;
@@ -29,12 +29,12 @@
   svg {
     vertical-align: middle;
     margin-right: 4px;
-    fill: #66637a;
+    fill: var(--color-text-secondary);
   }
 
   &:hover {
     svg {
-      fill: white;
+      fill: var(--color-text-on-dark);
     }
   }
 
@@ -49,7 +49,7 @@
   display: inline-block;
   height: 18px;
   width: 1px;
-  background: #66637a;
+  background: var(--color-text-secondary);
   vertical-align: bottom;
   margin: 0 4px;
   margin-top: 8px;
@@ -66,7 +66,7 @@
 .autoReloadLabel {
   @include NotoSansFont;
   font-size: 14px;
-  color: #66637a;
+  color: var(--color-text-secondary);
   margin-right: 6px;
   vertical-align: middle;
 }
@@ -74,7 +74,7 @@
 .autoReloadSelect {
   @include NotoSansFont;
   font-size: 13px;
-  color: #ffffff;
+  color: var(--color-text-on-dark);
   background-color: transparent;
   border: none;
   padding: 0;
@@ -83,8 +83,8 @@
   vertical-align: middle;
 
   option {
-    background-color: #1e2b3c;
-    color: #ffffff;
+    background-color: var(--color-bg-sidebar);
+    color: var(--color-text-on-dark);
   }
 }
 
@@ -94,14 +94,14 @@
   left: 0;
   right: 0;
   height: 2px;
-  background-color: #4a4a5a;
+  background-color: var(--color-text-tertiary);
   border-radius: 1px;
   overflow: hidden;
 }
 
 .autoReloadProgress {
   height: 100%;
-  background-color: #169cee;
+  background-color: var(--color-accent-blue);
   transition: width 0.1s linear;
 }
 

--- a/src/dashboard/Data/CustomDashboard/LoadCanvasDialog.react.js
+++ b/src/dashboard/Data/CustomDashboard/LoadCanvasDialog.react.js
@@ -156,7 +156,7 @@ const LoadCanvasDialog = ({ canvases, onClose, onLoad, onDelete, onToggleFavorit
               title="Delete canvas"
               aria-label={`Delete canvas ${canvas.name || 'Untitled Canvas'}`}
             >
-              <Icon name="trash-solid" width={18} height={18} fill="#94a3b8" />
+              <Icon name="trash-solid" width={18} height={18} fill="var(--color-text-tertiary)" />
             </button>
           </>
         )}
@@ -206,7 +206,7 @@ const LoadCanvasDialog = ({ canvases, onClose, onLoad, onDelete, onToggleFavorit
     >
       {canvases.length === 0 ? (
         <div className={styles.emptyState}>
-          <Icon name="canvas-outline" width={48} height={48} fill="#94a3b8" />
+          <Icon name="canvas-outline" width={48} height={48} fill="var(--color-text-tertiary)" />
           <p>No saved canvases found</p>
           <p className={styles.emptyHint}>Save your current canvas to see it here</p>
         </div>

--- a/src/dashboard/Data/CustomDashboard/LoadCanvasDialog.scss
+++ b/src/dashboard/Data/CustomDashboard/LoadCanvasDialog.scss
@@ -6,7 +6,7 @@
   align-items: center;
   justify-content: center;
   padding: 40px 20px;
-  color: #64748b;
+  color: var(--color-text-secondary);
 
   p {
     margin: 12px 0 0;
@@ -16,7 +16,7 @@
 
 .emptyHint {
   font-size: 12px !important;
-  color: #94a3b8 !important;
+  color: var(--color-text-tertiary) !important;
 }
 
 .canvasList {
@@ -32,19 +32,19 @@
   justify-content: space-between;
   padding: 12px 16px;
   margin-bottom: 8px;
-  background: #f8fafc;
+  background: var(--color-bg-secondary);
   border: 2px solid transparent;
   border-radius: 8px;
   cursor: pointer;
   transition: all 0.15s ease;
 
   &:hover {
-    background: #f1f5f9;
+    background: var(--color-bg-tertiary);
   }
 
   &.selected {
-    border-color: #169cee;
-    background: #e0f2fe;
+    border-color: var(--color-accent-blue);
+    background: var(--color-accent-blue-light);
   }
 
   &:last-child {
@@ -61,7 +61,7 @@
   @include NotoSansFont;
   font-size: 14px;
   font-weight: 500;
-  color: #1e293b;
+  color: var(--color-text-primary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -70,7 +70,7 @@
 .canvasDetails {
   @include NotoSansFont;
   font-size: 12px;
-  color: #64748b;
+  color: var(--color-text-secondary);
   margin-top: 2px;
 }
 
@@ -93,13 +93,13 @@
 
   &:hover {
     svg {
-      fill: #f59e0b;
+      fill: var(--color-accent-orange);
     }
   }
 
   &.favorited {
     svg {
-      fill: #f59e0b;
+      fill: var(--color-accent-orange);
     }
   }
 }
@@ -115,7 +115,7 @@
 
   &:hover {
     svg {
-      fill: #ef4444;
+      fill: var(--color-accent-red);
     }
   }
 }
@@ -125,7 +125,7 @@
   align-items: center;
   gap: 8px;
   font-size: 12px;
-  color: #64748b;
+  color: var(--color-text-secondary);
 
   span {
     white-space: nowrap;
@@ -144,20 +144,20 @@
 }
 
 .confirmYes {
-  background: #ef4444;
-  color: white;
+  background: var(--color-accent-red);
+  color: var(--color-text-on-dark);
 
   &:hover {
-    background: #dc2626;
+    background: var(--color-accent-red);
   }
 }
 
 .confirmNo {
-  background: #e2e8f0;
-  color: #475569;
+  background: var(--color-border-primary);
+  color: var(--color-text-primary);
 
   &:hover {
-    background: #cbd5e1;
+    background: var(--color-border-secondary);
   }
 }
 
@@ -175,14 +175,14 @@
   gap: 8px;
   width: 100%;
   padding: 8px 12px;
-  background: #e2e8f0;
+  background: var(--color-border-primary);
   border: none;
   border-radius: 6px;
   cursor: pointer;
   transition: background 0.15s ease;
 
   &:hover {
-    background: #cbd5e1;
+    background: var(--color-border-secondary);
   }
 }
 
@@ -191,7 +191,7 @@
   transition: transform 0.15s ease;
 
   &:after {
-    @include arrow('down', 10px, 6px, #64748b);
+    @include arrow('down', 10px, 6px, var(--color-text-secondary));
     content: '';
     display: block;
   }
@@ -201,7 +201,7 @@
   @include NotoSansFont;
   font-size: 13px;
   font-weight: 600;
-  color: #475569;
+  color: var(--color-text-primary);
   flex: 1;
   text-align: left;
 }
@@ -209,7 +209,7 @@
 .groupCount {
   @include NotoSansFont;
   font-size: 12px;
-  color: #94a3b8;
+  color: var(--color-text-tertiary);
 }
 
 .groupContent {
@@ -226,7 +226,7 @@
   @include NotoSansFont;
   font-size: 11px;
   font-weight: 600;
-  color: #94a3b8;
+  color: var(--color-text-tertiary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
   padding: 0 16px;

--- a/src/dashboard/Data/CustomDashboard/elements/DataTableConfigDialog.react.js
+++ b/src/dashboard/Data/CustomDashboard/elements/DataTableConfigDialog.react.js
@@ -112,7 +112,7 @@ const DataTableConfigDialog = ({
         <Field
           label={<Label text="No Classes Available" />}
           input={
-            <div style={{ padding: '20px', color: '#94a3b8' }}>
+            <div style={{ padding: '20px', color: 'var(--color-text-tertiary)' }}>
               No classes found. Create a class in the Data Browser first.
             </div>
           }

--- a/src/dashboard/Data/CustomDashboard/elements/DataTableElement.react.js
+++ b/src/dashboard/Data/CustomDashboard/elements/DataTableElement.react.js
@@ -45,7 +45,7 @@ const DataTableElement = ({
   if (!config || !config.className) {
     return (
       <div className={styles.noConfig}>
-        <Icon name="table" width={32} height={32} fill="#64748b" />
+        <Icon name="table" width={32} height={32} fill="var(--color-text-secondary)" />
         <p>No data table configured</p>
       </div>
     );
@@ -54,7 +54,7 @@ const DataTableElement = ({
   if (isLoading) {
     return (
       <div className={styles.loading}>
-        <Icon name="spinner" width={24} height={24} fill="#64748b" />
+        <Icon name="spinner" width={24} height={24} fill="var(--color-text-secondary)" />
         <p>Loading data...</p>
       </div>
     );
@@ -63,7 +63,7 @@ const DataTableElement = ({
   if (error) {
     return (
       <div className={styles.error}>
-        <Icon name="exclamation-triangle" width={24} height={24} fill="#ef4444" />
+        <Icon name="exclamation-triangle" width={24} height={24} fill="var(--color-accent-red)" />
         <p>Error loading data</p>
         {onRefresh && (
           <button type="button" onClick={onRefresh} className={styles.retryButton}>
@@ -77,7 +77,7 @@ const DataTableElement = ({
   if (!data || data.length === 0) {
     return (
       <div className={styles.noData}>
-        <Icon name="table" width={32} height={32} fill="#64748b" />
+        <Icon name="table" width={32} height={32} fill="var(--color-text-secondary)" />
         <p>No data found</p>
       </div>
     );
@@ -124,11 +124,11 @@ const DataTableElement = ({
           className={styles.expandButton}
           title="Expand"
         >
-          <Icon name="expand-outline" width={12} height={12} fill="#94a3b8" />
+          <Icon name="expand-outline" width={12} height={12} fill="var(--color-text-tertiary)" />
         </button>
         {onRefresh && (
           <button type="button" onClick={onRefresh} className={styles.refreshButton}>
-            <Icon name="refresh-solid" width={12} height={12} fill="#94a3b8" />
+            <Icon name="refresh-solid" width={12} height={12} fill="var(--color-text-tertiary)" />
           </button>
         )}
       </div>

--- a/src/dashboard/Data/CustomDashboard/elements/DataTableElement.scss
+++ b/src/dashboard/Data/CustomDashboard/elements/DataTableElement.scss
@@ -13,20 +13,20 @@
   align-items: center;
   gap: 8px;
   padding: 8px 0;
-  border-bottom: 1px solid #e3e3ea;
+  border-bottom: 1px solid var(--color-border-primary);
   flex-shrink: 0;
 }
 
 .tableTitle {
   font-size: 14px;
   font-weight: 600;
-  color: #0e0e1a;
+  color: var(--color-text-primary);
 }
 
 .rowCount {
   font-size: 12px;
-  color: #666666;
-  background-color: #e3e3ea;
+  color: var(--color-text-secondary);
+  background-color: var(--color-border-primary);
   padding: 2px 8px;
   border-radius: 4px;
 }
@@ -52,7 +52,7 @@
   }
 
   &:hover {
-    background-color: rgba(0, 0, 0, 0.1);
+    background-color: var(--color-interactive-hover);
   }
 }
 
@@ -77,7 +77,7 @@
   }
 
   &:hover {
-    background-color: rgba(0, 0, 0, 0.1);
+    background-color: var(--color-interactive-hover);
   }
 }
 
@@ -100,7 +100,7 @@
   th, td {
     padding: 8px 12px;
     text-align: left;
-    border-bottom: 1px solid #e3e3ea;
+    border-bottom: 1px solid var(--color-border-primary);
     max-width: 200px;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -108,8 +108,8 @@
   }
 
   th {
-    background-color: #f4f5f7;
-    color: #666666;
+    background-color: var(--color-bg-secondary);
+    color: var(--color-text-secondary);
     font-weight: 600;
     position: sticky;
     top: 0;
@@ -117,11 +117,11 @@
   }
 
   td {
-    color: #0e0e1a;
+    color: var(--color-text-primary);
   }
 
   tbody tr:hover {
-    background-color: rgba(0, 0, 0, 0.03);
+    background-color: var(--color-interactive-hover);
   }
 }
 
@@ -134,7 +134,7 @@
   align-items: center;
   justify-content: center;
   height: 100%;
-  color: #666666;
+  color: var(--color-text-secondary);
   gap: 8px;
 
   p {
@@ -144,20 +144,20 @@
 }
 
 .error {
-  color: #ef4444;
+  color: var(--color-accent-red);
 }
 
 .retryButton {
   padding: 6px 12px;
-  background-color: #e3e3ea;
-  border: 1px solid #c5c5d3;
+  background-color: var(--color-border-primary);
+  border: 1px solid var(--color-border-primary);
   border-radius: 4px;
-  color: #0e0e1a;
+  color: var(--color-text-primary);
   font-size: 12px;
   cursor: pointer;
   transition: all 0.15s ease;
 
   &:hover {
-    background-color: #c5c5d3;
+    background-color: var(--color-border-primary);
   }
 }

--- a/src/dashboard/Data/CustomDashboard/elements/ExpandModal.react.js
+++ b/src/dashboard/Data/CustomDashboard/elements/ExpandModal.react.js
@@ -58,7 +58,7 @@ const ExpandModal = ({ title, children, onClose }) => {
         <div className={styles.modalHeader}>
           <span className={styles.modalTitle}>{title}</span>
           <button type="button" onClick={onClose} className={styles.closeButton}>
-            <Icon name="x-outline" width={16} height={16} fill="#64748b" />
+            <Icon name="x-outline" width={16} height={16} fill="var(--color-text-secondary)" />
           </button>
         </div>
         <div className={styles.modalBody}>

--- a/src/dashboard/Data/CustomDashboard/elements/ExpandModal.scss
+++ b/src/dashboard/Data/CustomDashboard/elements/ExpandModal.scss
@@ -40,7 +40,7 @@
 .modalContent {
   width: 90vw;
   height: 85vh;
-  background: white;
+  background: var(--color-bg-elevated);
   border-radius: 8px;
   display: flex;
   flex-direction: column;
@@ -64,14 +64,14 @@
   align-items: center;
   justify-content: space-between;
   padding: 16px 20px;
-  border-bottom: 1px solid #e3e3ea;
+  border-bottom: 1px solid var(--color-border-primary);
   flex-shrink: 0;
 }
 
 .modalTitle {
   font-size: 16px;
   font-weight: 600;
-  color: #0e0e1a;
+  color: var(--color-text-primary);
 }
 
 .closeButton {
@@ -87,7 +87,7 @@
   transition: background-color 0.15s ease;
 
   &:hover {
-    background-color: rgba(0, 0, 0, 0.1);
+    background-color: var(--color-interactive-hover);
   }
 }
 

--- a/src/dashboard/Data/CustomDashboard/elements/GraphConfigDialog.react.js
+++ b/src/dashboard/Data/CustomDashboard/elements/GraphConfigDialog.react.js
@@ -124,7 +124,7 @@ const GraphConfigDialog = ({
         <Field
           label={<Label text="No Graphs Available" />}
           input={
-            <div style={{ padding: '20px', color: '#94a3b8' }}>
+            <div style={{ padding: '20px', color: 'var(--color-text-tertiary)' }}>
               No saved graphs found. Create a graph in the Data Browser first.
             </div>
           }

--- a/src/dashboard/Data/CustomDashboard/elements/GraphElement.react.js
+++ b/src/dashboard/Data/CustomDashboard/elements/GraphElement.react.js
@@ -23,7 +23,7 @@ const GraphElement = ({
   if (!config || !config.graphConfig) {
     return (
       <div className={styles.noConfig}>
-        <Icon name="chart-line" width={32} height={32} fill="#64748b" />
+        <Icon name="chart-line" width={32} height={32} fill="var(--color-text-secondary)" />
         <p>No graph configured</p>
       </div>
     );
@@ -63,11 +63,11 @@ const GraphElement = ({
           className={styles.expandButton}
           title="Expand"
         >
-          <Icon name="expand-outline" width={12} height={12} fill="#94a3b8" />
+          <Icon name="expand-outline" width={12} height={12} fill="var(--color-text-tertiary)" />
         </button>
         {onRefresh && (
           <button type="button" onClick={onRefresh} className={styles.refreshButton}>
-            <Icon name="refresh-solid" width={12} height={12} fill="#94a3b8" />
+            <Icon name="refresh-solid" width={12} height={12} fill="var(--color-text-tertiary)" />
           </button>
         )}
       </div>

--- a/src/dashboard/Data/CustomDashboard/elements/GraphElement.scss
+++ b/src/dashboard/Data/CustomDashboard/elements/GraphElement.scss
@@ -13,14 +13,14 @@
   align-items: center;
   gap: 8px;
   padding: 8px 0;
-  border-bottom: 1px solid #e3e3ea;
+  border-bottom: 1px solid var(--color-border-primary);
   flex-shrink: 0;
 }
 
 .graphTitle {
   font-size: 14px;
   font-weight: 600;
-  color: #0e0e1a;
+  color: var(--color-text-primary);
 }
 
 .expandButton {
@@ -44,7 +44,7 @@
   }
 
   &:hover {
-    background-color: rgba(0, 0, 0, 0.1);
+    background-color: var(--color-interactive-hover);
   }
 }
 
@@ -69,7 +69,7 @@
   }
 
   &:hover {
-    background-color: rgba(0, 0, 0, 0.1);
+    background-color: var(--color-interactive-hover);
   }
 }
 
@@ -91,7 +91,7 @@
   align-items: center;
   justify-content: center;
   height: 100%;
-  color: #666666;
+  color: var(--color-text-secondary);
   gap: 8px;
 
   p {

--- a/src/dashboard/Data/CustomDashboard/elements/StaticTextElement.scss
+++ b/src/dashboard/Data/CustomDashboard/elements/StaticTextElement.scss
@@ -1,7 +1,7 @@
 @import 'stylesheets/globals.scss';
 
 .staticText {
-  color: #0e0e1a;
+  color: var(--color-text-primary);
   word-wrap: break-word;
   overflow-wrap: break-word;
   white-space: pre-wrap;

--- a/src/dashboard/Data/CustomDashboard/elements/ViewConfigDialog.react.js
+++ b/src/dashboard/Data/CustomDashboard/elements/ViewConfigDialog.react.js
@@ -63,7 +63,7 @@ const ViewConfigDialog = ({
         <Field
           label={<Label text="No Views Available" />}
           input={
-            <div style={{ padding: '20px', color: '#94a3b8' }}>
+            <div style={{ padding: '20px', color: 'var(--color-text-tertiary)' }}>
               No views found. Create a view in the Views section first.
             </div>
           }
@@ -102,7 +102,7 @@ const ViewConfigDialog = ({
             <Field
               label={<Label text="View Details" description="Information about the selected view" />}
               input={
-                <div style={{ padding: '12px', backgroundColor: '#f4f5f7', borderRadius: '4px', fontSize: '12px', color: '#666666' }}>
+                <div style={{ padding: '12px', backgroundColor: 'var(--color-bg-tertiary)', borderRadius: 'var(--radius-md)', fontSize: '12px', color: 'var(--color-text-secondary)' }}>
                   {selectedView.cloudFunction ? (
                     <div>Cloud Function: <strong>{selectedView.cloudFunction}</strong></div>
                   ) : (

--- a/src/dashboard/Data/CustomDashboard/elements/ViewElement.react.js
+++ b/src/dashboard/Data/CustomDashboard/elements/ViewElement.react.js
@@ -140,7 +140,7 @@ const ViewElement = ({
   if (!config || !config.viewId) {
     return (
       <div className={styles.noConfig}>
-        <Icon name="visibility" width={32} height={32} fill="#64748b" />
+        <Icon name="visibility" width={32} height={32} fill="var(--color-text-secondary)" />
         <p>No view configured</p>
       </div>
     );
@@ -149,7 +149,7 @@ const ViewElement = ({
   if (isLoading) {
     return (
       <div className={styles.loading}>
-        <Icon name="spinner" width={24} height={24} fill="#64748b" />
+        <Icon name="spinner" width={24} height={24} fill="var(--color-text-secondary)" />
         <p>Loading view data...</p>
       </div>
     );
@@ -158,7 +158,7 @@ const ViewElement = ({
   if (error) {
     return (
       <div className={styles.error}>
-        <Icon name="exclamation-triangle" width={24} height={24} fill="#ef4444" />
+        <Icon name="exclamation-triangle" width={24} height={24} fill="var(--color-accent-red)" />
         <p>Error loading view data</p>
         {onRefresh && (
           <button type="button" onClick={onRefresh} className={styles.retryButton}>
@@ -172,7 +172,7 @@ const ViewElement = ({
   if (!data || data.length === 0) {
     return (
       <div className={styles.noData}>
-        <Icon name="visibility" width={32} height={32} fill="#64748b" />
+        <Icon name="visibility" width={32} height={32} fill="var(--color-text-secondary)" />
         <p>No data found</p>
       </div>
     );
@@ -343,11 +343,11 @@ const ViewElement = ({
           className={styles.expandButton}
           title="Expand"
         >
-          <Icon name="expand-outline" width={12} height={12} fill="#94a3b8" />
+          <Icon name="expand-outline" width={12} height={12} fill="var(--color-text-tertiary)" />
         </button>
         {onRefresh && (
           <button type="button" onClick={onRefresh} className={styles.refreshButton}>
-            <Icon name="refresh-solid" width={12} height={12} fill="#94a3b8" />
+            <Icon name="refresh-solid" width={12} height={12} fill="var(--color-text-tertiary)" />
           </button>
         )}
       </div>

--- a/src/dashboard/Data/CustomDashboard/elements/ViewElement.scss
+++ b/src/dashboard/Data/CustomDashboard/elements/ViewElement.scss
@@ -13,20 +13,20 @@
   align-items: center;
   gap: 8px;
   padding: 8px 0;
-  border-bottom: 1px solid #e3e3ea;
+  border-bottom: 1px solid var(--color-border-primary);
   flex-shrink: 0;
 }
 
 .tableTitle {
   font-size: 14px;
   font-weight: 600;
-  color: #0e0e1a;
+  color: var(--color-text-primary);
 }
 
 .rowCount {
   font-size: 12px;
-  color: #666666;
-  background-color: #e3e3ea;
+  color: var(--color-text-secondary);
+  background-color: var(--color-border-primary);
   padding: 2px 8px;
   border-radius: 4px;
 }
@@ -52,7 +52,7 @@
   }
 
   &:hover {
-    background-color: rgba(0, 0, 0, 0.1);
+    background-color: var(--color-interactive-hover);
   }
 }
 
@@ -77,7 +77,7 @@
   }
 
   &:hover {
-    background-color: rgba(0, 0, 0, 0.1);
+    background-color: var(--color-interactive-hover);
   }
 }
 
@@ -99,15 +99,15 @@
   th, td {
     padding: 8px 12px;
     text-align: left;
-    border-bottom: 1px solid #e3e3ea;
+    border-bottom: 1px solid var(--color-border-primary);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
 
   th {
-    background-color: #f4f5f7;
-    color: #666666;
+    background-color: var(--color-bg-secondary);
+    color: var(--color-text-secondary);
     font-weight: 600;
     position: sticky;
     top: 0;
@@ -115,11 +115,11 @@
   }
 
   td {
-    color: #0e0e1a;
+    color: var(--color-text-primary);
   }
 
   tbody tr:hover {
-    background-color: rgba(0, 0, 0, 0.03);
+    background-color: var(--color-interactive-hover);
   }
 }
 
@@ -136,7 +136,7 @@
   align-items: center;
   justify-content: center;
   height: 100%;
-  color: #666666;
+  color: var(--color-text-secondary);
   gap: 8px;
 
   p {
@@ -146,20 +146,20 @@
 }
 
 .error {
-  color: #ef4444;
+  color: var(--color-accent-red);
 }
 
 .retryButton {
   padding: 6px 12px;
-  background-color: #e3e3ea;
-  border: 1px solid #c5c5d3;
+  background-color: var(--color-border-primary);
+  border: 1px solid var(--color-border-primary);
   border-radius: 4px;
-  color: #0e0e1a;
+  color: var(--color-text-primary);
   font-size: 12px;
   cursor: pointer;
   transition: all 0.15s ease;
 
   &:hover {
-    background-color: #c5c5d3;
+    background-color: var(--color-border-primary);
   }
 }

--- a/src/dashboard/Data/Logs/Logs.scss
+++ b/src/dashboard/Data/Logs/Logs.scss
@@ -13,14 +13,14 @@
 }
 
 .content {
-  padding: 106px 10px 10px 10px;
+  padding: calc($toolbar-height + 10px) 10px 10px 10px;
   background: $logViewBackgroundColor;
   min-height: 100vh;
 }
 
 .empty {
   position: absolute;
-  top: 96px;
+  top: $toolbar-height;
   left: 0;
   right: 0;
   bottom: 0;

--- a/src/dashboard/Data/Migration/Migration.react.js
+++ b/src/dashboard/Data/Migration/Migration.react.js
@@ -81,7 +81,7 @@ const ClassProgressBar = ({ job, last }) => {
           className={[styles.detailCompletion, baseStyles.succeededBackground].join(' ')}
         />
       );
-      icon = <Icon name="check-solid" fill="#00db7c" width={15} height={15} />;
+      icon = <Icon name="check-solid" fill="var(--color-accent-green)" width={15} height={15} />;
       break;
     case MIGRATION_FATALED:
       progressDiv = (
@@ -90,7 +90,7 @@ const ClassProgressBar = ({ job, last }) => {
           className={[styles.detailCompletion, baseStyles.failedBackground].join(' ')}
         />
       );
-      icon = <Icon name="x-solid" fill="#ff395e" width={15} height={15} />;
+      icon = <Icon name="x-solid" fill="var(--color-accent-red)" width={15} height={15} />;
   }
   return (
     <div>

--- a/src/dashboard/Data/Migration/Migration.scss
+++ b/src/dashboard/Data/Migration/Migration.scss
@@ -10,7 +10,7 @@
 
 $migrationStatesWidth: 175px;
 $progressRowHeight: 25px;
-$progressRowBorder: 1px $grey solid;
+$progressRowBorder: 1px var(--color-border-primary) solid;
 $progressBarHeight: 10px;
 $progressBarGrey: #edeaeb;
 
@@ -40,7 +40,7 @@ $progressRowPadding: 15px;
 
 .statusBar {
 	clear: both;
-	background-color: $borderGrey;
+	background-color: var(--color-border-primary);
 	height: 32px;
 	padding-top: 8px;
 	padding-left: $progressRowPadding;
@@ -62,7 +62,7 @@ $progressRowPadding: 15px;
 
 .infoText {
 	@include DosisFont;
-	color: $blue;
+	color: var(--color-accent-blue);
 }
 
 .detailMongoName {
@@ -70,7 +70,7 @@ $progressRowPadding: 15px;
 	width: $migrationStatesWidth;
 	float: left;
 	font-size: 20px;
-	color: $blue;
+	color: var(--color-accent-blue);
 	padding-top: 15px;
 	padding-left: $progressRowPadding;
 	padding-right: $progressRowPadding;
@@ -139,13 +139,13 @@ $progressRowPadding: 15px;
 }
 
 .migrationStatusError {
-	color: $red;
+	color: var(--color-accent-red);
 	text-align: center;
 	display: block;
 }
 
 .longStateDescription {
-	background-color: $borderGrey;
+	background-color: var(--color-border-primary);
 	padding: $progressRowPadding;
 	border-radius: 5px;
 	margin-top: 20px;

--- a/src/dashboard/Data/Migration/MigrationStep.react.js
+++ b/src/dashboard/Data/Migration/MigrationStep.react.js
@@ -24,13 +24,13 @@ const MigrationStep = ({ title, description, descriptionWidth = '100%', percentC
       percentComplete = 100;
       progressClass = baseStyles.succeededBackground;
       titleClass = baseStyles.succeededText;
-      icon = <Icon name="check-solid" fill="#00db7c" width={15} height={15} />;
+      icon = <Icon name="check-solid" fill="var(--color-accent-green)" width={15} height={15} />;
       break;
     case AsyncStatus.FAILED:
       percentComplete = 100;
       progressClass = baseStyles.failedBackground;
       titleClass = baseStyles.failedText;
-      icon = <Icon name="x-solid" fill="#ff395e" width={15} height={15} />;
+      icon = <Icon name="x-solid" fill="var(--color-accent-red)" width={15} height={15} />;
       break;
     case AsyncStatus.PROGRESS:
       progressClass = baseStyles.progressBackground;

--- a/src/dashboard/Data/Migration/MigrationStep.scss
+++ b/src/dashboard/Data/Migration/MigrationStep.scss
@@ -16,7 +16,7 @@ $migrationStatesWidth: 175px;
 	width: calc(700px/3);
 	float: left;
 	&:not(:last-child) {
-		border-right: 2px solid $borderGrey;
+		border-right: 2px solid var(--color-border-primary);
 	}
 	&:last-child {
 		border-top-right-radius: 5px;

--- a/src/dashboard/Data/Playground/Playground.react.js
+++ b/src/dashboard/Data/Playground/Playground.react.js
@@ -1192,7 +1192,7 @@ export default function Playground() {
                 );
               } catch {
                 return (
-                  <div key={`${id}-${index}`} style={{ marginLeft: '2px', marginBottom: '1px', fontFamily: 'monospace', color: '#ff6b6b', fontSize: '12px', lineHeight: '1.2' }}>
+                  <div key={`${id}-${index}`} style={{ marginLeft: '2px', marginBottom: '1px', fontFamily: 'monospace', color: 'var(--color-accent-red)', fontSize: '12px', lineHeight: '1.2' }}>
                     [Error rendering value: {String(arg)}]
                   </div>
                 );
@@ -1292,7 +1292,7 @@ export default function Playground() {
                           name="check"
                           width={12}
                           height={12}
-                          fill="#ffffffff"
+                          fill="var(--color-text-on-dark)"
                           className="menuCheck"
                         />
                       )}
@@ -1361,7 +1361,7 @@ export default function Playground() {
 
   const renderTabs = () => {
     return (
-      <div className={styles['tab-bar']} style={{ backgroundColor: '#353446' }}>
+      <div className={styles['tab-bar']} style={{ backgroundColor: 'var(--color-bg-sidebar)' }}>
         <div className={styles['tab-container']}>
           {tabs.map(tab => (
             <div
@@ -1410,7 +1410,7 @@ export default function Playground() {
                       name="warn-outline"
                       width={12}
                       height={12}
-                      fill="#ffffff"
+                      fill="var(--color-text-on-dark)"
                       style={{ marginRight: '4px' }}
                     />
                   )}
@@ -1443,17 +1443,17 @@ export default function Playground() {
             onMouseEnter={(e) => {
               const icon = e.currentTarget.querySelector('svg');
               if (icon) {
-                icon.style.fill = '#ffffff';
+                icon.style.fill = 'var(--color-text-on-dark)';
               }
             }}
             onMouseLeave={(e) => {
               const icon = e.currentTarget.querySelector('svg');
               if (icon) {
-                icon.style.fill = '#a0a0a0';
+                icon.style.fill = 'var(--color-text-on-dark-muted)';
               }
             }}
           >
-            <Icon name="plus-solid" width={14} height={14} fill="#66637a" />
+            <Icon name="plus-solid" width={14} height={14} fill="var(--color-text-on-dark-muted)" />
           </button>
         </div>
       </div>

--- a/src/dashboard/Data/Playground/Playground.scss
+++ b/src/dashboard/Data/Playground/Playground.scss
@@ -1,6 +1,8 @@
+@import 'stylesheets/globals.scss';
+
 .playground-ctn {
-  padding-top: 96px;
-  background-color: #002b36;
+  padding-top: $toolbar-height;
+  background-color: var(--color-bg-sidebar);
   height: 100vh;
   display: flex;
   flex-direction: column;
@@ -16,7 +18,7 @@
 
 .editor-section {
   position: relative;
-  border-bottom: 1px solid #169cee;
+  border-bottom: 1px solid var(--color-accent-blue);
   overflow: hidden;
   display: flex;
   flex-direction: column;
@@ -35,8 +37,8 @@
 
 .tab-bar {
   display: flex;
-  background: #073642;
-  border-bottom: 1px solid #169cee;
+  background: var(--color-bg-sidebar-hover);
+  border-bottom: 1px solid var(--color-accent-blue);
   padding: 0 4px;
   align-items: flex-end;
   flex-shrink: 0;
@@ -49,16 +51,16 @@
   }
   
   &::-webkit-scrollbar-track {
-    background: #073642;
+    background: var(--color-bg-sidebar-hover);
   }
   
   &::-webkit-scrollbar-thumb {
-    background: #586e75;
+    background: var(--color-text-tertiary);
     border-radius: 2px;
   }
   
   &::-webkit-scrollbar-thumb:hover {
-    background: #657b83;
+    background: var(--color-text-on-dark-muted);
   }
 }
 
@@ -75,13 +77,13 @@
   padding: 4px 4px 4px 12px;
   margin-right: 4px;
   margin-bottom: -1px;
-  background: #2C2C35;
-  border: 1px solid #586e75;
+  background: var(--color-bg-sidebar-active);
+  border: 1px solid var(--color-text-tertiary);
   border-bottom: none;
   border-radius: 4px 4px 0 0;
   cursor: pointer;
   font-size: 12px;
-  color: #93a1a1;
+  color: var(--color-text-secondary);
   transition: all 0.2s ease;
   min-width: 80px;
   max-width: 200px;
@@ -89,14 +91,14 @@
   white-space: nowrap;
   
   &:hover {
-    background: #073642;
-    color: #fdf6e3;
+    background: var(--color-bg-sidebar-hover);
+    color: var(--color-text-on-dark);
   }
   
   &.tab-active {
-    background: #169cee;
-    color: #fdf6e3;
-    border-color: #169cee;
+    background: var(--color-accent-blue);
+    color: var(--color-text-on-dark);
+    border-color: var(--color-accent-blue);
   }
   
   /* Drag and drop styles */
@@ -107,8 +109,8 @@
   }
   
   &.tab-drag-over {
-    border-left: 3px solid #d33682;
-    background: rgba(211, 54, 130, 0.1);
+    border-left: 3px solid var(--color-accent-purple);
+    background: color-mix(in srgb, var(--color-accent-purple) 10%, transparent);
   }
   
   /* Make tabs draggable */
@@ -137,9 +139,9 @@
 
 .tab-rename-input {
   flex: 1;
-  background: #fdf6e3;
-  border: 1px solid #169cee;
-  color: #002b36;
+  background: var(--color-text-on-dark);
+  border: 1px solid var(--color-accent-blue);
+  color: var(--color-bg-sidebar);
   padding: 2px 4px;
   margin: 0;
   font-size: 12px;
@@ -149,7 +151,7 @@
   margin-right: 4px;
   
   &:focus {
-    box-shadow: 0 0 0 2px rgba(22, 156, 238, 0.3);
+    box-shadow: var(--color-interactive-focus-ring);
   }
 }
 
@@ -175,8 +177,8 @@
 
 .tab-new {
   background: none;
-  border: 1px solid #586e75;
-  color: #93a1a1;
+  border: 1px solid var(--color-text-tertiary);
+  color: var(--color-text-secondary);
   cursor: pointer;
   padding: 4px 8px;
   border-radius: 4px;
@@ -190,25 +192,25 @@
   flex-shrink: 0;
   
   &:hover {
-    background: #073642;
-    color: #fdf6e3;
-    border-color: #169cee;
+    background: var(--color-bg-sidebar-hover);
+    color: var(--color-text-on-dark);
+    border-color: var(--color-accent-blue);
   }
 }
 
 .resize-handle {
   height: 4px;
-  background: #169cee;
+  background: var(--color-accent-blue);
   cursor: ns-resize;
   position: relative;
   user-select: none;
   
   &:hover {
-    background: #2aa198;
+    background: var(--color-accent-green);
   }
   
   &:active {
-    background: #cb4b16;
+    background: var(--color-accent-orange);
   }
   
   &::before {
@@ -229,21 +231,21 @@
   position: absolute;
   bottom: 8px;
   right: 12px;
-  background: rgba(0, 43, 54, 0.9);
-  color: #93a1a1;
+  background: color-mix(in srgb, var(--color-bg-sidebar) 90%, transparent);
+  color: var(--color-text-secondary);
   padding: 6px 12px;
   border-radius: 4px;
   font-size: 12px;
   font-family: monospace;
-  border: 1px solid #073642;
+  border: 1px solid var(--color-bg-sidebar-hover);
   
   kbd {
-    background: #073642;
-    color: #839496;
+    background: var(--color-bg-sidebar-hover);
+    color: var(--color-text-secondary);
     padding: 2px 6px;
     border-radius: 3px;
     font-size: 11px;
-    border: 1px solid #586e75;
+    border: 1px solid var(--color-text-tertiary);
     margin: 0 2px;
   }
 }
@@ -265,7 +267,7 @@
   & > header {
     flex: none;
     padding: 12px 16px;
-    background-color: #169cee;
+    background-color: var(--color-accent-blue);
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -280,14 +282,14 @@
     flex: 1;
     width: 100%;
     overflow-y: auto;
-    background-color: #110D11;
+    background-color: var(--color-bg-sidebar);
   }
 }
 
 .console-output {
   padding: 2px 4px;
   overflow-y: auto;
-  background-color: #110D11;
+  background-color: var(--color-bg-sidebar);
   height: 100%;
   font-size: 12px;
   line-height: 1.2;
@@ -295,14 +297,14 @@
 
 .console-empty {
   text-align: center;
-  color: #586e75;
+  color: var(--color-text-tertiary);
   padding: 8px 6px;
   font-style: italic;
   font-size: 11px;
   line-height: 1.2;
   
   small {
-    color: #657b83;
+    color: var(--color-text-on-dark-muted);
     font-size: 10px;
   }
 }
@@ -313,25 +315,25 @@
   border-radius: 4px;
   
   &.console-error {
-    color: #dc322f;
-    background-color: rgba(220, 50, 47, 0.05);
+    color: var(--color-accent-red);
+    background-color: color-mix(in srgb, var(--color-accent-red) 5%, transparent);
   }
   
   &.console-warn {
-    color: #b58900;
-    background-color: rgba(181, 137, 0, 0.05);
+    color: var(--color-accent-orange);
+    background-color: color-mix(in srgb, var(--color-accent-orange) 5%, transparent);
   }
   
   &.console-info {
-    color: #268bd2;
+    color: var(--color-accent-blue);
   }
   
   &.console-debug {
-    color: #6c71c4;
+    color: var(--color-accent-purple);
   }
   
   &.console-log {
-    color: #93a1a1;
+    color: var(--color-text-secondary);
   }
 }
 
@@ -350,15 +352,15 @@
   flex-shrink: 0;
   font-family: monospace;
   font-size: 10px;
-  color: #657b83;
+  color: var(--color-text-on-dark-muted);
   text-align: right;
   min-width: 80px;
   padding-left: 6px;
-  border-left: 1px solid #073642;
+  border-left: 1px solid var(--color-bg-sidebar-hover);
   line-height: 1.2;
   
   &:hover {
-    color: #839496;
+    color: var(--color-text-secondary);
   }
 }
 
@@ -373,7 +375,7 @@
   margin-bottom: 8px;
   font-size: 12px;
   font-family: monospace;
-  color: #93a1a1;
+  color: var(--color-text-secondary);
 }
 
 .console-icon {
@@ -383,11 +385,11 @@
 .console-type {
   font-weight: 600;
   text-transform: uppercase;
-  color: #839496;
+  color: var(--color-text-secondary);
 }
 
 .console-timestamp {
-  color: #657b83;
+  color: var(--color-text-on-dark-muted);
   margin-left: auto;
   font-size: 11px;
 }
@@ -411,16 +413,16 @@
 }
 
 .console-output::-webkit-scrollbar-track {
-  background: #073642;
+  background: var(--color-bg-sidebar-hover);
 }
 
 .console-output::-webkit-scrollbar-thumb {
-  background: #586e75;
+  background: var(--color-text-tertiary);
   border-radius: 4px;
 }
 
 .console-output::-webkit-scrollbar-thumb:hover {
-  background: #657b83;
+  background: var(--color-text-on-dark-muted);
 }
 
 /* Responsive adjustments */

--- a/src/dashboard/Data/Views/EditViewDialog.react.js
+++ b/src/dashboard/Data/Views/EditViewDialog.react.js
@@ -162,10 +162,10 @@ export default class EditViewDialog extends React.Component {
                   colorLeft="#cbcbcb"
                   colorRight="#00db7c"
                 />
-                <span style={{ color: this.state.wordWrap ? '#333' : '#999' }}>Wrap</span>
+                <span style={{ color: this.state.wordWrap ? 'var(--color-text-primary)' : 'var(--color-text-tertiary)' }}>Wrap</span>
               </label>
               {this.state.error && (
-                <span style={{ color: '#d73a49', fontSize: '13px' }}>{this.state.error}</span>
+                <span style={{ color: 'var(--color-accent-red)', fontSize: '13px' }}>{this.state.error}</span>
               )}
             </>
           )}

--- a/src/dashboard/Data/Views/Views.react.js
+++ b/src/dashboard/Data/Views/Views.react.js
@@ -373,7 +373,7 @@ class Views extends TableView {
                   left: 0,
                   right: 0,
                   zIndex: 10,
-                  background: '#66637A',
+                  background: 'var(--color-bg-sidebar)',
                 }}
                 ref={this.headersRef}
               >

--- a/src/dashboard/Data/Views/Views.scss
+++ b/src/dashboard/Data/Views/Views.scss
@@ -8,12 +8,12 @@
   @include MonospaceFont;
   display: inline-block;
   vertical-align: top;
-  background: #66637A;
-  color: white;
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-on-dark);
   font-size: 12px;
   height: 30px;
   padding: 4px 16px;
-  border-right: 1px solid #e3e3ea;
+  border-right: 1px solid var(--color-border-primary);
   position: relative;
   white-space: nowrap;
   overflow: hidden;
@@ -25,7 +25,7 @@
 }
 
 .headerName {
-  color: white;
+  color: var(--color-text-on-dark);
   font-size: 12px;
   height: 22px;
   line-height: 22px;
@@ -37,7 +37,7 @@
 }
 
 .headerType {
-  color: #A2A6B1;
+  color: var(--color-text-on-dark-muted);
   font-size: 10px;
   height: 22px;
   line-height: 22px;
@@ -100,17 +100,17 @@
   font-size: 12px;
   white-space: nowrap;
   height: 30px;
-  border-bottom: 1px solid #e3e3ea;
+  border-bottom: 1px solid var(--color-border-primary);
 }
 
 .tableRow:nth-child(odd) {
-  background: #f4f5f7;
+  background: var(--color-bg-secondary);
 }
 
 .cell {
   line-height: 20px;
   padding: 5px 16px;
-  border-right: 1px solid #e3e3ea;
+  border-right: 1px solid var(--color-border-primary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/dashboard/Data/Webhooks/Webhooks.react.js
+++ b/src/dashboard/Data/Webhooks/Webhooks.react.js
@@ -27,7 +27,7 @@ import styles from './Webhooks.scss';
 
 const TableWarning = ({ text }) => (
   <div>
-    <Icon name="warn-outline" fill="#343445" width={20} height={20} />
+    <Icon name="warn-outline" fill="var(--color-text-primary)" width={20} height={20} />
     <span style={{ position: 'relative', top: '2px' }}> {text}</span>
   </div>
 );
@@ -331,7 +331,7 @@ class Webhooks extends TableView {
     if (hook.url) {
       deleteColumnContents = (
         <button type="button" onClick={showDelete} className={styles.deleteButton}>
-          <Icon name="trash-outline" fill="#343445" width={20} height={20} />
+          <Icon name="trash-outline" fill="var(--color-text-primary)" width={20} height={20} />
         </button>
       );
     } else {

--- a/src/dashboard/Push/Push.scss
+++ b/src/dashboard/Push/Push.scss
@@ -7,30 +7,43 @@
  */
 @import 'stylesheets/globals.scss';
 
+// =============================================================================
+// Modern (light / dark) — left-aligned, constrained width
+// =============================================================================
+
 .pushFlow {
-  padding: 120px 0 70px 0;
+  padding: calc(#{$toolbar-height} + var(--space-3)) var(--space-10) var(--space-10);
+  max-width: 720px;
 }
 
 .warning {
-  background: $orange;
-  color: white;
-  font-size: 12px;
-  text-align: center;
-  line-height: 30px;
-  padding: 0 10px;
+  @include UIFont;
+  background: color-mix(in srgb, var(--color-accent-orange) 12%, transparent);
+  color: var(--color-accent-orange);
+  font-size: var(--text-xs);
+  text-align: left;
+  line-height: 1.5;
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--color-accent-orange) 25%, transparent);
 }
 
 .info {
-  background: $blue;
-  color: white;
-  font-size: 14px;
-  text-align: center;
-  line-height: 20px;
-  padding: 18px;
+  @include UIFont;
+  background: color-mix(in srgb, var(--color-accent-blue) 10%, transparent);
+  color: var(--color-accent-blue);
+  font-size: var(--text-sm);
+  text-align: left;
+  line-height: 1.5;
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--color-accent-blue) 20%, transparent);
 }
 
 .infoSubline {
-  font-size: 12px;
+  font-size: var(--text-xs);
+  margin-top: var(--space-1);
+  opacity: 0.8;
 }
 
 // workaround for non standard spec
@@ -55,37 +68,123 @@
 }
 
 .invalidMessage {
-  padding-right: 5px;
+  padding-right: var(--space-2);
 }
 
 .localeContainer {
-  margin: 15px 0 25px 0;
+  margin: var(--space-4) 0 var(--space-6) 0;
+  border: 1px solid var(--color-border-secondary);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
 }
 
 .localeTitle {
-  margin: 5px 0;
-  font-weight: bold;
+  @include UIFont;
+  margin: 0 0 var(--space-3) 0;
+  font-weight: var(--font-weight-semibold);
+  font-size: var(--text-sm);
   position: relative;
-  text-align: center;
+  text-align: left;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .localeRemoveButton {
   @include buttonReset;
-  position: absolute;
-  right: 15px;
-  font-size: 12px;
-  top: 3px;
+  font-size: var(--text-xs);
+  color: var(--color-accent-red);
+  font-weight: var(--font-weight-medium);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+
   &:hover, &:focus {
     text-decoration: underline;
   }
 }
 
 .localizationSegment {
-  text-align: center;
-  padding: 20px 10px;
+  text-align: left;
+  padding: var(--space-4) 0;
 }
 
 .localedeviceCount {
-  margin-top: 5px;
-  color: $secondaryTextColor;
+  margin-top: var(--space-1);
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+}
+
+// =============================================================================
+// Classic — centered, original look
+// =============================================================================
+
+:global([data-theme="classic"]) {
+  .pushFlow {
+    padding: 120px 0 70px 0;
+    max-width: none;
+  }
+
+  .warning {
+    background: var(--color-accent-orange);
+    color: var(--color-text-on-dark);
+    font-size: 12px;
+    text-align: center;
+    line-height: 30px;
+    padding: 0 10px;
+    border-radius: 0;
+    border: none;
+  }
+
+  .info {
+    background: var(--color-accent-blue);
+    color: var(--color-text-on-dark);
+    font-size: 14px;
+    text-align: center;
+    line-height: 20px;
+    padding: 18px;
+    border-radius: 0;
+    border: none;
+  }
+
+  .infoSubline {
+    font-size: 12px;
+    opacity: 1;
+  }
+
+  .localeContainer {
+    margin: 15px 0 25px 0;
+    border: none;
+    border-radius: 0;
+    padding: 0;
+  }
+
+  .localeTitle {
+    margin: 5px 0;
+    text-align: center;
+    display: block;
+  }
+
+  .localeRemoveButton {
+    position: absolute;
+    right: 15px;
+    font-size: 12px;
+    top: 3px;
+    color: inherit;
+  }
+
+  .localizationSegment {
+    text-align: center;
+    padding: 20px 10px;
+  }
+}
+
+// =============================================================================
+// Responsive
+// =============================================================================
+
+@media (max-width: $bp-md - 1) {
+  .pushFlow {
+    padding: calc(#{$toolbar-height} + #{$mobile-header-height} + var(--space-4)) var(--space-3) var(--space-8);
+    max-width: none;
+  }
 }

--- a/src/dashboard/Push/PushAudiencesData.scss
+++ b/src/dashboard/Push/PushAudiencesData.scss
@@ -13,11 +13,11 @@
 }
 
 .pushAudienceData {
-  border: 1px solid $borderGrey;
+  border: 1px solid var(--color-border-primary);
 }
 
 .pushAudienceDialog {
   text-align: right;
-  border-top: 1px solid $borderGrey;
+  border-top: 1px solid var(--color-border-primary);
   padding: 15px 30px 15px 15px;
 }

--- a/src/dashboard/Push/PushAudiencesIndexRow.react.js
+++ b/src/dashboard/Push/PushAudiencesIndexRow.react.js
@@ -71,7 +71,7 @@ export default class PushAudiencesIndexRow extends PushAudiencesBaseRow {
             type="button"
             onClick={this.props.onDelete.bind(undefined, this.props.id, this.props.name)}
           >
-            <Icon name="trash-outline" fill="#343445" width={20} height={20} role="button" />
+            <Icon name="trash-outline" fill="var(--color-text-primary)" width={20} height={20} role="button" />
           </button>
         </td>
       </tr>

--- a/src/dashboard/Push/PushAudiencesIndexRow.scss
+++ b/src/dashboard/Push/PushAudiencesIndexRow.scss
@@ -55,13 +55,13 @@
   }
 
   .detailsHeaderListItem {
-    color: $secondaryTextColor;
+    color: var(--color-text-secondary);
   }
 }
 
 .moreDetails {
   @include buttonReset;
-  color: $blue;
+  color: var(--color-accent-blue);
   font-size: 14px;
 
   &:hover, &:focus {
@@ -89,7 +89,7 @@
   @include buttonReset;
   &:hover, &:focus {
     svg {
-      fill: $blue;
+      fill: var(--color-accent-blue);
     }
   }
 }

--- a/src/dashboard/Push/PushDetails.scss
+++ b/src/dashboard/Push/PushDetails.scss
@@ -8,7 +8,7 @@
 @import 'stylesheets/globals.scss';
 
 .detailsWrapper {
-  background: $white;
+  background: var(--color-bg-primary);
   padding-bottom: 100px;
 }
 
@@ -20,34 +20,36 @@
 .groupHeader {
   text-align: center;
   padding: 150px 0 50px 0;
-  background: $pushDetailsHeaderBackground;
+  background: var(--color-bg-secondary);
 }
 
 .headerTitle {
-  color: $blue;
+  color: var(--color-accent-blue);
   font-size: 12px;
   letter-spacing: 2px;
   margin-bottom: 10px;
+  text-transform: uppercase;
 }
 
 .headline {
   font-size: 26px;
   margin: 10px;
+  color: var(--color-text-primary);
 }
 
 .subline {
-  color: $secondaryTextColor;
+  color: var(--color-text-secondary);
   font-size: 14px;
 }
 
 .content {
   font-size: 14px;
-  color: $pushDetailsContent;
+  color: var(--color-text-secondary);
 }
 
 .tableSectionHeader, .chartTitle {
   font-size: 22px;
-  color: $blue;
+  color: var(--color-accent-blue);
   text-align: center;
   padding: 25px 0;
   line-height: 26px;
@@ -56,13 +58,34 @@
 
 .tableSectionWrap {
   width: 750px;
+  max-width: 100%;
   margin: 0 auto;
   padding: 20px 0;
 }
 
+@media (max-width: $bp-md - 1) {
+  .tableSectionWrap {
+    width: 100%;
+    padding: var(--space-3);
+  }
+
+  .groupA {
+    float: none;
+    width: 100%;
+  }
+
+  .groupB {
+    margin-left: 0;
+  }
+
+  .groupHeader {
+    padding: calc(#{$toolbar-height} + #{$mobile-header-height} + var(--space-4)) var(--space-3) var(--space-6);
+  }
+}
+
 .tableWrap {
-  border-radius: $borderRadiusConst;
-  border: 1px solid $borderGrey;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-primary);
   border-top: 0;
   overflow: hidden;
 }
@@ -73,7 +96,7 @@
 
 .deliveryMessage {
   font-size: 12px;
-  color: $secondaryTextColor;
+  color: var(--color-text-secondary);
   line-height: 16px;
 }
 
@@ -87,7 +110,7 @@
 }
 
 .messageHeader {
-  background: $white;
+  background: var(--color-bg-primary);
 }
 
 .chartWrap {

--- a/src/dashboard/Push/PushIndex.scss
+++ b/src/dashboard/Push/PushIndex.scss
@@ -34,21 +34,19 @@
 .experimentLabel, .localTimeLabel, .translationLabel {
   font-size: 12px;
   line-height: 12px;
-  color: $secondaryTextColor;
+  color: var(--color-text-secondary);
 }
 
 .tr {
   cursor: pointer;
 
-  //TODO: add focus styles once tab index is added
   &:hover {
-    background-color: $lightBlue;
+    background-color: var(--color-interactive-hover);
   }
 
-  //NOTE: would like to get rid of alternating styles - hard to see for users
   &:nth-child(2n) {
     &:hover {
-      background-color: $lightBlue;
+      background-color: var(--color-interactive-hover);
     }
   }
 }

--- a/src/dashboard/Push/PushNew.react.js
+++ b/src/dashboard/Push/PushNew.react.js
@@ -749,7 +749,7 @@ class PushNew extends DashboardView {
             {!this.state.loadingLocale && this.state.locales.length === 0 ? (
               <a
                 href="https://github.com/parse-community/parse-dashboard#configuring-localized-push-notifications"
-                style={{ color: '#169CEE' }}
+                style={{ color: 'var(--color-accent-blue)' }}
                 target="_blank" rel="noreferrer"
               >
                 Please follow this guide to setup the push locales feature

--- a/src/dashboard/Settings/CloudConfigSettings.react.js
+++ b/src/dashboard/Settings/CloudConfigSettings.react.js
@@ -432,9 +432,9 @@ export default class CloudConfigSettings extends DashboardView {
   renderParamMultiSelectWithButtons(value, onChange, placeholder, disabled, paramNames) {
     const allNames = paramNames || this.state.configParamNames;
     return (
-      <div style={{ width: '100%', background: '#f6fafb' }}>
+      <div style={{ width: '100%' }}>
         {this.renderParamMultiSelect(value, onChange, placeholder, disabled, allNames)}
-        <div style={{ display: 'flex', justifyContent: 'center', gap: '8px', marginTop: '8px', paddingBottom: '8px' }}>
+        <div style={{ display: 'flex', gap: '8px', marginTop: '8px' }}>
           <Button
             value="Select all"
             disabled={disabled || value.length === allNames.length}
@@ -728,7 +728,7 @@ export default class CloudConfigSettings extends DashboardView {
                 }
               />
             ))}
-            <div style={{ marginTop: '15px', paddingLeft: '62%' }}>
+            <div className={styles.form_buttons}>
               <Button
                 value="Reset to Defaults"
                 onClick={this.resetSyntaxColors.bind(this)}

--- a/src/dashboard/Settings/DashboardSettings/DashboardSettings.react.js
+++ b/src/dashboard/Settings/DashboardSettings/DashboardSettings.react.js
@@ -405,7 +405,7 @@ export default class DashboardSettings extends DashboardView {
                       name={this.state.passwordHidden ? 'visibility' : 'visibility_off'}
                       width={18}
                       height={18}
-                      fill="rgba(0,0,0,0.4)"
+                      fill="var(--color-text-tertiary)"
                     />
                   </a>
                 </div>
@@ -592,10 +592,10 @@ export default class DashboardSettings extends DashboardView {
           />
         </Fieldset>
         {this.viewPreferencesManager && this.scriptManager && this.viewPreferencesManager.isServerConfigEnabled() && (
-          <Fieldset legend="Settings Storage">
-            <div style={{ marginBottom: '20px', color: '#666', fontSize: '14px', textAlign: 'center' }}>
-              Storing dashboard settings on the server rather than locally in the browser storage makes the settings available across devices and browsers. It also prevents them from getting lost when resetting the browser website data. Settings that can be stored on the server are currently Data Browser Filters, Data Browser Graphs, Views, Keyboard Shortcuts, JS Console scripts, and Cloud Config history.
-            </div>
+          <Fieldset
+            legend="Settings Storage"
+            description="Store dashboard settings on the server to make them available across devices and browsers. Supports Data Browser Filters, Graphs, Views, Keyboard Shortcuts, JS Console scripts, and Cloud Config history."
+          >
             <Field
               label={
                 <Label
@@ -677,8 +677,8 @@ export default class DashboardSettings extends DashboardView {
           maxHeight: '300px',
           overflowY: 'auto',
           marginBottom: '15px',
-          border: '1px solid #e0e0e0',
-          borderRadius: '4px',
+          border: '1px solid var(--color-border-secondary)',
+          borderRadius: 'var(--radius-md)',
           padding: '10px'
         }}>
           {viewConflicts.length > 0 && (
@@ -690,7 +690,7 @@ export default class DashboardSettings extends DashboardView {
                   return (
                     <li key={conflict.id}>
                       {viewName || 'Unnamed view'}
-                      <span style={{ fontFamily: 'monospace', fontSize: '12px', color: '#666', marginLeft: '8px' }}>
+                      <span style={{ fontFamily: 'monospace', fontSize: '12px', color: 'var(--color-text-tertiary)', marginLeft: '8px' }}>
                         [{conflict.id}]
                       </span>
                     </li>
@@ -713,7 +713,7 @@ export default class DashboardSettings extends DashboardView {
                   return (
                     <li key={conflict.id}>
                       {displayText}
-                      <span style={{ fontFamily: 'monospace', fontSize: '12px', color: '#666', marginLeft: '8px' }}>
+                      <span style={{ fontFamily: 'monospace', fontSize: '12px', color: 'var(--color-text-tertiary)', marginLeft: '8px' }}>
                         [{conflict.id}]
                       </span>
                     </li>
@@ -732,7 +732,7 @@ export default class DashboardSettings extends DashboardView {
                   return (
                     <li key={conflict.id}>
                       {scriptName || 'Unnamed script'}
-                      <span style={{ fontFamily: 'monospace', fontSize: '12px', color: '#666', marginLeft: '8px' }}>
+                      <span style={{ fontFamily: 'monospace', fontSize: '12px', color: 'var(--color-text-tertiary)', marginLeft: '8px' }}>
                         [{conflict.id}]
                       </span>
                     </li>

--- a/src/dashboard/Settings/DashboardSettings/DashboardSettings.scss
+++ b/src/dashboard/Settings/DashboardSettings/DashboardSettings.scss
@@ -1,28 +1,83 @@
+@import 'stylesheets/globals.scss';
+
+// =============================================================================
+// Modern (light / dark) — left-aligned, constrained width
+// =============================================================================
+
+.settings_page {
+  padding: calc(#{$toolbar-height} + var(--space-3)) var(--space-10) var(--space-10);
+  max-width: 720px;
+}
+
 .copyData {
   max-height: 50vh;
-  overflow-y: scroll;
+  overflow-y: auto;
+  border-radius: var(--radius-md);
 }
+
 .newUser {
-  max-height: 100px;
-  overflow-y: scroll;
+  max-height: 200px;
+  overflow-y: auto;
+  border-radius: var(--radius-md);
 }
-.settings_page {
-  padding: 120px 0 80px 0;
-}
+
 .footer {
   display: flex;
-  padding: 10px;
-  justify-content: end;
-  gap: 10px;
+  padding: var(--space-3) 0;
+  justify-content: flex-end;
+  gap: var(--space-3);
 }
+
 .password {
   display: flex;
-  gap: 4px;
+  align-items: center;
+  gap: var(--space-2);
 }
+
 .userData {
-  padding: 10px;
+  padding: var(--space-4) 0;
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  line-height: 1.5;
 }
+
 .mfa {
   display: block;
-  margin-top: 10px;
+  margin-top: var(--space-3);
+  font-size: var(--text-sm);
+  word-break: break-all;
+}
+
+// =============================================================================
+// Classic — centered, original
+// =============================================================================
+
+:global([data-theme="classic"]) {
+  .settings_page {
+    padding: 120px 0 80px 0;
+    max-width: none;
+  }
+
+  .footer {
+    padding: 10px;
+  }
+
+  .userData {
+    padding: 10px;
+  }
+
+  .newUser {
+    max-height: 100px;
+  }
+}
+
+// =============================================================================
+// Responsive
+// =============================================================================
+
+@media (max-width: $bp-md - 1) {
+  .settings_page {
+    padding: calc(#{$toolbar-height} + #{$mobile-header-height} + var(--space-4)) var(--space-3) var(--space-8);
+    max-width: none;
+  }
 }

--- a/src/dashboard/Settings/GeneralSettings.scss
+++ b/src/dashboard/Settings/GeneralSettings.scss
@@ -9,7 +9,7 @@
 
 .cost {
 	font-size: 18px;
-	color: $blue;
+	color: var(--color-accent-blue);
 	line-height: 18px;
 	padding-right: 18px;
 	padding-top: 16px;
@@ -22,6 +22,6 @@
 	padding-right: 18px;
 	padding-top: 1px;
 	font-size: 14px;
-	color: #66637a;
+	color: var(--color-text-secondary);
 	line-height: 14px;
 }

--- a/src/dashboard/Settings/Settings.scss
+++ b/src/dashboard/Settings/Settings.scss
@@ -5,16 +5,21 @@
  * This source code is licensed under the license found in the LICENSE file in
  * the root directory of this source tree.
  */
+@import 'stylesheets/globals.scss';
+
+// =============================================================================
+// Modern (light / dark) — left-aligned, constrained width, clean spacing
+// =============================================================================
+
 .settings_page {
-  padding: 120px 0 80px 0;
+  padding: calc(#{$toolbar-height} + var(--space-3)) var(--space-10) var(--space-10);
+  max-width: 720px;
 }
 
 .form_buttons {
-  max-width: 50%;
-  margin: 20px auto 0;
   display: flex;
-  justify-content: center;
-  gap: 5px;
+  gap: var(--space-3);
+  margin-top: var(--space-6);
 
   & > div {
     background: transparent !important;
@@ -24,12 +29,56 @@
 }
 
 .sectionSeparator {
-  border-bottom-width: 1px;
-  margin-bottom: 20px;
+  padding-bottom: var(--space-4);
+  margin-bottom: var(--space-2);
+  border-bottom: 1px solid var(--color-border-secondary);
 }
 
 .lastField {
-  border-bottom-width: 1px;
-  border-bottom-left-radius: 5px;
-  border-bottom-right-radius: 5px;
+  // No special treatment in modern
+}
+
+// =============================================================================
+// Classic — centered, wider padding, original look
+// =============================================================================
+
+:global([data-theme="classic"]) {
+  .settings_page {
+    padding: 120px 0 80px 0;
+    max-width: none;
+  }
+
+  .form_buttons {
+    max-width: 50%;
+    margin: 20px auto 0;
+    justify-content: center;
+    gap: 5px;
+  }
+
+  .sectionSeparator {
+    border-bottom-width: 1px;
+    margin-bottom: 20px;
+    padding-bottom: 0;
+  }
+
+  .lastField {
+    border-bottom-width: 1px;
+    border-bottom-left-radius: 5px;
+    border-bottom-right-radius: 5px;
+  }
+}
+
+// =============================================================================
+// Responsive — mobile
+// =============================================================================
+
+@media (max-width: $bp-md - 1) {
+  .settings_page {
+    padding: calc(#{$toolbar-height} + #{$mobile-header-height} + var(--space-4)) var(--space-3) var(--space-8);
+    max-width: none;
+  }
+
+  .form_buttons {
+    max-width: 100%;
+  }
 }

--- a/src/dashboard/TableView.scss
+++ b/src/dashboard/TableView.scss
@@ -9,10 +9,10 @@
 
 .headers {
   position: sticky;
-  top: 96px;
+  top: $toolbar-height;
   left: 0;
   right: 0;
-  background: #66637A;
+  background: var(--color-bg-tertiary);
   height: 30px;
   white-space: nowrap;
   z-index: 10;
@@ -20,32 +20,32 @@
 
 .content {
   position: relative;
-  padding-top: 96px;
+  padding-top: $toolbar-height;
   min-height: 100vh;
 }
 
 .empty {
   position: absolute;
-  top: 126px;
+  top: calc($toolbar-height + 30px);
   left: 0;
   right: 0;
   bottom: 0;
 }
 
 .rows {
-  background: #fdfafb;
+  background: var(--color-bg-primary);
 
   table {
     width: 100%;
   }
 
   tr {
-    background: #fdfafb;
-    border-bottom: 1px solid $borderGrey;
+    background: var(--color-bg-primary);
+    border-bottom: 1px solid var(--color-border-primary);
   }
 
   tr:nth-child(2n) {
-    background: #f4f5f7;
+    background: var(--color-bg-secondary);
   }
 
   td {

--- a/src/dashboard/index.js
+++ b/src/dashboard/index.js
@@ -7,6 +7,8 @@
  */
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
+import { initTheme } from 'lib/theme';
+initTheme(); // Apply saved theme before any rendering to prevent flash
 import Immutable from 'immutable';
 import installDevTools from 'immutable-devtools';
 import React from 'react';

--- a/src/lib/theme.js
+++ b/src/lib/theme.js
@@ -1,0 +1,87 @@
+/*
+ * Theme management utility
+ * Handles theme persistence (localStorage) and application (data-theme attribute)
+ */
+
+const STORAGE_KEY = 'parse-dashboard-theme';
+const VALID_THEMES = ['light', 'dark', 'classic', 'auto'];
+
+/**
+ * Get the system's preferred color scheme
+ */
+function getSystemTheme() {
+  if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    return 'dark';
+  }
+  return 'light';
+}
+
+/**
+ * Resolve the effective theme (handles 'auto' → system preference)
+ */
+function resolveTheme(theme) {
+  if (theme === 'auto') {
+    return getSystemTheme();
+  }
+  return theme;
+}
+
+/**
+ * Apply theme to the document
+ */
+function applyTheme(theme) {
+  const resolved = resolveTheme(theme);
+  if (resolved === 'light') {
+    document.documentElement.removeAttribute('data-theme');
+  } else {
+    document.documentElement.setAttribute('data-theme', resolved);
+  }
+}
+
+/**
+ * Get the saved theme preference from localStorage
+ */
+export function getSavedTheme() {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved && VALID_THEMES.includes(saved)) {
+      return saved;
+    }
+  } catch (e) {
+    // localStorage may be unavailable
+  }
+  return 'light';
+}
+
+/**
+ * Set and apply a theme
+ */
+export function setTheme(theme) {
+  if (!VALID_THEMES.includes(theme)) {
+    return;
+  }
+  try {
+    localStorage.setItem(STORAGE_KEY, theme);
+  } catch (e) {
+    // localStorage may be unavailable
+  }
+  applyTheme(theme);
+}
+
+/**
+ * Initialize theme on page load. Call as early as possible.
+ */
+export function initTheme() {
+  const theme = getSavedTheme();
+  applyTheme(theme);
+
+  // If auto, listen for system preference changes
+  if (theme === 'auto' && window.matchMedia) {
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+      const current = getSavedTheme();
+      if (current === 'auto') {
+        applyTheme('auto');
+      }
+    });
+  }
+}

--- a/src/login/Login.scss
+++ b/src/login/Login.scss
@@ -8,21 +8,26 @@
 @import 'stylesheets/globals.scss';
 
 .message {
-  background: #f9f9fa;
+  @include UIFont;
+  background: var(--color-bg-secondary);
   height: 50px;
-  padding: 10px;
-  font-size: 13px;
+  padding: var(--space-3);
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  border-radius: var(--radius-md);
 }
 
 .error {
-  background: #f9f9fa;
+  @include UIFont;
+  background: var(--color-accent-red-light);
   height: 50px;
   line-height: 50px;
   overflow: hidden;
-  font-size: 13px;
-  color: $red;
+  font-size: var(--text-sm);
+  color: var(--color-accent-red);
+  border-radius: var(--radius-md);
 }
 
 body {
-  background: #0c5582;
+  background: var(--color-bg-sidebar);
 }

--- a/src/parse-interface-guide/PIG.scss
+++ b/src/parse-interface-guide/PIG.scss
@@ -63,11 +63,11 @@ h1 {
   font-size: 32px;
   font-weight: 400;
   margin: 10px auto;
-  color: $secondaryTextColor;
+  color: var(--color-text-secondary);
 }
 
 .component_name {
-  color: $mainTextColor;
+  color: var(--color-text-primary);
 }
 
 .table {

--- a/src/stylesheets/base.scss
+++ b/src/stylesheets/base.scss
@@ -10,20 +10,24 @@
 html, body {
   min-height: 100vh;
 }
-html{
-  background-color: #110D11;
+html {
+  background-color: var(--color-bg-secondary);
+  accent-color: var(--color-accent-blue);
+}
+:global([data-theme='dark']) {
+  color-scheme: dark;
 }
 
 body {
-  @include NotoSansFont;
+  font-family: var(--font-sans);
   box-sizing: border-box;
-  color: $mainTextColor;
-  background-color: #110D11;
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-secondary);
 }
 
 :global(#browser_mount) {
   min-height: 100vh;
-  background: #FDFAFB;
+  background: var(--color-bg-secondary);
 }
 
 * {
@@ -35,7 +39,7 @@ body {
 }
 
 a {
-  color: $blue;
+  color: var(--color-accent-blue);
   cursor: pointer;
   text-decoration: none;
 }
@@ -74,25 +78,25 @@ table {
 }
 
 .failedBackground {
-  background-color: $red;
+  background-color: var(--color-accent-red);
 }
 
 .succeededBackground {
-  background-color: $green;
+  background-color: var(--color-accent-green);
 }
 
 .progressBackground {
-  background-color: $blue;
+  background-color: var(--color-accent-blue);
 }
 
 .failedText {
-  color: $red;
+  color: var(--color-accent-red);
 }
 
 .succeededText {
-  color: $green;
+  color: var(--color-accent-green);
 }
 
 .progressText {
-  color: $blue;
+  color: var(--color-accent-blue);
 }

--- a/src/stylesheets/fonts.scss
+++ b/src/stylesheets/fonts.scss
@@ -5,6 +5,7 @@
  * This source code is licensed under the license found in the LICENSE file in
  * the root directory of this source tree.
  */
-@import url(https://fonts.googleapis.com/css?family=Dosis);
+@import url(https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap);
 @import url(https://fonts.googleapis.com/css?family=Source+Code+Pro);
 @import url(https://fonts.googleapis.com/css?family=Noto+Sans:400,700);
+@import url(https://fonts.googleapis.com/css?family=Dosis);

--- a/src/stylesheets/globals.scss
+++ b/src/stylesheets/globals.scss
@@ -6,6 +6,7 @@
  * the root directory of this source tree.
  */
 @use 'sass:math';
+@import 'tokens.scss';
 
 $white: #fff;
 $blue: #169cee;
@@ -53,19 +54,27 @@ $pushDetailsContent: #66637A;
 $darkPurple: #8D11BA;
 $blueGreen: #11A4BA;
 
-$sidebarCollapsedWidth: 54px;
+$sidebarCollapsedWidth: $sidebar-collapsed-width;
 
-@mixin NotoSansFont {
-  font-family: 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+// Primary UI font — uses theme's --font-sans
+@mixin UIFont {
+  font-family: var(--font-sans);
 }
 
-@mixin DosisFont {
-  font-family: 'Dosis', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+// Heading/label font — uses theme's --font-heading
+@mixin HeadingFont {
+  font-family: var(--font-heading);
 }
 
-@mixin MonospaceFont {
-  font-family: 'Source Code Pro', 'Courier New', monospace;
+// Monospace font — uses theme's --font-mono
+@mixin CodeFont {
+  font-family: var(--font-mono);
 }
+
+// Legacy aliases (used throughout codebase — do not remove)
+@mixin NotoSansFont { @include UIFont; }
+@mixin DosisFont { @include HeadingFont; }
+@mixin MonospaceFont { @include CodeFont; }
 
 @mixin arrow($direction, $base, $height, $color) {
   border-style: solid;

--- a/src/stylesheets/themes/classic.scss
+++ b/src/stylesheets/themes/classic.scss
@@ -1,0 +1,91 @@
+/*
+ * Classic Theme
+ * Original Parse Dashboard look & feel (pre-uplift)
+ * Apply via <html data-theme="classic">
+ */
+
+:global([data-theme='classic']) {
+  // --- Fonts ---
+  --font-sans: 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  --font-heading: 'Dosis', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  --font-mono: 'Source Code Pro', 'Courier New', monospace;
+  --font-data-browser: 'Source Code Pro', 'Fira Code', 'Courier New', monospace;
+
+  // --- Backgrounds ---
+  --color-bg-primary: #fdfafb;
+  --color-bg-secondary: #f4f5f7;
+  --color-bg-tertiary: #ecf0f3;
+  --color-bg-elevated: #ffffff;
+  --color-bg-sidebar: #0c5582;
+  --color-bg-sidebar-bottom: #0c5582;
+  --color-bg-sidebar-hover: #0d5e91;
+  --color-bg-sidebar-active: #159cee;
+  --color-bg-toolbar: #353446;
+
+  // --- Borders ---
+  --color-border-primary: #e3e3ea;
+  --color-border-secondary: #e0e0ea;
+  --color-border-focus: #169cee;
+
+  // --- Text ---
+  --color-text-primary: #555572;
+  --color-text-secondary: #a5a5b4;
+  --color-text-tertiary: #cccbd2;
+  --color-text-on-dark: #ffffff;
+  --color-text-on-dark-muted: #84a5bc;
+
+  // --- Accent ---
+  --color-accent-blue: #169cee;
+  --color-accent-blue-hover: #0e69a1;
+  --color-accent-blue-light: #acd7f1;
+  --color-accent-green: #00db7c;
+  --color-accent-green-light: #a8f0ad;
+  --color-accent-red: #ff395e;
+  --color-accent-red-light: #fbc3bd;
+  --color-accent-orange: #fd9539;
+  --color-accent-orange-light: #fde0b5;
+  --color-accent-purple: #343445;
+
+  // --- Data Browser (original look) ---
+  --color-cell-text: #0e69a1;
+  --color-cell-border: var(--color-border-primary);
+  --color-row-stripe: var(--color-bg-secondary);
+  --color-row-hover: var(--color-accent-blue-light);
+  --data-header-transform: none;
+  --data-header-tracking: normal;
+  --data-header-size: 12px;
+  --data-header-color: #ffffff;
+  --data-header-type-color: #a2a6b1;
+  --data-header-bg: #66637a;
+  --data-header-hover-bg: #5a576e;
+  --data-header-border-color: #5a576e;
+  --data-cell-padding: 5px;
+  --data-add-col-bg: #343445;
+  --data-add-col-color: #ffffff;
+  --data-add-col-border: none;
+  --data-check-bg: #726f85;
+
+  // --- Buttons (outlined style for classic) ---
+  --btn-border: 1px solid var(--color-accent-blue);
+  --btn-color: var(--color-accent-blue);
+  --btn-bg: none;
+  --btn-hover-bg: var(--color-accent-blue);
+  --btn-hover-color: #ffffff;
+  --btn-primary-bg: var(--color-accent-blue);
+  --btn-primary-color: #ffffff;
+  --btn-primary-border: 1px solid var(--color-accent-blue);
+  --btn-primary-hover-bg: var(--color-accent-blue-hover);
+  --btn-radius: 5px;
+
+  // --- Interactive ---
+  --color-interactive-hover: rgba(0, 0, 0, 0.04);
+  --color-interactive-active: rgba(0, 0, 0, 0.06);
+  --color-interactive-focus-ring: 0 0 0 2px #169cee, 0 0 0 4px rgba(22, 156, 238, 0.3);
+
+  // --- Elevation ---
+  --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.05);
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.04);
+  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.08), 0 2px 4px -2px rgba(0, 0, 0, 0.04);
+  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.08), 0 4px 6px -4px rgba(0, 0, 0, 0.04);
+  --shadow-overlay: 0 16px 32px -4px rgba(0, 0, 0, 0.12);
+}

--- a/src/stylesheets/themes/dark.scss
+++ b/src/stylesheets/themes/dark.scss
@@ -1,0 +1,91 @@
+/*
+ * Dark Theme
+ * Deep, muted palette for low-light environments
+ * Apply via <html data-theme="dark">
+ */
+
+:global([data-theme='dark']) {
+  // --- Fonts ---
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --font-heading: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --font-mono: 'Source Code Pro', 'Fira Code', 'Courier New', monospace;
+  --font-data-browser: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+
+  // --- Backgrounds ---
+  --color-bg-primary: #0f0f12;
+  --color-bg-secondary: #16161a;
+  --color-bg-tertiary: #1e1e24;
+  --color-bg-elevated: #1e1e24;
+  --color-bg-sidebar: #0c0c10;
+  --color-bg-sidebar-bottom: #0c0c10;
+  --color-bg-sidebar-hover: #1a1a22;
+  --color-bg-sidebar-active: #242430;
+  --color-bg-toolbar: #16161a;
+
+  // --- Borders ---
+  --color-border-primary: #2a2a35;
+  --color-border-secondary: #222230;
+  --color-border-focus: #3b82f6;
+
+  // --- Text ---
+  --color-text-primary: #e4e4e8;
+  --color-text-secondary: #9ca3af;
+  --color-text-tertiary: #6b7280;
+  --color-text-on-dark: #ffffff;
+  --color-text-on-dark-muted: #94a3b8;
+
+  // --- Accent ---
+  --color-accent-blue: #60a5fa;
+  --color-accent-blue-hover: #3b82f6;
+  --color-accent-blue-light: rgba(59, 130, 246, 0.15);
+  --color-accent-green: #34d399;
+  --color-accent-green-light: rgba(16, 185, 129, 0.15);
+  --color-accent-red: #f87171;
+  --color-accent-red-light: rgba(239, 68, 68, 0.15);
+  --color-accent-orange: #fbbf24;
+  --color-accent-orange-light: rgba(245, 158, 11, 0.15);
+  --color-accent-purple: #a78bfa;
+
+  // --- Data Browser ---
+  --color-cell-text: var(--color-text-secondary);
+  --color-cell-border: var(--color-border-secondary);
+  --color-row-stripe: transparent;
+  --color-row-hover: var(--color-interactive-hover);
+  --data-header-transform: uppercase;
+  --data-header-tracking: 0.04em;
+  --data-header-size: 11px;
+  --data-header-color: var(--color-text-secondary);
+  --data-header-type-color: var(--color-text-tertiary);
+  --data-header-bg: var(--color-bg-tertiary);
+  --data-header-hover-bg: var(--color-bg-secondary);
+  --data-header-border-color: var(--color-border-primary);
+  --data-cell-padding: 5px 8px;
+  --data-add-col-bg: var(--color-bg-secondary);
+  --data-add-col-color: var(--color-text-secondary);
+  --data-add-col-border: 1px solid var(--color-border-primary);
+  --data-check-bg: var(--color-bg-tertiary);
+
+  // --- Buttons ---
+  --btn-border: 1px solid var(--color-border-primary);
+  --btn-color: var(--color-text-primary);
+  --btn-bg: var(--color-bg-primary);
+  --btn-hover-bg: var(--color-bg-tertiary);
+  --btn-hover-color: var(--color-text-primary);
+  --btn-primary-bg: #e4e4e8;
+  --btn-primary-color: #0f0f12;
+  --btn-primary-border: 1px solid #e4e4e8;
+  --btn-primary-hover-bg: #c8c8d0;
+  --btn-radius: 6px;
+
+  // --- Interactive ---
+  --color-interactive-hover: rgba(255, 255, 255, 0.06);
+  --color-interactive-active: rgba(255, 255, 255, 0.08);
+  --color-interactive-focus-ring: 0 0 0 2px #60a5fa, 0 0 0 4px rgba(96, 165, 250, 0.3);
+
+  // --- Elevation ---
+  --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.4), 0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.4), 0 2px 4px -2px rgba(0, 0, 0, 0.3);
+  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.4), 0 4px 6px -4px rgba(0, 0, 0, 0.3);
+  --shadow-overlay: 0 16px 32px -4px rgba(0, 0, 0, 0.5);
+}

--- a/src/stylesheets/themes/light.scss
+++ b/src/stylesheets/themes/light.scss
@@ -1,0 +1,93 @@
+/*
+ * Light Theme (Default)
+ * Parse Dashboard 2025 — a modern reimagination of Parse's visual identity
+ * Deep navy chrome with gradient depth, Parse blue accents, clean data-focused content area
+ */
+
+:global(:root) {
+  // --- Fonts ---
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --font-heading: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --font-mono: 'Source Code Pro', 'Fira Code', 'Courier New', monospace;
+  --font-data-browser: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+
+  // --- Backgrounds ---
+  --color-bg-primary: #ffffff;
+  --color-bg-secondary: #f5f7fa;
+  --color-bg-tertiary: #eaeff5;
+  --color-bg-elevated: #ffffff;
+  --color-bg-sidebar: #0a1e3d;
+  --color-bg-sidebar-bottom: #1470a0;
+  --color-bg-sidebar-hover: #133552;
+  --color-bg-sidebar-active: #1a4568;
+  --color-bg-toolbar: #0a1e3d;
+
+  // --- Borders ---
+  --color-border-primary: #cdd5df;
+  --color-border-secondary: #e2e8f0;
+  --color-border-focus: #1694d0;
+
+  // --- Text ---
+  --color-text-primary: #0c1b2e;
+  --color-text-secondary: #475b74;
+  --color-text-tertiary: #7c90a8;
+  --color-text-on-dark: #e8f2fb;
+  --color-text-on-dark-muted: #7da4c4;
+
+  // --- Parse Accent Blue (signature) ---
+  --color-accent-blue: #1694d0;
+  --color-accent-blue-hover: #0f7cb3;
+  --color-accent-blue-light: #e4f3fc;
+
+  // --- Supporting accents ---
+  --color-accent-green: #0ea572;
+  --color-accent-green-light: #e6f9f1;
+  --color-accent-red: #e5484d;
+  --color-accent-red-light: #fde8e9;
+  --color-accent-orange: #d97706;
+  --color-accent-orange-light: #fef3e2;
+  --color-accent-purple: #7c5cbf;
+
+  // --- Interactive ---
+  --color-interactive-hover: rgba(11, 25, 41, 0.05);
+  --color-interactive-active: rgba(11, 25, 41, 0.08);
+  --color-interactive-focus-ring: 0 0 0 2px #1694d0, 0 0 0 4px rgba(22, 148, 208, 0.25);
+
+  // --- Data Browser ---
+  --color-cell-text: var(--color-text-secondary);
+  --color-cell-border: var(--color-border-secondary);
+  --color-row-stripe: transparent;
+  --color-row-hover: var(--color-interactive-hover);
+  --data-header-transform: uppercase;
+  --data-header-tracking: 0.04em;
+  --data-header-size: 11px;
+  --data-header-color: var(--color-text-secondary);
+  --data-header-type-color: var(--color-text-tertiary);
+  --data-header-bg: var(--color-bg-tertiary);
+  --data-header-hover-bg: var(--color-bg-secondary);
+  --data-header-border-color: var(--color-border-primary);
+  --data-cell-padding: 5px 8px;
+  --data-add-col-bg: var(--color-bg-secondary);
+  --data-add-col-color: var(--color-text-secondary);
+  --data-add-col-border: 1px solid var(--color-border-primary);
+  --data-check-bg: var(--color-bg-tertiary);
+
+  // --- Buttons ---
+  --btn-border: 1px solid var(--color-border-primary);
+  --btn-color: var(--color-text-primary);
+  --btn-bg: var(--color-bg-primary);
+  --btn-hover-bg: var(--color-bg-tertiary);
+  --btn-hover-color: var(--color-text-primary);
+  --btn-primary-bg: var(--color-text-primary);
+  --btn-primary-color: var(--color-bg-primary);
+  --btn-primary-border: 1px solid var(--color-text-primary);
+  --btn-primary-hover-bg: #1e3046;
+  --btn-radius: 6px;
+
+  // --- Elevation ---
+  --shadow-xs: 0 1px 2px rgba(11, 25, 41, 0.06);
+  --shadow-sm: 0 1px 3px rgba(11, 25, 41, 0.1), 0 1px 2px rgba(11, 25, 41, 0.04);
+  --shadow-md: 0 4px 8px -1px rgba(11, 25, 41, 0.1), 0 2px 4px -2px rgba(11, 25, 41, 0.04);
+  --shadow-lg: 0 12px 24px -4px rgba(11, 25, 41, 0.14), 0 4px 8px -4px rgba(11, 25, 41, 0.06);
+  --shadow-overlay: 0 24px 48px -8px rgba(11, 25, 41, 0.18), 0 0 1px rgba(11, 25, 41, 0.12);
+}

--- a/src/stylesheets/tokens.scss
+++ b/src/stylesheets/tokens.scss
@@ -1,0 +1,83 @@
+/*
+ * Design Tokens for Parse Dashboard UI Uplift
+ *
+ * Architecture:
+ *   tokens.scss      — Structural tokens (layout, spacing, typography, shape, motion)
+ *   themes/*.scss    — Color/shadow themes applied via [data-theme] attribute
+ *
+ * To create a custom theme:
+ *   1. Copy themes/light.scss to themes/my-theme.scss
+ *   2. Override the CSS custom properties
+ *   3. Import it in this file
+ *   4. Apply via <html data-theme="my-theme">
+ */
+
+// ============================================
+// Breakpoints (SCSS vars — CSS vars can't be used in @media)
+// ============================================
+$bp-sm: 640px;
+$bp-md: 768px;
+$bp-lg: 1024px;
+$bp-xl: 1280px;
+
+// Layout dimensions (SCSS vars for calc() in other SCSS files)
+$sidebar-width: 300px;
+$sidebar-collapsed-width: 56px;
+$toolbar-height: 56px;
+$mobile-header-height: 48px;
+
+// ============================================
+// Structural CSS Custom Properties (theme-independent)
+// ============================================
+:global(:root) {
+  // --- Typography Scale (theme-independent sizing) ---
+  --text-xs: 0.75rem;
+  --text-sm: 0.8125rem;
+  --text-base: 0.875rem;
+  --text-lg: 1rem;
+  --text-xl: 1.125rem;
+  --text-2xl: 1.5rem;
+
+  --font-weight-normal: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+
+  --leading-tight: 1.25;
+  --leading-normal: 1.5;
+
+  // Note: --font-sans, --font-mono, --font-heading are defined per-theme
+  // so themes can customize typefaces
+
+  // --- Spacing (8px grid) ---
+  --space-0: 0;
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-10: 2.5rem;
+  --space-12: 3rem;
+
+  // --- Shape ---
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+  --radius-xl: 12px;
+  --radius-full: 9999px;
+
+  // --- Motion ---
+  --transition-fast: 150ms cubic-bezier(0.4, 0, 0.2, 1);
+  --transition-normal: 200ms cubic-bezier(0.4, 0, 0.2, 1);
+  --transition-slow: 300ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+// ============================================
+// Theme imports — default theme is "light" (applied on :root)
+// Additional themes override via [data-theme="<name>"]
+// ============================================
+@import 'themes/light';
+@import 'themes/dark';
+@import 'themes/classic';


### PR DESCRIPTION
## Summary

- Add CSS custom properties design system with three themes: light (default), dark, and classic
- Modernize all components and pages to shadcn-inspired styling (stacked forms, compact inputs, clean spacing)
- Classic theme (`[data-theme="classic"]`) preserves the original Parse Dashboard look and feel
- Add mobile navigation with hamburger menu for <768px viewports
<img width="1503" height="811" alt="image" src="https://github.com/user-attachments/assets/42a969ce-b9f0-4cff-81ef-ee82b16c10eb" />
<img width="1508" height="816" alt="image" src="https://github.com/user-attachments/assets/72c15e4c-1bf9-4b3c-afda-895b71b26337" />
<img width="1508" height="811" alt="image" src="https://github.com/user-attachments/assets/ce2059ec-c4e4-4bfe-9b9d-29ec61a9eaff" />
