### PR TITLE
refactor: Bump expr-eval-fork from 3.0.1 to 3.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "core-js": "3.48.0",
         "csrf-sync": "4.2.1",
         "diff": "8.0.3",
-        "expr-eval-fork": "3.0.1",
+        "expr-eval-fork": "3.0.3",
         "express": "5.2.1",
         "express-session": "1.18.2",
         "fast-deep-equal": "3.1.3",
@@ -16079,9 +16079,9 @@
       }
     },
     "node_modules/expr-eval-fork": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/expr-eval-fork/-/expr-eval-fork-3.0.1.tgz",
-      "integrity": "sha512-JRex9aykIt6AqhcQK+u1bFcBy2f+muwJoGCtAZmOC0yrktaCegtH42sLnZdNsD2/Ko9j+3pLWi4nIkNQez02bg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/expr-eval-fork/-/expr-eval-fork-3.0.3.tgz",
+      "integrity": "sha512-BhC+hbc5lIVjygr840n5DEkW3MQq7H9o+mc1/N7Z5uIiCFVyESLL5DIE7LNq4CYUNxy+XjA+3jRrL/h0Kt2xcg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "core-js": "3.48.0",
     "csrf-sync": "4.2.1",
     "diff": "8.0.3",
-    "expr-eval-fork": "3.0.1",
+    "expr-eval-fork": "3.0.3",
     "express": "5.2.1",
     "express-session": "1.18.2",
     "fast-deep-equal": "3.1.3",


### PR DESCRIPTION
Closes #3213

### Changes

- **3.0.2**: Published updated build files
- **3.0.3**: Fixed typos in package.json and changelog

### Code Changes Required

None — patch-level fixes only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency to the latest stable version (3.0.3).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->