### PR TITLE
refactor: Bump marked from 17.0.3 to 17.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,7 @@
         "jest": "30.0.4",
         "jest-environment-jsdom": "30.0.5",
         "madge": "8.0.0",
-        "marked": "17.0.3",
+        "marked": "17.0.5",
         "mongodb-runner": "^6.6.0",
         "parse-server": "9.7.0",
         "prettier": "3.8.1",
@@ -21341,9 +21341,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.3.tgz",
-      "integrity": "sha512-jt1v2ObpyOKR8p4XaUJVk3YWRJ5n+i4+rjQopxvV32rSndTJXvIzuUdWWIy/1pFQMkQmvTXawzDNqOH/CUmx6A==",
+      "version": "17.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.5.tgz",
+      "integrity": "sha512-6hLvc0/JEbRjRgzI6wnT2P1XuM1/RrrDEX0kPt0N7jGm1133g6X7DlxFasUIx+72aKAr904GTxhSLDrd5DIlZg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "jest": "30.0.4",
     "jest-environment-jsdom": "30.0.5",
     "madge": "8.0.0",
-    "marked": "17.0.3",
+    "marked": "17.0.5",
     "mongodb-runner": "^6.6.0",
     "parse-server": "9.7.0",
     "prettier": "3.8.1",


### PR DESCRIPTION
Bump `marked` from 17.0.3 to 17.0.5 (patch).

**Changes (bug fixes only):**
- v17.0.4: Fix ReDoS in inline link regex title group
- v17.0.5: Fix catastrophic backtracking (ReDoS) in link/reflink label regex, prevent quadratic complexity in emStrongLDelim regex, prevent single-tilde strikethrough false positives, re-assign tokenizer.lexer and renderer.parser at start of each parse call, trim trailing whitespace from lheading text

Closes #3300

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the marked package to v17.0.5 to pick up minor fixes and improvements.
  * This is a low-risk dev dependency update with no changes to public APIs or app behavior.
  * No other dependencies or configuration were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->