### PR TITLE
feat: Show server URL and version in the sidebar footer

### DIFF
--- a/src/components/Sidebar/Sidebar.react.js
+++ b/src/components/Sidebar/Sidebar.react.js
@@ -185,12 +185,44 @@ const Sidebar = ({
     >
       <SidebarHeader isCollapsed={!appsMenuOpen && collapsed} dashboardUser={dashboardUser} />
       {sidebarContent}
-      {dashboardUser && (
+      {((!collapsed && currentApp?.serverURL) || dashboardUser) && (
         <div className={styles.footer}>
-          <a href={`${mountPath}logout`} className={styles.more}>
-            <Icon height={16} width={16} name="logout" />
-            Logout
-          </a>
+          {!collapsed && currentApp?.serverURL && (
+            <div className={styles.serverInfo}>
+              <div className={styles.serverInfoRow} title={currentApp.serverURL}>
+                Server URL: <span className={styles.serverInfoValue}>{currentApp.serverURL}</span>
+              </div>
+              {currentApp.serverInfo?.error ? (
+                <div
+                  className={styles.serverInfoRow}
+                  title={currentApp.serverInfo.error.toString()}
+                >
+                  Server not reachable:{' '}
+                  <span className={styles.serverInfoValue}>
+                    {currentApp.serverInfo.error.toString()}
+                  </span>
+                </div>
+              ) : (
+                <div className={styles.serverInfoRow}>
+                  Server version:{' '}
+                  <span className={styles.serverInfoValue}>
+                    {currentApp.serverInfo?.parseServerVersion || 'unknown'}
+                  </span>
+                </div>
+              )}
+              {!currentApp.serverInfo?.error && currentApp.serverInfo?.versionWarning && (
+                <div className={styles.versionWarning} title={currentApp.serverInfo.versionWarning}>
+                  ⚠️ {currentApp.serverInfo.versionWarning}
+                </div>
+              )}
+            </div>
+          )}
+          {dashboardUser && (
+            <a href={`${mountPath}logout`} className={styles.more}>
+              <Icon height={16} width={16} name="logout" />
+              Logout
+            </a>
+          )}
         </div>
       )}
     </div>

--- a/src/components/Sidebar/Sidebar.scss
+++ b/src/components/Sidebar/Sidebar.scss
@@ -10,7 +10,7 @@
 $headerHeight: 48px;
 $menuSectionHeight: 24px;
 $sidebarMenuItemHeight: 48px;
-$footerHeight: 36px;
+$footerHeight: 84px;
 
 .sidebar {
   position: fixed;
@@ -41,7 +41,7 @@ $footerHeight: 36px;
   overflow-y: auto;
   top: $headerHeight;
   right: 0;
-  bottom: 36px;
+  bottom: $footerHeight;
   left: 0;
 }
 
@@ -58,6 +58,8 @@ $footerHeight: 36px;
   bottom: 0;
   left: 0;
   right: 0;
+  min-height: $footerHeight;
+  box-sizing: border-box;
 
   a {
     color: white;
@@ -76,6 +78,28 @@ $footerHeight: 36px;
       border: none;
     }
   }
+}
+
+.serverInfo {
+  @include DosisFont;
+  text-align: left;
+  padding: 0 14px 8px;
+  font-size: 11px;
+  line-height: 16px;
+  color: #788c97;
+}
+
+.serverInfoRow {
+  @include ellipsis();
+}
+
+.serverInfoValue {
+  color: white;
+}
+
+.versionWarning {
+  @include ellipsis();
+  color: #ff9800;
 }
 
 .header {


### PR DESCRIPTION
Closes #1053

Re-surfaces the Parse server URL and version in the sidebar footer so they stay visible inside an app. They previously appeared only on the app-listing cards, which single-app users rarely see.

### Before / After

| Before (no server info) | After |
| :---: | :---: |
| <img src="https://raw.githubusercontent.com/dblythy/parse-dashboard/3f5db28410c874bcba208e73a07eec9cd87db22f/.github/pr-assets/1053/before.png" width="280"> | <img src="https://raw.githubusercontent.com/dblythy/parse-dashboard/3f5db28410c874bcba208e73a07eec9cd87db22f/.github/pr-assets/1053/after-normal.png" width="280"> |

### Other states

The footer adapts to the server status, and sits above the Logout row when a dashboard user is configured.

| With Logout | Unsupported version | Server unreachable |
| :---: | :---: | :---: |
| <img src="https://raw.githubusercontent.com/dblythy/parse-dashboard/3f5db28410c874bcba208e73a07eec9cd87db22f/.github/pr-assets/1053/after-with-logout.png" width="240"> | <img src="https://raw.githubusercontent.com/dblythy/parse-dashboard/3f5db28410c874bcba208e73a07eec9cd87db22f/.github/pr-assets/1053/version-warning.png" width="240"> | <img src="https://raw.githubusercontent.com/dblythy/parse-dashboard/3f5db28410c874bcba208e73a07eec9cd87db22f/.github/pr-assets/1053/unreachable.png" width="240"> |
