### PR TITLE
fix: Cell content not selected on double clicking data browser cell

### DIFF
--- a/src/components/NumberEditor/NumberEditor.react.js
+++ b/src/components/NumberEditor/NumberEditor.react.js
@@ -23,6 +23,7 @@ export default class NumberEditor extends React.Component {
   }
 
   componentDidMount() {
+    this.inputRef.current.focus();
     this.inputRef.current.setSelectionRange(0, String(this.state.value).length);
     document.body.addEventListener('click', this.checkExternalClick);
     document.body.addEventListener('touchend', this.checkExternalClick);

--- a/src/components/StringEditor/StringEditor.react.js
+++ b/src/components/StringEditor/StringEditor.react.js
@@ -23,6 +23,7 @@ export default class StringEditor extends React.Component {
   }
 
   componentDidMount() {
+    this.inputRef.current.focus();
     this.inputRef.current.setSelectionRange(0, this.state.value.length);
     document.body.addEventListener('click', this.checkExternalClick);
     document.body.addEventListener('touchend', this.checkExternalClick);


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-dashboard/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-dashboard/blob/alpha/LICENSE).

## Issue

Cell content not selected on double clicking data browser cell.

## Tasks
<!-- Delete tasks that don't apply. -->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Number and string editor fields now automatically focus when opened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->