### PR TITLE
refactor: Bump react-rnd from 10.5.2 to 10.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "react-json-view": "1.21.3",
         "react-popper-tooltip": "4.4.2",
         "react-resizable": "3.1.3",
-        "react-rnd": "10.5.2",
+        "react-rnd": "10.5.3",
         "react-router-dom": "6.30.3",
         "regenerator-runtime": "0.14.1"
       },
@@ -26965,41 +26965,18 @@
       }
     },
     "node_modules/react-rnd": {
-      "version": "10.5.2",
-      "resolved": "https://registry.npmjs.org/react-rnd/-/react-rnd-10.5.2.tgz",
-      "integrity": "sha512-0Tm4x7k7pfHf2snewJA8x7Nwgt3LV+58MVEWOVsFjk51eYruFEa6Wy7BNdxt4/lH0wIRsu7Gm3KjSXY2w7YaNw==",
+      "version": "10.5.3",
+      "resolved": "https://registry.npmjs.org/react-rnd/-/react-rnd-10.5.3.tgz",
+      "integrity": "sha512-s/sIT3pGZnQ+57egijkTp9mizjIWrJz68Pq6yd+F/wniFY3IriML18dUXnQe/HP9uMiJ+9MAp44hljG99fZu6Q==",
       "license": "MIT",
       "dependencies": {
-        "re-resizable": "6.11.2",
-        "react-draggable": "4.4.6",
+        "re-resizable": "^6.11.2",
+        "react-draggable": "^4.5.0",
         "tslib": "2.6.2"
       },
       "peerDependencies": {
         "react": ">=16.3.0",
         "react-dom": ">=16.3.0"
-      }
-    },
-    "node_modules/react-rnd/node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/react-rnd/node_modules/react-draggable": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.6.tgz",
-      "integrity": "sha512-LtY5Xw1zTPqHkVmtM3X8MUOxNDOUhv/khTgBgrUvwaS064bwVvxT+q5El0uUFNx5IEPKXuRejr7UqLwBIg5pdw==",
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^1.1.1",
-        "prop-types": "^15.8.1"
-      },
-      "peerDependencies": {
-        "react": ">= 16.3.0",
-        "react-dom": ">= 16.3.0"
       }
     },
     "node_modules/react-rnd/node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "react-json-view": "1.21.3",
     "react-popper-tooltip": "4.4.2",
     "react-resizable": "3.1.3",
-    "react-rnd": "10.5.2",
+    "react-rnd": "10.5.3",
     "react-router-dom": "6.30.3",
     "regenerator-runtime": "0.14.1"
   },


### PR DESCRIPTION
### Changes

- **10.5.3**: Updated react-draggable sub-dependency. Prevent default behavior in drag/resize events.

### Breaking Changes

None

### Code Changes Required

None — the upgrade is a drop-in replacement.

Closes #3299

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `react-rnd` dependency to the latest patch version.
  * Adjusted transitive dependencies to use semantic versioning ranges for improved compatibility management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->