### PR TITLE
fix: Return to previous class when navigating back after Related records

### DIFF
--- a/src/components/Toolbar/Toolbar.react.js
+++ b/src/components/Toolbar/Toolbar.react.js
@@ -9,23 +9,11 @@ import PropTypes from 'lib/PropTypes';
 import React from 'react';
 import Icon from 'components/Icon/Icon.react';
 import styles from 'components/Toolbar/Toolbar.scss';
-import { useNavigate, useNavigationType, NavigationType } from 'react-router-dom';
 
 const Toolbar = props => {
-  const action = useNavigationType();
-  const navigate = useNavigate();
-  let backButton;
-  if (props.relation || (props.filters && props.filters.size && action !== NavigationType.Pop)) {
-    backButton = (
-      <a className={styles.iconButton} onClick={() => navigate(-1)}>
-        <Icon width={32} height={32} fill="#ffffff" name="left-outline" />
-      </a>
-    );
-  }
   return (
     <div className={styles.toolbar}>
       <div className={styles.title}>
-        <div className={styles.nav}>{backButton}</div>
         <div className={styles.titleText}>
           <div className={styles.section}>{props.section}</div>
           <div>
@@ -82,7 +70,6 @@ Toolbar.propTypes = {
   section: PropTypes.string,
   subsection: PropTypes.string,
   details: PropTypes.string,
-  relation: PropTypes.object,
 };
 
 export default Toolbar;

--- a/src/components/Toolbar/Toolbar.scss
+++ b/src/components/Toolbar/Toolbar.scss
@@ -30,10 +30,6 @@ body:global(.expanded) {
     height: 80px;
     right: 135px;
 
-    .nav {
-      display: none;
-    }
-
     .titleText {
       display: none;
     }
@@ -44,17 +40,6 @@ body:global(.expanded) {
   position: absolute;
   left: 14px;
   bottom: 10px;
-}
-
-.nav {
-  display: inline-block;
-}
-
-.iconButton {
-  display: block;
-  padding-top: 10px;
-  padding-right: 10px;
-  cursor: pointer;
 }
 
 .titleText {

--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -752,8 +752,7 @@ class Browser extends DashboardView {
     const queryString = queryParams.toString();
     const url = queryString ? `browser/${source}?${queryString}` : `browser/${source}`;
 
-    // Push new history entry instead of replacing to enable browser back button
-    this.props.navigate(generatePath(this.context, url));
+    this.props.navigate(generatePath(this.context, url), { replace: true });
   }
 
   redirectToFirstClass(classList, context) {

--- a/src/dashboard/Data/Browser/BrowserToolbar.react.js
+++ b/src/dashboard/Data/Browser/BrowserToolbar.react.js
@@ -296,8 +296,6 @@ const BrowserToolbar = ({
   return (
     <Toolbar
       className={className}
-      relation={relation}
-      filters={filters}
       section={relation ? `Relation <${relation.targetClassName}>` : 'Class'}
       subsection={subsection}
       details={details.join(' \u2022 ')}


### PR DESCRIPTION
Closes #3349

After navigating A→B via *Related records* and pressing **Back**:

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/edbce0ab-92dd-4b59-99af-7b28ae8980c8) | ![after](https://github.com/user-attachments/assets/da418d7e-25de-4aa7-8775-93a410df8c6a) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the toolbar experience to show a simpler header without the back-link behavior.
  * Browser navigation now updates the current view more cleanly instead of creating extra history entries.
  * Minor toolbar styling adjustments were made to keep the layout consistent with the updated header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->