### PR TITLE
fix: Keep vertical scrollbar visible in data browser with wide tables

### DIFF
--- a/src/dashboard/Data/Browser/Browser.scss
+++ b/src/dashboard/Data/Browser/Browser.scss
@@ -13,7 +13,7 @@
   left: 300px;
   right: 0;
   bottom: 36px;
-  overflow: auto;
+  overflow: hidden;
 }
 
 body:global(.expanded) {
@@ -82,6 +82,7 @@ body:global(.expanded) {
   bottom: 0;
   left: 0;
   width: 100%;
+  overflow: auto;
 }
 
 .table .empty {


### PR DESCRIPTION
Closes #2045

## Approach

Move vertical and horizontal scrolling to the `.table` container instead of `.browser`.

### Problem
`.browser` (position: fixed) handled both overflow axes via `overflow: auto`. The vertical scrollbar was positioned at the right edge of the scrollable content area — when a table had many columns, users had to scroll all the way to the right to access the vertical scrollbar.

### Fix
Delegate scrolling to `.table` (absolutely positioned child inside `.browser`) by adding `overflow: auto` to it. `.browser` now uses `overflow: hidden`, acting only as a positioning container.

Since `.table` has `width: 100%` of `.browser` (which is `position: fixed; left: 300px; right: 0`), `.table`'s right edge = `.browser`'s right edge = viewport edge. The vertical scrollbar is always visible at the viewport edge regardless of table width.

### Changes
Only `Browser.scss` — 2 lines changed.
- `.browser`: `overflow: auto` → `overflow: hidden`
- `.table`: added `overflow: auto`

### Additional benefit
`tableRef.current.scrollTop = 0` in `componentWillReceiveProps` now correctly works — `.table` is now the actual scroll container, whereas before `overflow: visible` on `.table` made the scroll reset effectively a no-op.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved scrolling behavior in the data browser interface. The table region now enables independent scrolling while maintaining the fixed container layout for better usability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/parse-community/parse-dashboard/pull/3357)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->