### PR TITLE
refactor: Bump sass from 1.98.0 to 1.99.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,7 @@
         "prettier": "3.8.1",
         "puppeteer": "24.37.2",
         "react-test-renderer": "16.13.1",
-        "sass": "1.98.0",
+        "sass": "1.99.0",
         "sass-loader": "16.0.7",
         "semantic-release": "25.0.3",
         "semver": "7.7.4",
@@ -27672,9 +27672,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sass": {
-      "version": "1.98.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.98.0.tgz",
-      "integrity": "sha512-+4N/u9dZ4PrgzGgPlKnaaRQx64RO0JBKs9sDhQ2pLgN6JQZ25uPQZKQYaBJU48Kd5BxgXoJ4e09Dq7nMcOUW3A==",
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.99.0.tgz",
+      "integrity": "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "prettier": "3.8.1",
     "puppeteer": "24.37.2",
     "react-test-renderer": "16.13.1",
-    "sass": "1.98.0",
+    "sass": "1.99.0",
     "sass-loader": "16.0.7",
     "semantic-release": "25.0.3",
     "semver": "7.7.4",


### PR DESCRIPTION
Closes #3321

## Changes
- Bumps [sass](https://github.com/sass/dart-sass) from 1.98.0 to 1.99.0 (devDependency)
- Adds support for parent selectors (`&`) at the root of the document
- User-defined functions named `calc` or `clamp` are no longer forbidden
- Various function name restrictions relaxed with deprecation warnings for exotic patterns
- Full release notes: [sass/dart-sass v1.99.0](https://github.com/sass/dart-sass/releases/tag/1.99.0)

## Breaking Changes
- None

## Code Changes Required
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated sass dependency to version 1.99.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->