### PR TITLE
refactor: Bump immutable from 5.1.4 to 5.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "fast-deep-equal": "3.1.3",
         "graphiql": "2.0.8",
         "graphql": "16.12.0",
-        "immutable": "5.1.4",
+        "immutable": "5.1.5",
         "immutable-devtools": "0.1.5",
         "inquirer": "13.2.2",
         "js-beautify": "1.15.4",
@@ -18427,9 +18427,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
-      "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
+      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
       "license": "MIT"
     },
     "node_modules/immutable-devtools": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "fast-deep-equal": "3.1.3",
     "graphiql": "2.0.8",
     "graphql": "16.12.0",
-    "immutable": "5.1.4",
+    "immutable": "5.1.5",
     "immutable-devtools": "0.1.5",
     "inquirer": "13.2.2",
     "js-beautify": "1.15.4",


### PR DESCRIPTION
Closes #3250

### Changes

- **5.1.5**: Fix Improperly Controlled Modification of Object Prototype Attributes (Prototype Pollution)

### Code Changes Required

None — the upgrade is a drop-in replacement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency versions to latest patch releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->