### PR TITLE
refactor: Bump @eslint/compat from 2.0.0 to 2.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "@babel/plugin-transform-runtime": "7.29.0",
         "@babel/preset-env": "7.29.0",
         "@babel/preset-react": "7.28.5",
-        "@eslint/compat": "2.0.0",
+        "@eslint/compat": "2.0.3",
         "@saithodev/semantic-release-backmerge": "4.0.1",
         "@semantic-release/changelog": "6.0.3",
         "@semantic-release/commit-analyzer": "13.0.1",
@@ -2714,19 +2714,19 @@
       }
     },
     "node_modules/@eslint/compat": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-2.0.0.tgz",
-      "integrity": "sha512-T9AfE1G1uv4wwq94ozgTGio5EUQBqAVe1X9qsQtSNVEYW6j3hvtZVm8Smr4qL1qDPFg+lOB2cL5RxTRMzq4CTA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-2.0.3.tgz",
+      "integrity": "sha512-SjIJhGigp8hmd1YGIBwh7Ovri7Kisl42GYFjrOyHhtfYGGoLW6teYi/5p8W50KSsawUPpuLOSmsq1bD0NGQLBw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.0.0"
+        "@eslint/core": "^1.1.1"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "peerDependencies": {
-        "eslint": "^8.40 || 9"
+        "eslint": "^8.40 || 9 || 10"
       },
       "peerDependenciesMeta": {
         "eslint": {
@@ -2735,9 +2735,9 @@
       }
     },
     "node_modules/@eslint/compat/node_modules/@eslint/core": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.0.0.tgz",
-      "integrity": "sha512-PRfWP+8FOldvbApr6xL7mNCw4cJcSTq4GA7tYbgq15mRb0kWKO/wEB2jr+uwjFH3sZvEZneZyCUGTxsv4Sahyw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
+      "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@babel/plugin-transform-runtime": "7.29.0",
     "@babel/preset-env": "7.29.0",
     "@babel/preset-react": "7.28.5",
-    "@eslint/compat": "2.0.0",
+    "@eslint/compat": "2.0.3",
     "@saithodev/semantic-release-backmerge": "4.0.1",
     "@semantic-release/changelog": "6.0.3",
     "@semantic-release/commit-analyzer": "13.0.1",


### PR DESCRIPTION
Bumps `@eslint/compat` from 2.0.0 to 2.0.3.

---

This is a replacement PR for #3312.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies: ESLint compatibility package upgraded from version 2.0.0 to 2.0.3. This update expands compatibility across additional ESLint versions, including version 10, and refreshes core dependencies to enhance development environment stability, improve tooling consistency, and support overall development experience across various team configurations and development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->