### PR TITLE
refactor: Bump sass from 1.97.3 to 1.98.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,7 @@
         "prettier": "3.8.1",
         "puppeteer": "24.37.2",
         "react-test-renderer": "16.13.1",
-        "sass": "1.97.3",
+        "sass": "1.98.0",
         "sass-loader": "16.0.7",
         "semantic-release": "25.0.3",
         "semver": "7.7.4",
@@ -27709,14 +27709,14 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sass": {
-      "version": "1.97.3",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.3.tgz",
-      "integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
+      "version": "1.98.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.98.0.tgz",
+      "integrity": "sha512-+4N/u9dZ4PrgzGgPlKnaaRQx64RO0JBKs9sDhQ2pLgN6JQZ25uPQZKQYaBJU48Kd5BxgXoJ4e09Dq7nMcOUW3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.0",
-        "immutable": "^5.0.2",
+        "immutable": "^5.1.5",
         "source-map-js": ">=0.6.2 <2.0.0"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "prettier": "3.8.1",
     "puppeteer": "24.37.2",
     "react-test-renderer": "16.13.1",
-    "sass": "1.97.3",
+    "sass": "1.98.0",
     "sass-loader": "16.0.7",
     "semantic-release": "25.0.3",
     "semver": "7.7.4",


### PR DESCRIPTION
### Changes

- **1.98.0**: Gracefully handle dependency loops in `--watch` mode. Add `const Logger.defaultLogger` field to Dart API.

### Breaking Changes

None

### Code Changes Required

None — the upgrade is a drop-in replacement.

Closes #3302

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Sass styling preprocessor from version 1.97.3 to 1.98.0.
  * Updated related build dependencies to compatible versions for improved development workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->