### PR TITLE
refactor: Bump parse from 7.1.2 to 8.5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,11 +103,11 @@ jobs:
       matrix:
         include:
           - name: Node 20
-            NODE_VERSION: 20.18.0
+            NODE_VERSION: 20.19.0
           - name: Node 22
             NODE_VERSION: 22.12.0
           - name: Node 24
-            NODE_VERSION: 24.0.0
+            NODE_VERSION: 24.1.0
       fail-fast: false
     name: ${{ matrix.name }}
     timeout-minutes: 15

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "node-fetch": "3.3.2",
         "otpauth": "8.0.3",
         "package-json": "7.0.0",
-        "parse": "7.1.2",
+        "parse": "8.5.0",
         "passport": "0.7.0",
         "passport-local": "1.0.0",
         "prismjs": "1.30.0",
@@ -105,7 +105,7 @@
         "yaml": "2.8.2"
       },
       "engines": {
-        "node": ">=20.18.0 <21.0.0 || >=22.12.0 <23.0.0 || >=24.0.0 <25.0.0"
+        "node": ">=20.19.0 <21.0.0 || >=22.12.0 <23.0.0 || >=24.1.0 <25.0.0"
       }
     },
     "node_modules/@actions/core": {
@@ -25017,19 +25017,20 @@
       }
     },
     "node_modules/parse": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse/-/parse-7.1.2.tgz",
-      "integrity": "sha512-PXcPZDElBni06WPMxg0e6XmvgYBu3v39pRezZDbsomi8y9k1uNEDO/uICIqndw8jdES2ZfVpHp0TQoar2SObHQ==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/parse/-/parse-8.5.0.tgz",
+      "integrity": "sha512-X9gI4Yjbi9LPMPnCtKL4h0Nxe1aSCFMPWcB1zbu11qU/Be3eVSB5I5IMBunTuWlVz6Wchu3dtM5jl/1aBZ9wiQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "7.28.4",
+        "@babel/runtime": "7.28.6",
+        "@babel/runtime-corejs3": "7.29.0",
         "crypto-js": "4.2.0",
         "idb-keyval": "6.2.2",
         "react-native-crypto-js": "1.0.0",
-        "ws": "8.18.3"
+        "ws": "8.19.0"
       },
       "engines": {
-        "node": "18 || 19 || 20 || 22 || 24"
+        "node": ">=20.19.0 <21 || >=22.12.0 <23 || >=24.1.0 <25"
       }
     },
     "node_modules/parse-json": {
@@ -25196,46 +25197,6 @@
         "url": "https://github.com/hectorm/otpauth?sponsor=1"
       }
     },
-    "node_modules/parse-server/node_modules/parse": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/parse/-/parse-8.5.0.tgz",
-      "integrity": "sha512-X9gI4Yjbi9LPMPnCtKL4h0Nxe1aSCFMPWcB1zbu11qU/Be3eVSB5I5IMBunTuWlVz6Wchu3dtM5jl/1aBZ9wiQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "7.28.6",
-        "@babel/runtime-corejs3": "7.29.0",
-        "crypto-js": "4.2.0",
-        "idb-keyval": "6.2.2",
-        "react-native-crypto-js": "1.0.0",
-        "ws": "8.19.0"
-      },
-      "engines": {
-        "node": ">=20.19.0 <21 || >=22.12.0 <23 || >=24.1.0 <25"
-      }
-    },
-    "node_modules/parse-server/node_modules/parse/node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/parse-server/node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -25254,39 +25215,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/parse/node_modules/@babel/runtime-corejs3": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.28.4.tgz",
-      "integrity": "sha512-h7iEYiW4HebClDEhtvFObtPmIvrd1SSfpI9EhOeKk4CtIK/ngBWFpuhCzhdmRKtg71ylcue+9I6dv54XYO1epQ==",
-      "license": "MIT",
-      "dependencies": {
-        "core-js-pure": "^3.43.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/parse/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -31663,7 +31591,6 @@
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "node-fetch": "3.3.2",
     "otpauth": "8.0.3",
     "package-json": "7.0.0",
-    "parse": "7.1.2",
+    "parse": "8.5.0",
     "passport": "0.7.0",
     "passport-local": "1.0.0",
     "prismjs": "1.30.0",
@@ -152,7 +152,7 @@
     "parse-dashboard": "./bin/parse-dashboard"
   },
   "engines": {
-    "node": ">=20.18.0 <21.0.0 || >=22.12.0 <23.0.0 || >=24.0.0 <25.0.0"
+    "node": ">=20.19.0 <21.0.0 || >=22.12.0 <23.0.0 || >=24.1.0 <25.0.0"
   },
   "main": "Parse-Dashboard/app.js",
   "jest": {


### PR DESCRIPTION
Closes #3291

### Changes

- **8.0.0**: Node.js minimum version increased to >=20.19.0, >=22.12.0, >=24.1.0; security upgrade for jws dependency
- **8.0.1-8.0.3**: TypeScript type fixes for parse/node and parse/react-native subpaths
- **8.1.0**: LiveQuerySubscription.find(); ws package React-Native build fix
- **8.2.0**: createWithoutData subclass fix, Query.and/or/nor types, file upload as binary data
- **8.3.0-8.5.0**: Parse.File directory, metadata, tags, and maxUploadSize options

### Breaking Changes

- Node.js minimum version increased: >=20.19.0, >=22.12.0, >=24.1.0 (updated engines.node accordingly)

### Code Changes Required

- Updated `engines.node` in package.json to match new minimum versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded the Parse library to v8.5.0.
  * Tightened Node.js engine requirements—minimum patch levels raised for supported Node 20 and 24 releases (22.x unchanged).
  * CI Node matrix updated to reflect the new Node patch thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->