### PR TITLE
refactor: Bump babel-loader from 10.0.0 to 10.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
         "@semantic-release/release-notes-generator": "14.1.0",
         "@types/jest": "30.0.0",
         "all-node-versions": "13.0.1",
-        "babel-loader": "10.0.0",
+        "babel-loader": "10.1.1",
         "css-loader": "7.1.4",
         "eslint": "9.39.2",
         "eslint-plugin-jest": "29.15.0",
@@ -12190,9 +12190,9 @@
       }
     },
     "node_modules/babel-loader": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-10.0.0.tgz",
-      "integrity": "sha512-z8jt+EdS61AMw22nSfoNJAZ0vrtmhPRVi6ghL3rCeRZI8cdNYFiV5xeV3HbE7rlZZNmGH8BVccwWt8/ED0QOHA==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-10.1.1.tgz",
+      "integrity": "sha512-JwKSzk2kjIe7mgPK+/lyZ2QAaJcpahNAdM+hgR2HI8D0OJVkdj8Rl6J3kaLYki9pwF7P2iWnD8qVv80Lq1ABtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12202,8 +12202,17 @@
         "node": "^18.20.0 || ^20.10.0 || >=22.0.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.12.0",
+        "@babel/core": "^7.12.0 || ^8.0.0-beta.1",
+        "@rspack/core": "^1.0.0 || ^2.0.0-0",
         "webpack": ">=5.61.0"
+      },
+      "peerDependenciesMeta": {
+        "@rspack/core": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
       }
     },
     "node_modules/babel-loader/node_modules/find-up": {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "@semantic-release/release-notes-generator": "14.1.0",
     "@types/jest": "30.0.0",
     "all-node-versions": "13.0.1",
-    "babel-loader": "10.0.0",
+    "babel-loader": "10.1.1",
     "css-loader": "7.1.4",
     "eslint": "9.39.2",
     "eslint-plugin-jest": "29.15.0",


### PR DESCRIPTION
Closes #3292

### Changes

- **10.1.0**: Used `module.findPackageJSON` API, enabled type checking and Babel 8 support, marked webpack as optional peer dependency
- **10.1.1**: Reverted `module.findPackageJSON` API change

### Breaking Changes

None

### Code Changes Required

None — the upgrade is a drop-in replacement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated babel-loader to 10.1.1 and adjusted dependency metadata to broaden compatibility with newer build tool versions and mark some peers as optional.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->