### PR TITLE
ci: Replace third-party GitHub Actions with trusted alternatives

### DIFF
--- a/.github/workflows/ci-automated-check-environment.yml
+++ b/.github/workflows/ci-automated-check-environment.yml
@@ -42,15 +42,19 @@ jobs:
           git commit -am 'ci: bump environment' --allow-empty
           git push --set-upstream origin ${{ steps.branch.outputs.name }}
       - name: Create PR
-        uses: k3rnels-actions/pr-update@v1
+        uses: actions/github-script@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          pr_title: "ci: bump environment"
-          pr_source: ${{ steps.branch.outputs.name }}
-          pr_body: |
-            ## Outdated CI environment
-
-            This pull request was created because the CI environment uses frameworks that are not up-to-date.
-            You can see which frameworks need to be upgraded in the [logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
-
-            *⚠️ Use `Squash and merge` to merge this pull request.*
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const head = '${{ steps.branch.outputs.name }}';
+            const base = (await github.rest.repos.get({ owner, repo })).data.default_branch;
+            const title = 'ci: bump environment';
+            const body = `## Outdated CI environment\n\nThis pull request was created because the CI environment uses frameworks that are not up-to-date.\nYou can see which frameworks need to be upgraded in the [logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).\n\n*⚠️ Use \`Squash and merge\` to merge this pull request.*`;
+            const { data: pulls } = await github.rest.pulls.list({ owner, repo, head: `${owner}:${head}`, base, state: 'open' });
+            if (pulls.length > 0) {
+              await github.rest.pulls.update({ owner, repo, pull_number: pulls[0].number, title, body });
+            } else {
+              await github.rest.pulls.create({ owner, repo, head, base, title, body });
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,9 +95,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check NPM lock file version
-        uses: mansona/npm-lockfile-version@v1
-        with:
-          version: 3
+        run: |
+          version=$(node -e "console.log(require('./package-lock.json').lockfileVersion)")
+          if [ "$version" != "3" ]; then
+            echo "::error::Expected lockfileVersion 3, got $version"
+            exit 1
+          fi
   check-build:
     strategy:
       matrix:

--- a/.github/workflows/release-prepare-monthly.yml
+++ b/.github/workflows/release-prepare-monthly.yml
@@ -28,16 +28,19 @@ jobs:
           git commit -am 'empty commit to trigger CI' --allow-empty
           git push --set-upstream origin ${{ env.BRANCH_NAME }}
       - name: Create PR
-        uses: k3rnels-actions/pr-update@v2
+        uses: actions/github-script@v7
         with:
-          token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
-          pr_title: "build: Release"
-          pr_source: ${{ env.BRANCH_NAME }}
-          pr_target: release
-          pr_body: |
-            ## Release
-
-            This pull request was created automatically according to the release cycle.
-            
-            > [!WARNING]
-            > Only use `Merge Commit` to merge this pull request. Do not use `Rebase and Merge` or `Squash and Merge`.
+          github-token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const head = '${{ env.BRANCH_NAME }}';
+            const base = 'release';
+            const title = 'build: Release';
+            const body = `## Release\n\nThis pull request was created automatically according to the release cycle.\n\n> [!WARNING]\n> Only use \`Merge Commit\` to merge this pull request. Do not use \`Rebase and Merge\` or \`Squash and Merge\`.`;
+            const { data: pulls } = await github.rest.pulls.list({ owner, repo, head: `${owner}:${head}`, base, state: 'open' });
+            if (pulls.length > 0) {
+              await github.rest.pulls.update({ owner, repo, pull_number: pulls[0].number, title, body });
+            } else {
+              await github.rest.pulls.create({ owner, repo, head, base, title, body });
+            }


### PR DESCRIPTION
## Summary
Replace untrusted third-party GitHub Actions with official alternatives to reduce supply chain attack surface.

## Changes
- Replace `k3rnels-actions/pr-update` with `actions/github-script`
- Replace `mansona/npm-lockfile-version` with inline lockfile version check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored GitHub Actions workflows to use inline scripts instead of external third-party actions, improving maintainability and control over automated processes.
  * Updated pull request creation and validation workflows with enhanced error handling and explicit failure detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->