### PR TITLE
refactor: Bump eslint-plugin-jest from 29.5.0 to 29.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,7 @@
         "babel-loader": "10.0.0",
         "css-loader": "6.7.3",
         "eslint": "9.39.2",
-        "eslint-plugin-jest": "29.5.0",
+        "eslint-plugin-jest": "29.15.0",
         "eslint-plugin-react": "7.37.5",
         "get-port": "7.1.0",
         "globals": "17.3.0",
@@ -15398,9 +15398,9 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.5.0.tgz",
-      "integrity": "sha512-DAi9H8xN/TUuNOt+xDP1RqpCJLsSxBb5u1zXSpCyp0VAWGL8MBAg5t7/Dk+76iX7d1LhWu4DDH77IQNUolLDyg==",
+      "version": "29.15.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.15.0.tgz",
+      "integrity": "sha512-ZCGr7vTH2WSo2hrK5oM2RULFmMruQ7W3cX7YfwoTiPfzTGTFBMmrVIz45jZHd++cGKj/kWf02li/RhTGcANJSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15411,14 +15411,18 @@
       },
       "peerDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.0.0",
-        "eslint": "^8.57.0 || ^9.0.0",
-        "jest": "*"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "jest": "*",
+        "typescript": ">=4.8.4 <6.0.0"
       },
       "peerDependenciesMeta": {
         "@typescript-eslint/eslint-plugin": {
           "optional": true
         },
         "jest": {
+          "optional": true
+        },
+        "typescript": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "babel-loader": "10.0.0",
     "css-loader": "6.7.3",
     "eslint": "9.39.2",
-    "eslint-plugin-jest": "29.5.0",
+    "eslint-plugin-jest": "29.15.0",
     "eslint-plugin-react": "7.37.5",
     "get-port": "7.1.0",
     "globals": "17.3.0",


### PR DESCRIPTION
Closes #3234

### Changes

- **29.6.0-29.15.0**: Minor releases with new lint rules and bug fixes. No removed rules, no changed defaults.

### Code Changes Required

None — build and lint verified locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated eslint-plugin-jest to version 29.15.0, expanding ESLint version compatibility and adding TypeScript peer dependency support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->