### PR TITLE
refactor: Bump diff from 8.0.3 to 8.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "copy-to-clipboard": "3.3.3",
         "core-js": "3.48.0",
         "csrf-sync": "4.2.1",
-        "diff": "8.0.3",
+        "diff": "8.0.4",
         "expr-eval-fork": "3.0.3",
         "express": "5.2.1",
         "express-session": "1.19.0",
@@ -14528,9 +14528,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/diff": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
-      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "copy-to-clipboard": "3.3.3",
     "core-js": "3.48.0",
     "csrf-sync": "4.2.1",
-    "diff": "8.0.3",
+    "diff": "8.0.4",
     "expr-eval-fork": "3.0.3",
     "express": "5.2.1",
     "express-session": "1.19.0",


### PR DESCRIPTION
Closes #3322

## Changes
- Bumps [diff](https://github.com/kpdecker/jsdiff) from 8.0.3 to 8.0.4 (patch)
- This is a regular dependency used for text diffing in the dashboard

## Breaking Changes
- None

## Code Changes Required
- None