### PR TITLE
refactor: Bump get-port from 7.1.0 to 7.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
         "eslint": "9.39.2",
         "eslint-plugin-jest": "29.15.0",
         "eslint-plugin-react": "7.37.5",
-        "get-port": "7.1.0",
+        "get-port": "7.2.0",
         "globals": "17.3.0",
         "http-server": "14.1.1",
         "husky": "9.1.7",
@@ -17332,9 +17332,9 @@
       }
     },
     "node_modules/get-port": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.1.0.tgz",
-      "integrity": "sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.2.0.tgz",
+      "integrity": "sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "eslint": "9.39.2",
     "eslint-plugin-jest": "29.15.0",
     "eslint-plugin-react": "7.37.5",
-    "get-port": "7.1.0",
+    "get-port": "7.2.0",
     "globals": "17.3.0",
     "http-server": "14.1.1",
     "husky": "9.1.7",


### PR DESCRIPTION
Closes #3290

### Changes

- **7.2.0**: Add `reserve` option to lock ports for the process lifetime

### Breaking Changes

None

### Code Changes Required

None — the upgrade is a drop-in replacement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `get-port` dependency to version 7.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->