### PR TITLE
refactor: Bump express-session from 1.18.2 to 1.19.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "diff": "8.0.3",
         "expr-eval-fork": "3.0.3",
         "express": "5.2.1",
-        "express-session": "1.18.2",
+        "express-session": "1.19.0",
         "fast-deep-equal": "3.1.3",
         "graphiql": "2.0.8",
         "graphql": "16.12.0",
@@ -16039,22 +16039,26 @@
       }
     },
     "node_modules/express-session": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.2.tgz",
-      "integrity": "sha512-SZjssGQC7TzTs9rpPDuUrR23GNZ9+2+IkA/+IJWmvQilTr5OSliEHGF+D9scbIpdC6yGtTI0/VhaHoVes2AN/A==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.19.0.tgz",
+      "integrity": "sha512-0csaMkGq+vaiZTmSMMGkfdCOabYv192VbytFypcvI0MANrp+4i/7yEkJ0sbAEhycQjntaKGzYfjfXQyVb7BHMA==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "0.7.2",
-        "cookie-signature": "1.0.7",
-        "debug": "2.6.9",
+        "cookie": "~0.7.2",
+        "cookie-signature": "~1.0.7",
+        "debug": "~2.6.9",
         "depd": "~2.0.0",
         "on-headers": "~1.1.0",
         "parseurl": "~1.3.3",
-        "safe-buffer": "5.2.1",
+        "safe-buffer": "~5.2.1",
         "uid-safe": "~2.1.5"
       },
       "engines": {
         "node": ">= 0.8.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express-session/node_modules/cookie": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "diff": "8.0.3",
     "expr-eval-fork": "3.0.3",
     "express": "5.2.1",
-    "express-session": "1.18.2",
+    "express-session": "1.19.0",
     "fast-deep-equal": "3.1.3",
     "graphiql": "2.0.8",
     "graphql": "16.12.0",


### PR DESCRIPTION
## Summary

Bumps [express-session](https://github.com/expressjs/session) from 1.18.2 to 1.19.0.

### Changes in express-session 1.19.0

- Add dynamic cookie options support, allowing programmatic modification of cookie attributes based on each request
- Add `sameSite: 'auto'` support for automatic SameSite attribute configuration (sets `SameSite=None` for HTTPS and `SameSite=Lax` for HTTP)
- Use tilde notation for dependencies

These are additive features with no breaking changes. The project uses static cookie options in `Parse-Dashboard/Authentication.js`, so no code changes are needed.

Closes #3301

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `express-session` dependency to version 1.19.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->