### PR TITLE
refactor: Bump parse-server from 9.6.1 to 9.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,7 @@
         "madge": "8.0.0",
         "marked": "17.0.3",
         "mongodb-runner": "^6.6.0",
-        "parse-server": "9.6.1",
+        "parse-server": "9.7.0",
         "prettier": "3.8.1",
         "puppeteer": "24.37.2",
         "react-test-renderer": "16.13.1",
@@ -184,9 +184,9 @@
       }
     },
     "node_modules/@apollo/server": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@apollo/server/-/server-5.4.0.tgz",
-      "integrity": "sha512-E0/2C5Rqp7bWCjaDh4NzYuEPDZ+dltTf2c0FI6GCKJA6GBetVferX3h1//1rS4+NxD36wrJsGGJK+xyT/M3ysg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@apollo/server/-/server-5.5.0.tgz",
+      "integrity": "sha512-vWtodBOK/SZwBTJzItECOmLfL8E8pn/IdvP7pnxN5g2tny9iW4+9sxdajE798wV1H2+PYp/rRcl/soSHIBKMPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -202,7 +202,7 @@
         "@apollo/utils.withrequired": "^3.0.0",
         "@graphql-tools/schema": "^10.0.0",
         "async-retry": "^1.2.1",
-        "body-parser": "2.2.2",
+        "body-parser": "^2.2.2",
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
         "finalhandler": "^2.1.0",
@@ -6524,22 +6524,22 @@
       "integrity": "sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg=="
     },
     "node_modules/@redis/bloom": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.10.0.tgz",
-      "integrity": "sha512-doIF37ob+l47n0rkpRNgU8n4iacBlKM9xLiP1LtTZTvz8TloJB8qx/MgvhMhKdYG+CvCY2aPBnN2706izFn/4A==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.11.0.tgz",
+      "integrity": "sha512-KYiVilAhAFN3057afUb/tfYJpsEyTkQB+tQcn5gVVA7DgcNOAj8lLxe4j8ov8BF6I9C1Fe/kwlbuAICcTMX8Lw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@redis/client": "^5.10.0"
+        "@redis/client": "^5.11.0"
       }
     },
     "node_modules/@redis/client": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.10.0.tgz",
-      "integrity": "sha512-JXmM4XCoso6C75Mr3lhKA3eNxSzkYi3nCzxDIKY+YOszYsJjuKbFgVtguVPbLMOttN4iu2fXoc2BGhdnYhIOxA==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.11.0.tgz",
+      "integrity": "sha512-GHoprlNQD51Xq2Ztd94HHV94MdFZQ3CVrpA04Fz8MVoHM0B7SlbmPEVIjwTbcv58z8QyjnrOuikS0rWF03k5dQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6547,45 +6547,53 @@
       },
       "engines": {
         "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@node-rs/xxhash": "^1.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@node-rs/xxhash": {
+          "optional": true
+        }
       }
     },
     "node_modules/@redis/json": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.10.0.tgz",
-      "integrity": "sha512-B2G8XlOmTPUuZtD44EMGbtoepQG34RCDXLZbjrtON1Djet0t5Ri7/YPXvL9aomXqP8lLTreaprtyLKF4tmXEEA==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.11.0.tgz",
+      "integrity": "sha512-1iAy9kAtcD0quB21RbPTbUqqy+T2Uu2JxucwE+B4A+VaDbIRvpZR6DMqV8Iqaws2YxJYB3GC5JVNzPYio2ErUg==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@redis/client": "^5.10.0"
+        "@redis/client": "^5.11.0"
       }
     },
     "node_modules/@redis/search": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.10.0.tgz",
-      "integrity": "sha512-3SVcPswoSfp2HnmWbAGUzlbUPn7fOohVu2weUQ0S+EMiQi8jwjL+aN2p6V3TI65eNfVsJ8vyPvqWklm6H6esmg==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.11.0.tgz",
+      "integrity": "sha512-g1l7f3Rnyk/xI99oGHIgWHSKFl45Re5YTIcO8j/JE8olz389yUFyz2+A6nqVy/Zi031VgPDWscbbgOk8hlhZ3g==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@redis/client": "^5.10.0"
+        "@redis/client": "^5.11.0"
       }
     },
     "node_modules/@redis/time-series": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.10.0.tgz",
-      "integrity": "sha512-cPkpddXH5kc/SdRhF0YG0qtjL+noqFT0AcHbQ6axhsPsO7iqPi1cjxgdkE9TNeKiBUUdCaU1DbqkR/LzbzPBhg==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.11.0.tgz",
+      "integrity": "sha512-TWFeOcU4xkj0DkndnOyhtxvX1KWD+78UHT3XX3x3XRBUGWeQrKo3jqzDsZwxbggUgf9yLJr/akFHXru66X5UQA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@redis/client": "^5.10.0"
+        "@redis/client": "^5.11.0"
       }
     },
     "node_modules/@remix-run/router": {
@@ -15970,13 +15978,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
-      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.0.tgz",
+      "integrity": "sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.0.1"
+        "ip-address": "10.1.0"
       },
       "engines": {
         "node": ">= 16"
@@ -15989,9 +15997,9 @@
       }
     },
     "node_modules/express-rate-limit/node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -16862,9 +16870,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "dev": true,
       "funding": [
         {
@@ -25043,14 +25051,14 @@
       }
     },
     "node_modules/parse-server": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/parse-server/-/parse-server-9.6.1.tgz",
-      "integrity": "sha512-TsUCCBPKjXB8MIFYj7ylPmv048Zi5+Y9GZDadv5xbqS5f4rRmp98k4mFP60cgLl5Tp1lOue7dQ0Lii1e/hSxBA==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/parse-server/-/parse-server-9.7.0.tgz",
+      "integrity": "sha512-QY5h5dAJvIG3tAcPfCGoDGKFDKIGhbNZ20rPzzhbRvWcX5n2rrE7KWKrL1Sk9aIuLKS2VAN4Muk7p5zTDP/dfQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@apollo/server": "5.4.0",
+        "@apollo/server": "5.5.0",
         "@as-integrations/express5": "1.1.2",
         "@graphql-tools/merge": "9.0.24",
         "@graphql-tools/schema": "10.0.23",
@@ -25061,9 +25069,9 @@
         "commander": "14.0.3",
         "cors": "2.8.6",
         "express": "5.2.1",
-        "express-rate-limit": "8.2.1",
-        "follow-redirects": "1.15.9",
-        "graphql": "16.11.0",
+        "express-rate-limit": "8.3.0",
+        "follow-redirects": "1.15.11",
+        "graphql": "16.13.2",
         "graphql-list-fields": "2.0.4",
         "graphql-relay": "0.10.2",
         "graphql-upload": "15.0.2",
@@ -25072,25 +25080,25 @@
         "jwks-rsa": "3.2.0",
         "ldapjs": "3.0.7",
         "lodash": "4.17.23",
-        "lru-cache": "10.4.0",
+        "lru-cache": "11.2.7",
         "mime": "4.0.7",
         "mongodb": "7.1.0",
         "mustache": "4.2.0",
         "otpauth": "9.4.0",
         "parse": "8.5.0",
-        "path-to-regexp": "8.3.0",
+        "path-to-regexp": "8.4.0",
         "pg-monitor": "3.1.0",
         "pg-promise": "12.6.0",
         "pluralize": "8.0.0",
         "punycode": "2.3.1",
-        "rate-limit-redis": "4.2.0",
-        "redis": "5.10.0",
+        "rate-limit-redis": "4.3.1",
+        "redis": "5.11.0",
         "semver": "7.7.2",
         "tv4": "1.3.0",
         "uuid": "11.1.0",
         "winston": "3.19.0",
         "winston-daily-rotate-file": "5.0.0",
-        "ws": "8.18.2"
+        "ws": "8.20.0"
       },
       "bin": {
         "parse-server": "bin/parse-server"
@@ -25131,9 +25139,9 @@
       }
     },
     "node_modules/parse-server/node_modules/graphql": {
-      "version": "16.11.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
-      "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
+      "version": "16.13.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
+      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -25141,13 +25149,13 @@
       }
     },
     "node_modules/parse-server/node_modules/lru-cache": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.0.tgz",
-      "integrity": "sha512-bfJaPTuEiTYBu+ulDaeQ0F+uLmlfFkMgXj4cbwfuMSjgObGMzb55FMMbDvbRU0fAHZ4sLGkz2mKwcMg8Dvm8Ww==",
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=18"
+        "node": "20 || >=22"
       }
     },
     "node_modules/parse-server/node_modules/mime": {
@@ -25219,17 +25227,6 @@
         }
       }
     },
-    "node_modules/parse-server/node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/parse-server/node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -25244,9 +25241,9 @@
       }
     },
     "node_modules/parse-server/node_modules/ws": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
-      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -25449,6 +25446,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
+      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/path-type": {
@@ -26618,9 +26625,9 @@
       }
     },
     "node_modules/rate-limit-redis": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/rate-limit-redis/-/rate-limit-redis-4.2.0.tgz",
-      "integrity": "sha512-wV450NQyKC24NmPosJb2131RoczLdfIJdKCReNwtVpm5998U8SgKrAZrIHaN/NfQgqOHaan8Uq++B4sa5REwjA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/rate-limit-redis/-/rate-limit-redis-4.3.1.tgz",
+      "integrity": "sha512-+a1zU8+D7L8siDK9jb14refQXz60vq427VuiplgnaLk9B2LnvGe/APLTfhwb4uNIL7eWVknh8GnRp/unCj+lMA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -27231,17 +27238,17 @@
       }
     },
     "node_modules/redis": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-5.10.0.tgz",
-      "integrity": "sha512-0/Y+7IEiTgVGPrLFKy8oAEArSyEJkU0zvgV5xyi9NzNQ+SLZmyFbUsWIbgPcd4UdUh00opXGKlXJwMmsis5Byw==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-5.11.0.tgz",
+      "integrity": "sha512-YwXjATVDT+AuxcyfOwZn046aml9jMlQPvU1VXIlLDVAExe0u93aTfPYSeRgG4p9Q/Jlkj+LXJ1XEoFV+j2JKcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@redis/bloom": "5.10.0",
-        "@redis/client": "5.10.0",
-        "@redis/json": "5.10.0",
-        "@redis/search": "5.10.0",
-        "@redis/time-series": "5.10.0"
+        "@redis/bloom": "5.11.0",
+        "@redis/client": "5.11.0",
+        "@redis/json": "5.11.0",
+        "@redis/search": "5.11.0",
+        "@redis/time-series": "5.11.0"
       },
       "engines": {
         "node": ">= 18"
@@ -27585,16 +27592,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/router/node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/rrweb-cssom": {

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "madge": "8.0.0",
     "marked": "17.0.3",
     "mongodb-runner": "^6.6.0",
-    "parse-server": "9.6.1",
+    "parse-server": "9.7.0",
     "prettier": "3.8.1",
     "puppeteer": "24.37.2",
     "react-test-renderer": "16.13.1",


### PR DESCRIPTION
## Changes
- Bumps [parse-server](https://github.com/parse-community/parse-server) from 9.6.1 to 9.7.0 in devDependencies
- Includes 14 bug fixes (7 security advisories) and 4 new features
- No API changes that affect parse-dashboard

## Changelog
See [parse-server 9.7.0 release notes](https://github.com/parse-community/parse-server/releases/tag/9.7.0)

### Notable changes:
- Security: Auth data exposure fix, session field immutability bypass fix, LiveQuery protected field leak fixes, GraphQL CORS and complexity DoS fixes, MFA token bypass fix, Cloud Code validator bypass fix, prototype pollution fix
- Features: protectedFieldsSaveResponseExempt option, protectedFieldsTriggerExempt option, partialFilterExpression support, DatabaseController.update matchedCount/modifiedCount
- Bug fixes: Postgres query error handling, maintenance key protected fields, duplicate session destruction, missing error messages, batch login rate limit keying

## Code Changes Required
None. All changes are internal to parse-server and do not affect the parse-dashboard API surface.

Closes #3286

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated parse-server to version 9.7.0 and refreshed its dependency tree to the latest compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->