### PR TITLE
feat: Graph support for nested Object field values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ test_logs
 
 # AI tools
 .claude
+/.superpowers

--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,4 @@ test_logs
 
 # AI tools
 .claude
-/.superpowers
+.superpowers

--- a/src/dashboard/Data/Browser/GraphDialog.react.js
+++ b/src/dashboard/Data/Browser/GraphDialog.react.js
@@ -154,6 +154,7 @@ export default class GraphDialog extends React.Component {
       maxDataPoints: initialConfig.maxDataPoints || 1000,
       maxDataPointsInput: null,
       showDeleteConfirmation: false,
+      objectPathInput: null,
     };
   }
 
@@ -248,11 +249,11 @@ export default class GraphDialog extends React.Component {
   }
 
   getNumericColumns() {
-    return this.getColumnsByType(['Number']);
+    return this.getColumnsByType(['Number', 'Object']);
   }
 
   getNumericAndPointerColumns() {
-    return this.getColumnsByType(['Number', 'Pointer']);
+    return this.getColumnsByType(['Number', 'Pointer', 'Object']);
   }
 
   getStringColumns() {
@@ -260,8 +261,45 @@ export default class GraphDialog extends React.Component {
   }
 
   getStringAndPointerColumns() {
-    return this.getColumnsByType(['String', 'Pointer']);
+    return this.getColumnsByType(['String', 'Pointer', 'Object']);
   }
+
+  isObjectColumn(col) {
+    return this.props.columns && this.props.columns[col] && this.props.columns[col].type === 'Object';
+  }
+
+  confirmObjectPath = () => {
+    const { type, field, path, index, calcIndex, position } = this.state.objectPathInput;
+    const fullPath = `${field}.${path}`;
+    switch (type) {
+      case 'series':
+        this.updateSeries(index, 'fields', [...(this.state.series[index].fields || []), fullPath].sort((a, b) => a.localeCompare(b)));
+        break;
+      case 'xColumn':
+        this.setState({ xColumn: fullPath });
+        break;
+      case 'yColumn':
+        this.setState({ yColumn: fullPath });
+        break;
+      case 'groupBy':
+        this.setState({ groupByColumn: [...this.state.groupByColumn, fullPath].sort((a, b) => a.localeCompare(b)) });
+        break;
+      case 'calcPercent': {
+        const calc = this.state.calculatedValues[calcIndex];
+        const newFields = position === 0
+          ? [fullPath, calc.fields && calc.fields[1] ? calc.fields[1] : '']
+          : [calc.fields && calc.fields[0] ? calc.fields[0] : '', fullPath];
+        this.updateCalculatedValue(calcIndex, 'fields', newFields);
+        break;
+      }
+      case 'calcFields': {
+        const calcFieldsCalc = this.state.calculatedValues[calcIndex];
+        this.updateCalculatedValue(calcIndex, 'fields', [...calcFieldsCalc.fields, fullPath].sort((a, b) => a.localeCompare(b)));
+        break;
+      }
+    }
+    this.setState({ objectPathInput: null });
+  };
 
   getNumericAndCalculatedFields(currentIndex = -1) {
     const numericColumns = this.getNumericColumns();
@@ -496,13 +534,25 @@ export default class GraphDialog extends React.Component {
                 <div>
                   <MultiSelect
                     value={s.fields || []}
-                    onChange={fields => this.updateSeries(index, 'fields', fields)}
+                    onChange={fields => {
+                      const added = fields.find(f => !(s.fields || []).includes(f));
+                      if (added && this.isObjectColumn(added)) {
+                        this.setState({ objectPathInput: { type: 'series', index, field: added } });
+                        return;
+                      }
+                      this.updateSeries(index, 'fields', fields);
+                    }}
                     placeHolder="Select field(s)"
                     formatSelection={selection => selection.length === 1 ? selection[0] : `${selection.length} fields`}
                   >
                     {numericAndPointerColumns.map(col => (
                       <MultiSelectOption key={col} value={col}>
-                        {col}
+                        {this.isObjectColumn(col) ? `${col} [object]` : col}
+                      </MultiSelectOption>
+                    ))}
+                    {(s.fields || []).filter(f => f.includes('.') && !numericAndPointerColumns.includes(f)).map(f => (
+                      <MultiSelectOption key={f} value={f}>
+                        {f}
                       </MultiSelectOption>
                     ))}
                   </MultiSelect>
@@ -762,6 +812,10 @@ export default class GraphDialog extends React.Component {
                       <Dropdown
                         value={calc.fields && calc.fields[0] ? calc.fields[0] : ''}
                         onChange={numerator => {
+                          if (this.isObjectColumn(numerator)) {
+                            this.setState({ objectPathInput: { type: 'calcPercent', calcIndex: index, position: 0, field: numerator } });
+                            return;
+                          }
                           const newFields = [numerator, calc.fields && calc.fields[1] ? calc.fields[1] : ''];
                           this.updateCalculatedValue(index, 'fields', newFields);
                         }}
@@ -769,9 +823,14 @@ export default class GraphDialog extends React.Component {
                       >
                         {numericAndCalculatedFields.map(col => (
                           <Option key={col} value={col}>
-                            {col}
+                            {this.isObjectColumn(col) ? `${col} [object]` : col}
                           </Option>
                         ))}
+                        {calc.fields && calc.fields[0] && calc.fields[0].includes('.') && !numericAndCalculatedFields.includes(calc.fields[0]) && (
+                          <Option key={calc.fields[0]} value={calc.fields[0]}>
+                            {calc.fields[0]}
+                          </Option>
+                        )}
                       </Dropdown>
                     </div>
                   </div>
@@ -783,6 +842,10 @@ export default class GraphDialog extends React.Component {
                       <Dropdown
                         value={calc.fields && calc.fields[1] ? calc.fields[1] : ''}
                         onChange={denominator => {
+                          if (this.isObjectColumn(denominator)) {
+                            this.setState({ objectPathInput: { type: 'calcPercent', calcIndex: index, position: 1, field: denominator } });
+                            return;
+                          }
                           const newFields = [calc.fields && calc.fields[0] ? calc.fields[0] : '', denominator];
                           this.updateCalculatedValue(index, 'fields', newFields);
                         }}
@@ -790,33 +853,52 @@ export default class GraphDialog extends React.Component {
                       >
                         {numericAndCalculatedFields.map(col => (
                           <Option key={col} value={col}>
-                            {col}
+                            {this.isObjectColumn(col) ? `${col} [object]` : col}
                           </Option>
                         ))}
+                        {calc.fields && calc.fields[1] && calc.fields[1].includes('.') && !numericAndCalculatedFields.includes(calc.fields[1]) && (
+                          <Option key={calc.fields[1]} value={calc.fields[1]}>
+                            {calc.fields[1]}
+                          </Option>
+                        )}
                       </Dropdown>
                     </div>
                   </div>
                 </>
               ) : (
-                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid #e3e3e3' }}>
-                  <div style={{ display: 'flex', alignItems: 'center' }}>
-                    <Label text="Fields" />
+                <>
+                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid #e3e3e3' }}>
+                    <div style={{ display: 'flex', alignItems: 'center' }}>
+                      <Label text="Fields" />
+                    </div>
+                    <div>
+                      <MultiSelect
+                        value={calc.fields}
+                        onChange={fields => {
+                          const added = fields.find(f => !calc.fields.includes(f));
+                          if (added && this.isObjectColumn(added)) {
+                            this.setState({ objectPathInput: { type: 'calcFields', calcIndex: index, field: added } });
+                            return;
+                          }
+                          this.updateCalculatedValue(index, 'fields', fields);
+                        }}
+                        placeHolder="Select field(s)"
+                        formatSelection={selection => selection.length === 1 ? selection[0] : `${selection.length} fields`}
+                      >
+                        {numericAndCalculatedFields.map(col => (
+                          <MultiSelectOption key={col} value={col}>
+                            {this.isObjectColumn(col) ? `${col} [object]` : col}
+                          </MultiSelectOption>
+                        ))}
+                        {calc.fields.filter(f => f.includes('.') && !numericAndCalculatedFields.includes(f)).map(f => (
+                          <MultiSelectOption key={f} value={f}>
+                            {f}
+                          </MultiSelectOption>
+                        ))}
+                      </MultiSelect>
+                    </div>
                   </div>
-                  <div>
-                    <MultiSelect
-                      value={calc.fields}
-                      onChange={fields => this.updateCalculatedValue(index, 'fields', fields)}
-                      placeHolder="Select field(s)"
-                      formatSelection={selection => selection.length === 1 ? selection[0] : `${selection.length} fields`}
-                    >
-                      {numericAndCalculatedFields.map(col => (
-                        <MultiSelectOption key={col} value={col}>
-                          {col}
-                        </MultiSelectOption>
-                      ))}
-                    </MultiSelect>
-                  </div>
-                </div>
+                </>
               )}
               {(chartType === 'bar' || chartType === 'line') && (
                 <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid #e3e3e3' }}>
@@ -990,31 +1072,54 @@ export default class GraphDialog extends React.Component {
         <Field label={<Label text="X-Axis" />} input={
           <Dropdown
             value={this.state.xColumn}
-            onChange={xColumn => this.setState({ xColumn })}
+            onChange={xColumn => {
+              if (this.isObjectColumn(xColumn)) {
+                this.setState({ objectPathInput: { type: 'xColumn', field: xColumn } });
+                return;
+              }
+              this.setState({ xColumn });
+            }}
             placeHolder="Select field"
           >
             {(chartType === 'scatter' ? numericColumns : allColumns).map(col => (
               <Option key={col} value={col}>
-                {col}
+                {this.isObjectColumn(col) ? `${col} [object]` : col}
               </Option>
             ))}
+            {this.state.xColumn && this.state.xColumn.includes('.') && !(chartType === 'scatter' ? numericColumns : allColumns).includes(this.state.xColumn) && (
+              <Option key={this.state.xColumn} value={this.state.xColumn}>
+                {this.state.xColumn}
+              </Option>
+            )}
           </Dropdown>
         } />
-
         {chartType === 'scatter' && (
-          <Field label={<Label text="Y-Axis" />} input={
-            <Dropdown
-              value={this.state.yColumn}
-              onChange={yColumn => this.setState({ yColumn })}
-              placeHolder="Select field"
-            >
-              {numericColumns.map(col => (
-                <Option key={col} value={col}>
-                  {col}
-                </Option>
-              ))}
-            </Dropdown>
-          } />
+          <>
+            <Field label={<Label text="Y-Axis" />} input={
+              <Dropdown
+                value={this.state.yColumn}
+                onChange={yColumn => {
+                  if (this.isObjectColumn(yColumn)) {
+                    this.setState({ objectPathInput: { type: 'yColumn', field: yColumn } });
+                    return;
+                  }
+                  this.setState({ yColumn });
+                }}
+                placeHolder="Select field"
+              >
+                {numericColumns.map(col => (
+                  <Option key={col} value={col}>
+                    {this.isObjectColumn(col) ? `${col} [object]` : col}
+                  </Option>
+                ))}
+                {this.state.yColumn && this.state.yColumn.includes('.') && !numericColumns.includes(this.state.yColumn) && (
+                  <Option key={this.state.yColumn} value={this.state.yColumn}>
+                    {this.state.yColumn}
+                  </Option>
+                )}
+              </Dropdown>
+            } />
+          </>
         )}
 
         {(chartType === 'bar' || chartType === 'line' || chartType === 'pie' || chartType === 'doughnut' || chartType === 'radar') && (
@@ -1034,20 +1139,34 @@ export default class GraphDialog extends React.Component {
         )}
 
         {stringAndPointerColumns.length > 0 && (
-          <Field label={<Label text="Group By" description="Optional"/>} input={
-            <MultiSelect
-              value={this.state.groupByColumn}
-              onChange={groupByColumn => this.setState({ groupByColumn })}
-              placeHolder="Select field(s)"
-              formatSelection={selection => selection.length === 1 ? selection[0] : `${selection.length} fields`}
-            >
-              {stringAndPointerColumns.map(col => (
-                <MultiSelectOption key={col} value={col}>
-                  {col}
-                </MultiSelectOption>
-              ))}
-            </MultiSelect>
-          } />
+          <>
+            <Field label={<Label text="Group By" description="Optional"/>} input={
+              <MultiSelect
+                value={this.state.groupByColumn}
+                onChange={groupByColumn => {
+                  const added = groupByColumn.find(f => !this.state.groupByColumn.includes(f));
+                  if (added && this.isObjectColumn(added)) {
+                    this.setState({ objectPathInput: { type: 'groupBy', field: added } });
+                    return;
+                  }
+                  this.setState({ groupByColumn });
+                }}
+                placeHolder="Select field(s)"
+                formatSelection={selection => selection.length === 1 ? selection[0] : `${selection.length} fields`}
+              >
+                {stringAndPointerColumns.map(col => (
+                  <MultiSelectOption key={col} value={col}>
+                    {this.isObjectColumn(col) ? `${col} [object]` : col}
+                  </MultiSelectOption>
+                ))}
+                {this.state.groupByColumn.filter(f => f.includes('.') && !stringAndPointerColumns.includes(f)).map(f => (
+                  <MultiSelectOption key={f} value={f}>
+                    {f}
+                  </MultiSelectOption>
+                ))}
+              </MultiSelect>
+            } />
+          </>
         )}
       </>
     );
@@ -1207,26 +1326,51 @@ export default class GraphDialog extends React.Component {
     );
 
     return (
-      <Modal
-        type={Modal.Types.INFO}
-        icon="analytics-outline"
-        iconSize={40}
-        title={isEditing ? 'Edit Graph' : 'Create Graph'}
-        subtitle={isEditing ? 'Modify your data visualization settings' : 'Configure your data visualization'}
-        customFooter={customFooter}
-      >
-        <div style={{
-          maxHeight: 'calc(100vh - 260px)',
-          overflowY: 'auto',
-          overflowX: 'hidden',
-          border: 'none'
-        }}>
-          {this.renderTitleSection()}
-          {this.renderChartTypeSection()}
-          {this.renderColumnSelectionSection()}
-          {this.renderOptionsSection()}
-        </div>
-      </Modal>
+      <>
+        <Modal
+          type={Modal.Types.INFO}
+          icon="analytics-outline"
+          iconSize={40}
+          title={isEditing ? 'Edit Graph' : 'Create Graph'}
+          subtitle={isEditing ? 'Modify your data visualization settings' : 'Configure your data visualization'}
+          customFooter={customFooter}
+        >
+          <div style={{
+            maxHeight: 'calc(100vh - 260px)',
+            overflowY: 'auto',
+            overflowX: 'hidden',
+            border: 'none'
+          }}>
+            {this.renderTitleSection()}
+            {this.renderChartTypeSection()}
+            {this.renderColumnSelectionSection()}
+            {this.renderOptionsSection()}
+          </div>
+        </Modal>
+        {this.state.objectPathInput && (
+          <Modal
+            type={Modal.Types.INFO}
+            title="Enter Object Path"
+            subtitle={`Specify the nested key path for "${this.state.objectPathInput.field}"`}
+            confirmText="Add"
+            cancelText="Cancel"
+            onConfirm={this.confirmObjectPath}
+            onCancel={() => this.setState({ objectPathInput: null })}
+            disabled={!this.state.objectPathInput.path || !this.state.objectPathInput.path.trim()}
+          >
+            <Field label={<Label text="Path" />} input={
+              <div style={{ display: 'flex', alignItems: 'center' }}>
+                <span style={{ paddingLeft: '10px', color: '#666', whiteSpace: 'nowrap' }}>{this.state.objectPathInput.field}.</span>
+                <TextInput
+                  value={this.state.objectPathInput.path || ''}
+                  onChange={path => this.setState({ objectPathInput: { ...this.state.objectPathInput, path } })}
+                  placeholder="e.g. views.count"
+                />
+              </div>
+            } />
+          </Modal>
+        )}
+      </>
     );
   }
 }

--- a/src/dashboard/Data/Browser/GraphDialog.react.js
+++ b/src/dashboard/Data/Browser/GraphDialog.react.js
@@ -18,6 +18,7 @@ import Option from 'components/Dropdown/Option.react';
 import Toggle from 'components/Toggle/Toggle.react';
 import TextInput from 'components/TextInput/TextInput.react';
 import styles from 'components/Modal/Modal.scss';
+import stringCompare from 'lib/stringCompare';
 import { validateFormula } from 'lib/FormulaEvaluator';
 
 const CHART_TYPES = [
@@ -241,7 +242,7 @@ export default class GraphDialog extends React.Component {
     return Object.entries(this.props.columns)
       .filter(([key, col]) => key !== 'objectId' && (!types || types.includes(col.type)))
       .map(([key]) => key)
-      .sort((a, b) => a.localeCompare(b));
+      .sort(stringCompare);
   }
 
   getAllColumns() {
@@ -268,36 +269,25 @@ export default class GraphDialog extends React.Component {
     return this.props.columns && this.props.columns[col] && this.props.columns[col].type === 'Object';
   }
 
-  confirmObjectPath = () => {
-    const { type, field, path, index, calcIndex, position } = this.state.objectPathInput;
-    const fullPath = `${field}.${path}`;
-    switch (type) {
-      case 'series':
-        this.updateSeries(index, 'fields', [...(this.state.series[index].fields || []), fullPath].sort((a, b) => a.localeCompare(b)));
-        break;
-      case 'xColumn':
-        this.setState({ xColumn: fullPath });
-        break;
-      case 'yColumn':
-        this.setState({ yColumn: fullPath });
-        break;
-      case 'groupBy':
-        this.setState({ groupByColumn: [...this.state.groupByColumn, fullPath].sort((a, b) => a.localeCompare(b)) });
-        break;
-      case 'calcPercent': {
-        const calc = this.state.calculatedValues[calcIndex];
-        const newFields = position === 0
-          ? [fullPath, calc.fields && calc.fields[1] ? calc.fields[1] : '']
-          : [calc.fields && calc.fields[0] ? calc.fields[0] : '', fullPath];
-        this.updateCalculatedValue(calcIndex, 'fields', newFields);
-        break;
-      }
-      case 'calcFields': {
-        const calcFieldsCalc = this.state.calculatedValues[calcIndex];
-        this.updateCalculatedValue(calcIndex, 'fields', [...calcFieldsCalc.fields, fullPath].sort((a, b) => a.localeCompare(b)));
-        break;
-      }
+  isObjectDotPath(fieldValue) {
+    if (!fieldValue || !this.props.columns) {
+      return false;
     }
+    const dotIndex = fieldValue.indexOf('.');
+    if (dotIndex <= 0) {
+      return false;
+    }
+    const topLevel = fieldValue.substring(0, dotIndex);
+    return this.props.columns[topLevel] && this.props.columns[topLevel].type === 'Object';
+  }
+
+  getObjectDotPathOptions(selectedFields, columnList) {
+    return (selectedFields || []).filter(f => this.isObjectDotPath(f) && !columnList.includes(f));
+  }
+
+  confirmObjectPath = () => {
+    const { field, path, onConfirm } = this.state.objectPathInput;
+    onConfirm(`${field}.${path}`);
     this.setState({ objectPathInput: null });
   };
 
@@ -537,7 +527,7 @@ export default class GraphDialog extends React.Component {
                     onChange={fields => {
                       const added = fields.find(f => !(s.fields || []).includes(f));
                       if (added && this.isObjectColumn(added)) {
-                        this.setState({ objectPathInput: { type: 'series', index, field: added } });
+                        this.setState({ objectPathInput: { field: added, onConfirm: fullPath => this.updateSeries(index, 'fields', [...(s.fields || []), fullPath].sort(stringCompare)) } });
                         return;
                       }
                       this.updateSeries(index, 'fields', fields);
@@ -550,7 +540,7 @@ export default class GraphDialog extends React.Component {
                         {this.isObjectColumn(col) ? `${col} [object]` : col}
                       </MultiSelectOption>
                     ))}
-                    {(s.fields || []).filter(f => f.includes('.') && !numericAndPointerColumns.includes(f)).map(f => (
+                    {this.getObjectDotPathOptions(s.fields, numericAndPointerColumns).map(f => (
                       <MultiSelectOption key={f} value={f}>
                         {f}
                       </MultiSelectOption>
@@ -813,7 +803,7 @@ export default class GraphDialog extends React.Component {
                         value={calc.fields && calc.fields[0] ? calc.fields[0] : ''}
                         onChange={numerator => {
                           if (this.isObjectColumn(numerator)) {
-                            this.setState({ objectPathInput: { type: 'calcPercent', calcIndex: index, position: 0, field: numerator } });
+                            this.setState({ objectPathInput: { field: numerator, onConfirm: fullPath => this.updateCalculatedValue(index, 'fields', [fullPath, calc.fields && calc.fields[1] ? calc.fields[1] : '']) } });
                             return;
                           }
                           const newFields = [numerator, calc.fields && calc.fields[1] ? calc.fields[1] : ''];
@@ -826,7 +816,7 @@ export default class GraphDialog extends React.Component {
                             {this.isObjectColumn(col) ? `${col} [object]` : col}
                           </Option>
                         ))}
-                        {calc.fields && calc.fields[0] && calc.fields[0].includes('.') && !numericAndCalculatedFields.includes(calc.fields[0]) && (
+                        {calc.fields && calc.fields[0] && this.isObjectDotPath(calc.fields[0]) && !numericAndCalculatedFields.includes(calc.fields[0]) && (
                           <Option key={calc.fields[0]} value={calc.fields[0]}>
                             {calc.fields[0]}
                           </Option>
@@ -843,7 +833,7 @@ export default class GraphDialog extends React.Component {
                         value={calc.fields && calc.fields[1] ? calc.fields[1] : ''}
                         onChange={denominator => {
                           if (this.isObjectColumn(denominator)) {
-                            this.setState({ objectPathInput: { type: 'calcPercent', calcIndex: index, position: 1, field: denominator } });
+                            this.setState({ objectPathInput: { field: denominator, onConfirm: fullPath => this.updateCalculatedValue(index, 'fields', [calc.fields && calc.fields[0] ? calc.fields[0] : '', fullPath]) } });
                             return;
                           }
                           const newFields = [calc.fields && calc.fields[0] ? calc.fields[0] : '', denominator];
@@ -856,7 +846,7 @@ export default class GraphDialog extends React.Component {
                             {this.isObjectColumn(col) ? `${col} [object]` : col}
                           </Option>
                         ))}
-                        {calc.fields && calc.fields[1] && calc.fields[1].includes('.') && !numericAndCalculatedFields.includes(calc.fields[1]) && (
+                        {calc.fields && calc.fields[1] && this.isObjectDotPath(calc.fields[1]) && !numericAndCalculatedFields.includes(calc.fields[1]) && (
                           <Option key={calc.fields[1]} value={calc.fields[1]}>
                             {calc.fields[1]}
                           </Option>
@@ -866,39 +856,37 @@ export default class GraphDialog extends React.Component {
                   </div>
                 </>
               ) : (
-                <>
-                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid #e3e3e3' }}>
-                    <div style={{ display: 'flex', alignItems: 'center' }}>
-                      <Label text="Fields" />
-                    </div>
-                    <div>
-                      <MultiSelect
-                        value={calc.fields}
-                        onChange={fields => {
-                          const added = fields.find(f => !calc.fields.includes(f));
-                          if (added && this.isObjectColumn(added)) {
-                            this.setState({ objectPathInput: { type: 'calcFields', calcIndex: index, field: added } });
-                            return;
-                          }
-                          this.updateCalculatedValue(index, 'fields', fields);
-                        }}
-                        placeHolder="Select field(s)"
-                        formatSelection={selection => selection.length === 1 ? selection[0] : `${selection.length} fields`}
-                      >
-                        {numericAndCalculatedFields.map(col => (
-                          <MultiSelectOption key={col} value={col}>
-                            {this.isObjectColumn(col) ? `${col} [object]` : col}
-                          </MultiSelectOption>
-                        ))}
-                        {calc.fields.filter(f => f.includes('.') && !numericAndCalculatedFields.includes(f)).map(f => (
-                          <MultiSelectOption key={f} value={f}>
-                            {f}
-                          </MultiSelectOption>
-                        ))}
-                      </MultiSelect>
-                    </div>
+                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid #e3e3e3' }}>
+                  <div style={{ display: 'flex', alignItems: 'center' }}>
+                    <Label text="Fields" />
                   </div>
-                </>
+                  <div>
+                    <MultiSelect
+                      value={calc.fields}
+                      onChange={fields => {
+                        const added = fields.find(f => !calc.fields.includes(f));
+                        if (added && this.isObjectColumn(added)) {
+                          this.setState({ objectPathInput: { field: added, onConfirm: fullPath => this.updateCalculatedValue(index, 'fields', [...calc.fields, fullPath].sort(stringCompare)) } });
+                          return;
+                        }
+                        this.updateCalculatedValue(index, 'fields', fields);
+                      }}
+                      placeHolder="Select field(s)"
+                      formatSelection={selection => selection.length === 1 ? selection[0] : `${selection.length} fields`}
+                    >
+                      {numericAndCalculatedFields.map(col => (
+                        <MultiSelectOption key={col} value={col}>
+                          {this.isObjectColumn(col) ? `${col} [object]` : col}
+                        </MultiSelectOption>
+                      ))}
+                      {this.getObjectDotPathOptions(calc.fields, numericAndCalculatedFields).map(f => (
+                        <MultiSelectOption key={f} value={f}>
+                          {f}
+                        </MultiSelectOption>
+                      ))}
+                    </MultiSelect>
+                  </div>
+                </div>
               )}
               {(chartType === 'bar' || chartType === 'line') && (
                 <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', borderTop: '1px solid #e3e3e3' }}>
@@ -1074,7 +1062,7 @@ export default class GraphDialog extends React.Component {
             value={this.state.xColumn}
             onChange={xColumn => {
               if (this.isObjectColumn(xColumn)) {
-                this.setState({ objectPathInput: { type: 'xColumn', field: xColumn } });
+                this.setState({ objectPathInput: { field: xColumn, onConfirm: fullPath => this.setState({ xColumn: fullPath }) } });
                 return;
               }
               this.setState({ xColumn });
@@ -1086,7 +1074,7 @@ export default class GraphDialog extends React.Component {
                 {this.isObjectColumn(col) ? `${col} [object]` : col}
               </Option>
             ))}
-            {this.state.xColumn && this.state.xColumn.includes('.') && !(chartType === 'scatter' ? numericColumns : allColumns).includes(this.state.xColumn) && (
+            {this.state.xColumn && this.isObjectDotPath(this.state.xColumn) && !(chartType === 'scatter' ? numericColumns : allColumns).includes(this.state.xColumn) && (
               <Option key={this.state.xColumn} value={this.state.xColumn}>
                 {this.state.xColumn}
               </Option>
@@ -1094,32 +1082,30 @@ export default class GraphDialog extends React.Component {
           </Dropdown>
         } />
         {chartType === 'scatter' && (
-          <>
-            <Field label={<Label text="Y-Axis" />} input={
-              <Dropdown
-                value={this.state.yColumn}
-                onChange={yColumn => {
-                  if (this.isObjectColumn(yColumn)) {
-                    this.setState({ objectPathInput: { type: 'yColumn', field: yColumn } });
-                    return;
-                  }
-                  this.setState({ yColumn });
-                }}
-                placeHolder="Select field"
-              >
-                {numericColumns.map(col => (
-                  <Option key={col} value={col}>
-                    {this.isObjectColumn(col) ? `${col} [object]` : col}
-                  </Option>
-                ))}
-                {this.state.yColumn && this.state.yColumn.includes('.') && !numericColumns.includes(this.state.yColumn) && (
-                  <Option key={this.state.yColumn} value={this.state.yColumn}>
-                    {this.state.yColumn}
-                  </Option>
-                )}
-              </Dropdown>
-            } />
-          </>
+          <Field label={<Label text="Y-Axis" />} input={
+            <Dropdown
+              value={this.state.yColumn}
+              onChange={yColumn => {
+                if (this.isObjectColumn(yColumn)) {
+                  this.setState({ objectPathInput: { field: yColumn, onConfirm: fullPath => this.setState({ yColumn: fullPath }) } });
+                  return;
+                }
+                this.setState({ yColumn });
+              }}
+              placeHolder="Select field"
+            >
+              {numericColumns.map(col => (
+                <Option key={col} value={col}>
+                  {this.isObjectColumn(col) ? `${col} [object]` : col}
+                </Option>
+              ))}
+              {this.state.yColumn && this.isObjectDotPath(this.state.yColumn) && !numericColumns.includes(this.state.yColumn) && (
+                <Option key={this.state.yColumn} value={this.state.yColumn}>
+                  {this.state.yColumn}
+                </Option>
+              )}
+            </Dropdown>
+          } />
         )}
 
         {(chartType === 'bar' || chartType === 'line' || chartType === 'pie' || chartType === 'doughnut' || chartType === 'radar') && (
@@ -1139,34 +1125,32 @@ export default class GraphDialog extends React.Component {
         )}
 
         {stringAndPointerColumns.length > 0 && (
-          <>
-            <Field label={<Label text="Group By" description="Optional"/>} input={
-              <MultiSelect
-                value={this.state.groupByColumn}
-                onChange={groupByColumn => {
-                  const added = groupByColumn.find(f => !this.state.groupByColumn.includes(f));
-                  if (added && this.isObjectColumn(added)) {
-                    this.setState({ objectPathInput: { type: 'groupBy', field: added } });
-                    return;
-                  }
-                  this.setState({ groupByColumn });
-                }}
-                placeHolder="Select field(s)"
-                formatSelection={selection => selection.length === 1 ? selection[0] : `${selection.length} fields`}
-              >
-                {stringAndPointerColumns.map(col => (
-                  <MultiSelectOption key={col} value={col}>
-                    {this.isObjectColumn(col) ? `${col} [object]` : col}
-                  </MultiSelectOption>
-                ))}
-                {this.state.groupByColumn.filter(f => f.includes('.') && !stringAndPointerColumns.includes(f)).map(f => (
-                  <MultiSelectOption key={f} value={f}>
-                    {f}
-                  </MultiSelectOption>
-                ))}
-              </MultiSelect>
-            } />
-          </>
+          <Field label={<Label text="Group By" description="Optional"/>} input={
+            <MultiSelect
+              value={this.state.groupByColumn}
+              onChange={groupByColumn => {
+                const added = groupByColumn.find(f => !this.state.groupByColumn.includes(f));
+                if (added && this.isObjectColumn(added)) {
+                  this.setState({ objectPathInput: { field: added, onConfirm: fullPath => this.setState({ groupByColumn: [...this.state.groupByColumn, fullPath].sort(stringCompare) }) } });
+                  return;
+                }
+                this.setState({ groupByColumn });
+              }}
+              placeHolder="Select field(s)"
+              formatSelection={selection => selection.length === 1 ? selection[0] : `${selection.length} fields`}
+            >
+              {stringAndPointerColumns.map(col => (
+                <MultiSelectOption key={col} value={col}>
+                  {this.isObjectColumn(col) ? `${col} [object]` : col}
+                </MultiSelectOption>
+              ))}
+              {this.getObjectDotPathOptions(this.state.groupByColumn, stringAndPointerColumns).map(f => (
+                <MultiSelectOption key={f} value={f}>
+                  {f}
+                </MultiSelectOption>
+              ))}
+            </MultiSelect>
+          } />
         )}
       </>
     );

--- a/src/lib/GraphDataUtils.js
+++ b/src/lib/GraphDataUtils.js
@@ -1170,6 +1170,28 @@ export function generateColors(count) {
 }
 
 /**
+ * Check if a field reference is a valid column.
+ * Supports Object dot-path references like "metadata.views.count" —
+ * splits on the first dot, checks that the top-level field exists and is of type Object.
+ */
+function isValidColumn(col, columns) {
+  if (!col || !columns) {
+    return false;
+  }
+  // Direct column match
+  if (columns[col]) {
+    return true;
+  }
+  // Object dot-path: split on first dot, check top-level is Object type
+  const dotIndex = col.indexOf('.');
+  if (dotIndex > 0) {
+    const topLevel = col.substring(0, dotIndex);
+    return columns[topLevel] && columns[topLevel].type === 'Object';
+  }
+  return false;
+}
+
+/**
  * Validate graph configuration
  * @param {Object} config - Graph configuration object
  * @param {Object} columns - Available columns with types
@@ -1200,7 +1222,7 @@ export function validateGraphConfig(config, columns) {
       if (!xColumn || !yColumn) {
         return { isValid: false, error: 'Scatter plots require both X and Y axis columns' };
       }
-      if (!columns || !columns[xColumn] || !columns[yColumn]) {
+      if (!columns || !isValidColumn(xColumn, columns) || !isValidColumn(yColumn, columns)) {
         return { isValid: false, error: 'Selected columns do not exist' };
       }
       break;
@@ -1215,7 +1237,7 @@ export function validateGraphConfig(config, columns) {
         for (const s of series) {
           const fields = s.fields || [];
           for (const col of fields) {
-            if (!columns[col]) {
+            if (!isValidColumn(col, columns)) {
               return { isValid: false, error: `Field '${col}' does not exist` };
             }
           }
@@ -1230,7 +1252,7 @@ export function validateGraphConfig(config, columns) {
       if (!xColumn || !hasValuesToDisplay) {
         return { isValid: false, error: 'Bar/line charts require both X axis and at least one series or calculated value' };
       }
-      if (!columns || !columns[xColumn]) {
+      if (!columns || !isValidColumn(xColumn, columns)) {
         return { isValid: false, error: 'X column does not exist' };
       }
       // Validate all series fields exist
@@ -1238,7 +1260,7 @@ export function validateGraphConfig(config, columns) {
         for (const s of series) {
           const fields = s.fields || [];
           for (const col of fields) {
-            if (!columns[col]) {
+            if (!isValidColumn(col, columns)) {
               return { isValid: false, error: `Field '${col}' does not exist` };
             }
           }

--- a/src/lib/tests/GraphDataUtils.test.js
+++ b/src/lib/tests/GraphDataUtils.test.js
@@ -111,6 +111,72 @@ describe('GraphDataUtils', () => {
       expect(validateGraphConfig(config, null).isValid).toBe(false);
       expect(validateGraphConfig(config, undefined).isValid).toBe(false);
     });
+
+    it('should validate bar chart with Object dot-path field in series', () => {
+      const config = {
+        chartType: 'bar',
+        xColumn: 'category',
+        series: [{ fields: ['metadata.views.count'], aggregationType: 'sum' }],
+      };
+      const columns = {
+        category: { type: 'String' },
+        metadata: { type: 'Object' },
+      };
+
+      expect(validateGraphConfig(config, columns).isValid).toBe(true);
+    });
+
+    it('should reject Object dot-path field when top-level column does not exist', () => {
+      const config = {
+        chartType: 'bar',
+        xColumn: 'category',
+        series: [{ fields: ['nonexistent.views.count'], aggregationType: 'sum' }],
+      };
+      const columns = {
+        category: { type: 'String' },
+      };
+
+      expect(validateGraphConfig(config, columns).isValid).toBe(false);
+    });
+
+    it('should reject dot-path field when top-level column is not an Object type', () => {
+      const config = {
+        chartType: 'bar',
+        xColumn: 'category',
+        series: [{ fields: ['score.nested'], aggregationType: 'sum' }],
+      };
+      const columns = {
+        category: { type: 'String' },
+        score: { type: 'Number' },
+      };
+
+      expect(validateGraphConfig(config, columns).isValid).toBe(false);
+    });
+
+    it('should validate scatter plot with Object dot-path columns', () => {
+      const config = {
+        chartType: 'scatter',
+        xColumn: 'stats.x',
+        yColumn: 'stats.y',
+      };
+      const columns = {
+        stats: { type: 'Object' },
+      };
+
+      expect(validateGraphConfig(config, columns).isValid).toBe(true);
+    });
+
+    it('should validate pie chart with Object dot-path field in series', () => {
+      const config = {
+        chartType: 'pie',
+        series: [{ fields: ['data.value'], aggregationType: 'sum' }],
+      };
+      const columns = {
+        data: { type: 'Object' },
+      };
+
+      expect(validateGraphConfig(config, columns).isValid).toBe(true);
+    });
   });
 
   describe('processScatterData', () => {
@@ -530,6 +596,111 @@ describe('GraphDataUtils', () => {
         // Expected: (sum_a + sum_b) / 2 = (2 + 1) / 2 = 1.5
         expect(avgDataset.data[0]).toBe(1.5);
       });
+    });
+  });
+
+  describe('processBarLineData with Object dot-path fields', () => {
+    const mockData = [
+      { attributes: { month: 'Jan', stats: { revenue: 100 } } },
+      { attributes: { month: 'Jan', stats: { revenue: 200 } } },
+      { attributes: { month: 'Feb', stats: { revenue: 150 } } },
+    ];
+
+    it('should process Object dot-path fields in series', () => {
+      const series = [{ fields: ['stats.revenue'], aggregationType: 'sum' }];
+      const result = processBarLineData(mockData, 'month', series, null);
+
+      expect(result).toHaveProperty('labels');
+      expect(result).toHaveProperty('datasets');
+      expect(result.labels).toContain('Jan');
+      expect(result.labels).toContain('Feb');
+      expect(result.datasets.length).toBe(1);
+      // Labels sorted alphabetically: Feb=150, Jan=300
+      const janIdx = result.labels.indexOf('Jan');
+      const febIdx = result.labels.indexOf('Feb');
+      expect(result.datasets[0].data[janIdx]).toBe(300);
+      expect(result.datasets[0].data[febIdx]).toBe(150);
+    });
+
+    it('should handle missing nested values gracefully', () => {
+      const dataWithMissing = [
+        { attributes: { month: 'Jan', stats: { revenue: 100 } } },
+        { attributes: { month: 'Jan', stats: {} } },
+        { attributes: { month: 'Feb', stats: { revenue: 150 } } },
+      ];
+      const series = [{ fields: ['stats.revenue'], aggregationType: 'sum' }];
+      const result = processBarLineData(dataWithMissing, 'month', series, null);
+
+      expect(result.labels).toContain('Jan');
+      expect(result.labels).toContain('Feb');
+      // Jan: only 100 (second row has no revenue), Feb: 150
+      const janIdx = result.labels.indexOf('Jan');
+      const febIdx = result.labels.indexOf('Feb');
+      expect(result.datasets[0].data[janIdx]).toBe(100);
+      expect(result.datasets[0].data[febIdx]).toBe(150);
+    });
+
+    it('should handle deeply nested Object dot-path fields', () => {
+      const deepData = [
+        { attributes: { month: 'Jan', a: { b: { c: 10 } } } },
+        { attributes: { month: 'Feb', a: { b: { c: 20 } } } },
+      ];
+      const series = [{ fields: ['a.b.c'], aggregationType: 'sum' }];
+      const result = processBarLineData(deepData, 'month', series, null);
+
+      const janIdx = result.labels.indexOf('Jan');
+      const febIdx = result.labels.indexOf('Feb');
+      expect(result.datasets[0].data[janIdx]).toBe(10);
+      expect(result.datasets[0].data[febIdx]).toBe(20);
+    });
+  });
+
+  describe('processScatterData with Object dot-path fields', () => {
+    it('should process Object dot-path fields for scatter axes', () => {
+      const mockData = [
+        { attributes: { stats: { x: 1, y: 2 } } },
+        { attributes: { stats: { x: 3, y: 4 } } },
+      ];
+      const result = processScatterData(mockData, 'stats.x', 'stats.y');
+
+      expect(result).toHaveProperty('datasets');
+      expect(result.datasets[0].data).toEqual([
+        { x: 1, y: 2 },
+        { x: 3, y: 4 },
+      ]);
+    });
+
+    it('should skip rows with missing nested values in scatter', () => {
+      const mockData = [
+        { attributes: { stats: { x: 1, y: 2 } } },
+        { attributes: { stats: { x: 3 } } },
+        { attributes: { stats: { x: 5, y: 6 } } },
+      ];
+      const result = processScatterData(mockData, 'stats.x', 'stats.y');
+
+      expect(result.datasets[0].data).toEqual([
+        { x: 1, y: 2 },
+        { x: 5, y: 6 },
+      ]);
+    });
+  });
+
+  describe('processPieData with Object dot-path fields', () => {
+    it('should process Object dot-path fields in pie series', () => {
+      const mockData = [
+        { attributes: { category: 'A', metrics: { value: 10 } } },
+        { attributes: { category: 'A', metrics: { value: 20 } } },
+        { attributes: { category: 'B', metrics: { value: 30 } } },
+      ];
+      const series = [{ fields: ['metrics.value'], aggregationType: 'sum', title: 'Value' }];
+      const result = processPieData(mockData, series, 'category');
+
+      expect(result).toHaveProperty('labels');
+      expect(result).toHaveProperty('datasets');
+      expect(result.labels).toContain('Value (A)');
+      expect(result.labels).toContain('Value (B)');
+      expect(result.datasets[0].data).toContain(30); // A: 10 + 20
+      expect(result.datasets[0].data).toContain(30); // B: 30
     });
   });
 });


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-dashboard/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-dashboard/blob/alpha/LICENSE).

## Issue

Graphs cannot display values from Object-type fields. For example, if a field `metadata` contains `{ "views": { "count": 1 } }`, there is no way to graph `metadata.views.count`.

## Approach

Object fields appear in all graph dropdowns with an `[object]` suffix. Clicking one opens a modal to enter the nested key path. The composed dot-path (e.g., `metadata.views.count`) becomes a selectable field like any other. No data processing changes needed since `getNestedValue` already handles dot-path traversal.

## Tasks

- [x] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to visualize nested data fields in graph configurations, enabling more detailed analytics from complex data structures.

* **Tests**
  * Added comprehensive test coverage for nested field validation and data processing across chart types.

* **Chores**
  * Updated repository git ignore configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->