### PR TITLE
fix: Chart not displayed when formula references an undefined field

### DIFF
--- a/src/lib/FormulaEvaluator.js
+++ b/src/lib/FormulaEvaluator.js
@@ -140,7 +140,19 @@ export function evaluateFormula(formula, variables) {
   try {
     const processedFormula = preprocessFormula(formula);
     const expr = parser.parse(processedFormula);
-    let result = expr.evaluate(variables);
+
+    // Default any variables referenced by the formula but missing from the
+    // provided variables to 0. This keeps charts rendering when a referenced
+    // field has no value on a row (consistent with the "sum" operator, which
+    // already treats missing fields as 0).
+    const safeVariables = { ...(variables || {}) };
+    for (const varName of expr.variables()) {
+      if (!(varName in safeVariables)) {
+        safeVariables[varName] = 0;
+      }
+    }
+
+    let result = expr.evaluate(safeVariables);
 
     // Convert boolean results to numbers (for comparison operators)
     if (typeof result === 'boolean') {

--- a/src/lib/tests/FormulaEvaluator.test.js
+++ b/src/lib/tests/FormulaEvaluator.test.js
@@ -169,8 +169,15 @@ describe('FormulaEvaluator', () => {
         expect(evaluateFormula('invalid syntax !!!', { x: 10 })).toBe(null);
       });
 
-      it('should return null for undefined variables', () => {
-        expect(evaluateFormula('unknownVar * 2', {})).toBe(null);
+      it('should treat undefined variables as 0', () => {
+        // Undefined variables should default to 0 so charts still render
+        // when a referenced field has no value on a row (consistent with the
+        // behavior of the "sum" operator, which already treats missing fields
+        // as 0).
+        expect(evaluateFormula('unknownVar * 2', {})).toBe(0);
+        expect(evaluateFormula('x + unknownVar', { x: 5 })).toBe(5);
+        expect(evaluateFormula('x * y', { x: 10 })).toBe(0);
+        expect(evaluateFormula('a + b + c', { b: 7 })).toBe(7);
       });
 
       it('should return null for NaN results', () => {

--- a/src/lib/tests/GraphDataUtils.test.js
+++ b/src/lib/tests/GraphDataUtils.test.js
@@ -332,6 +332,55 @@ describe('GraphDataUtils', () => {
         // Should not throw, chart should render with regular values
         expect(result).toHaveProperty('datasets');
       });
+
+      it('should render chart when a referenced field is undefined on some rows', () => {
+        // Reproduces the bug where a formula referencing a field that is
+        // undefined on a row caused the entire chart to be empty. Undefined
+        // fields should be treated as 0 instead.
+        const dataWithMissingField = [
+          { attributes: { month: 'Jan', price: 10 } }, // quantity undefined
+          { attributes: { month: 'Feb', price: 20, quantity: 3 } },
+          { attributes: { month: 'Mar', price: 15 } }, // quantity undefined
+        ];
+
+        const calculatedValues = [{
+          name: 'Total',
+          operator: 'formula',
+          formula: 'price * quantity',
+        }];
+
+        const result = processBarLineData(dataWithMissingField, 'month', [], null, calculatedValues);
+
+        expect(result).toHaveProperty('datasets');
+        expect(result.datasets.length).toBe(1);
+        expect(result.datasets[0].label).toBe('Total');
+        // Jan: 10 * 0 = 0, Feb: 20 * 3 = 60, Mar: 15 * 0 = 0
+        expect(result.datasets[0].data).toContain(60);
+      });
+
+      it('should render chart when the referenced field is undefined on every row', () => {
+        // Even more extreme case: the field exists in the schema but no row
+        // has a value for it. The chart should still render (using 0 for the
+        // missing field) rather than disappearing entirely.
+        const dataWithAllMissing = [
+          { attributes: { month: 'Jan', price: 10 } },
+          { attributes: { month: 'Feb', price: 20 } },
+        ];
+
+        const calculatedValues = [{
+          name: 'Total',
+          operator: 'formula',
+          formula: 'price + quantity',
+        }];
+
+        const result = processBarLineData(dataWithAllMissing, 'month', [], null, calculatedValues);
+
+        expect(result).toHaveProperty('datasets');
+        expect(result.datasets.length).toBe(1);
+        // Jan: 10 + 0 = 10, Feb: 20 + 0 = 20
+        expect(result.datasets[0].data).toContain(10);
+        expect(result.datasets[0].data).toContain(20);
+      });
     });
 
     describe('processPieData with formula', () => {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-dashboard/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-dashboard/blob/alpha/LICENSE).

## Issue

In the Data Browser, when creating a chart (e.g. bar chart) and adding a calculated value with the `formula` operator, the chart did not render any data if the formula referenced a field whose value was `undefined` (or missing) on the data rows.

This was inconsistent with the `sum` operator, which already treats a missing/undefined field as `0` and still renders the chart.

## Approach

When `expr-eval-fork` evaluates a formula and encounters an identifier that is not in the variables map, it throws. The error was being caught and `evaluateFormula` returned `null` for every row, leaving the chart with no data.

`evaluateFormula` now fills in any variables referenced by the parsed formula but missing from the variables map with `0` before evaluation. This makes `formula` behave consistently with `sum`: a referenced field that is undefined on a row is treated as `0`, and the chart renders.

Note that this only affects runtime evaluation. Formula validation in the chart configuration dialog still rejects unknown identifiers, so genuine typos are caught at configuration time.

## Tasks

- [x] Add tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Formulas now gracefully handle missing variables by defaulting them to 0 instead of producing errors or invalid results.

* **Tests**
  * Updated formula evaluation tests to verify undefined variable handling.
  * Added chart rendering tests to ensure visualizations display correctly when referenced fields are undefined.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/parse-community/parse-dashboard/pull/3360?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->