### PR TITLE
refactor: Bump mongodb-runner from 6.7.1 to 6.7.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,7 @@
         "jest-environment-jsdom": "30.0.5",
         "madge": "8.0.0",
         "marked": "17.0.5",
-        "mongodb-runner": "^6.6.0",
+        "mongodb-runner": "6.7.3",
         "parse-server": "9.7.0",
         "prettier": "3.8.1",
         "puppeteer": "24.37.2",
@@ -4870,9 +4870,9 @@
       }
     },
     "node_modules/@mongodb-js/oidc-mock-provider": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/oidc-mock-provider/-/oidc-mock-provider-0.13.6.tgz",
-      "integrity": "sha512-2K7KfCwWquonVKvi/MEPWG+Q8vnTGLMcm1I5En0zf9Jqk6CFuoEnojVK7IJtVHdXYp9oR6fnNCMzir5xs965mQ==",
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/oidc-mock-provider/-/oidc-mock-provider-0.13.7.tgz",
+      "integrity": "sha512-OARcW2flFuMtA0TxHsE5oItrpr06w/w0Ihi1Rnqbakyc7/y/yARemBCP4iJX1qLKPLJYwGlEmWrAA4ocs5wrKg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -21740,14 +21740,14 @@
       }
     },
     "node_modules/mongodb-runner": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/mongodb-runner/-/mongodb-runner-6.7.1.tgz",
-      "integrity": "sha512-bYCk1EC0wp4boNyZYJ0Prk6Ye5Mq4ibANzL2RrI2vglSCunjaMfaMIFVJl7isyABwAqJah2RT8va/q8QKa26qQ==",
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/mongodb-runner/-/mongodb-runner-6.7.3.tgz",
+      "integrity": "sha512-wNGwVAuMh9+LF3ajfGTiGL2YV/dssrlf5eUuDuTwNC0xL/gSAZGYUJRGVeOQYy4ISMd8G+xTSPltwcoxy+F0UQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/mongodb-downloader": "^1.1.7",
-        "@mongodb-js/oidc-mock-provider": "^0.13.6",
+        "@mongodb-js/mongodb-downloader": "^1.1.9",
+        "@mongodb-js/oidc-mock-provider": "^0.13.7",
         "@mongodb-js/saslprep": "^1.4.6",
         "@peculiar/x509": "^1.14.2",
         "debug": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "jest-environment-jsdom": "30.0.5",
     "madge": "8.0.0",
     "marked": "17.0.5",
-    "mongodb-runner": "^6.6.0",
+    "mongodb-runner": "6.7.3",
     "parse-server": "9.7.0",
     "prettier": "3.8.1",
     "puppeteer": "24.37.2",


### PR DESCRIPTION
## Changes

- Bump `mongodb-runner` from `6.7.1` to `6.7.3` (devDependency, patch)
- Pin to exact version `6.7.3`

### Changelog

- fix: default condition should be last one (mongodb-js/devtools-shared#629)
- fix(mongodb-server-log-checker): ignore warnings from internal clients (mongodb-js/devtools-shared#627)
- feat(mongodb-server-log-checker): add package (mongodb-js/devtools-shared#624)
- chore(mongodb-downloader): bump tar (mongodb-js/devtools-shared#625)

## Breaking Changes

None.

## Code Changes Required

None.

---

Closes #3323

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies to latest compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->