### PR TITLE
fix: Crash when filtering unique on a pointer field

### DIFF
--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -71,7 +71,7 @@ export default class BrowserCell extends Component {
       );
       let value = this.props.value;
       let dataValue = this.props.value.id || this.props.value.objectId;
-      if (defaultPointerKey !== 'objectId') {
+      if (defaultPointerKey !== 'objectId' && typeof this.props.value.get === 'function') {
         dataValue = this.props.value.get(defaultPointerKey);
         if (dataValue && typeof dataValue === 'object') {
           if (dataValue instanceof Date) {

--- a/src/components/BrowserRow/BrowserRow.react.js
+++ b/src/components/BrowserRow/BrowserRow.react.js
@@ -67,13 +67,15 @@ export default class BrowserRow extends Component {
       return acc;
     }, requiredCols);
     // for dynamically changing required field on _User class
-    if (
-      obj.className === '_User' &&
-      (obj.get('username') !== undefined || obj.get('password') !== undefined)
-    ) {
-      requiredCols = ['username', 'password'];
-    } else if (obj.className === '_User' && obj.get('authData') !== undefined) {
-      requiredCols = ['authData'];
+    if (!isUnique) {
+      if (
+        obj.className === '_User' &&
+        (obj.get('username') !== undefined || obj.get('password') !== undefined)
+      ) {
+        requiredCols = ['username', 'password'];
+      } else if (obj.className === '_User' && obj.get('authData') !== undefined) {
+        requiredCols = ['authData'];
+      }
     }
     const highlightColor = '#eef4fb';
     const stickyHighlightColor = '#d6e4f0';

--- a/src/lib/tests/BrowserRow.test.js
+++ b/src/lib/tests/BrowserRow.test.js
@@ -104,4 +104,29 @@ describe('BrowserRow', () => {
       expect(checkboxCell.props.style.background).toBe('#ffffff');
     });
   });
+
+  describe('Unique filter', () => {
+    beforeAll(() => {
+      global.localStorage = {
+        getItem: () => null,
+        setItem: () => {},
+        removeItem: () => {},
+      };
+    });
+
+    it('does not crash rendering a unique _User pointer value', () => {
+      const rawUserPointer = { __type: 'Pointer', className: '_User', objectId: 'user1' };
+      expect(() =>
+        renderer.create(
+          <BrowserRow
+            {...defaultProps}
+            isUnique={true}
+            obj={rawUserPointer}
+            columns={{ owner: { type: 'Pointer', targetClass: '_User' } }}
+            order={[{ name: 'owner', width: 150, visible: true }]}
+          />
+        )
+      ).not.toThrow();
+    });
+  });
 });


### PR DESCRIPTION
Closes #2657

![Before and after](https://raw.githubusercontent.com/dblythy/parse-dashboard/12683410cbb2d7fb0297aa41b9933f31419719ad/.github/pr-assets/2657/before-after.png)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of pointer-based values so browser cells no longer rely on missing data access methods.
  * Fixed unique-row rendering for user records so required-field logic is only applied when appropriate.
  * Added coverage to help ensure unique filters render safely for user pointers without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->