### PR TITLE
fix: Prevent logs page crash on non-string log message

### DIFF
--- a/src/components/LogView/LogViewEntry.react.js
+++ b/src/components/LogView/LogViewEntry.react.js
@@ -22,6 +22,9 @@ const TIMESTAMP_REGEX = [
 
 const isError = str => str[0] === 'E';
 
+const normalizeText = value =>
+  typeof value === 'string' ? value : JSON.stringify(value) || '';
+
 const getLogEntryInfo = str => {
   const re = getTimestampRegex();
   const timeStampStr = str.match(re) ? str.match(re)[0] : '';
@@ -36,7 +39,7 @@ const getLogEntryInfo = str => {
 const getTimestampRegex = () => new RegExp(TIMESTAMP_REGEX, ['i']);
 
 const LogViewEntry = ({ text = '', timestamp }) => {
-  const logEntryInfo = getLogEntryInfo(text);
+  const logEntryInfo = getLogEntryInfo(normalizeText(text));
   const classes = [styles.entry, logEntryInfo.error ? styles.error : ''];
   return (
     <li className={classes.join(' ')}>

--- a/src/lib/tests/LogViewEntry.test.js
+++ b/src/lib/tests/LogViewEntry.test.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2016-present, Parse, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+jest.dontMock('../../components/LogView/LogViewEntry.react');
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+const LogViewEntry = require('../../components/LogView/LogViewEntry.react').default;
+
+describe('LogViewEntry', () => {
+  it('renders a string log message', () => {
+    const text = 'I2015-09-30T00:36:45.522Z] hello world';
+    const tree = renderer
+      .create(<LogViewEntry text={text} timestamp="I2015-09-30T00:36:45.522Z]" />)
+      .toJSON();
+    expect(JSON.stringify(tree)).toContain('hello world');
+  });
+
+  it('does not crash when the message is a non-string object', () => {
+    const message = { ok: 0, code: 40352, codeName: 'Location40352', name: 'MongoError' };
+    let tree;
+    expect(() => {
+      tree = renderer
+        .create(<LogViewEntry text={message} timestamp="2021-08-20T09:59:24.974Z" />)
+        .toJSON();
+    }).not.toThrow();
+    expect(JSON.stringify(tree)).toContain('MongoError');
+  });
+});


### PR DESCRIPTION
Closes #1459

The Logs page crashes with `TypeError: str.match is not a function` (blanking the whole dashboard) when a log entry's `message` is not a string. Parse Server can write a non-string `message` (for example a raw `MongoError` object), and `LogViewEntry` calls string methods (`.match`, `.replace`, indexing) on it directly.

This normalizes a non-string log message to a string before parsing, so the entry renders (as JSON) instead of crashing. Writing `message` as a string is a separate Parse Server concern; this is the graceful-handling half described in the issue.

### Before / After

| Before (dashboard crashes to blank; console: `str.match is not a function`) | After (entries render, object message shown as JSON) |
| :---: | :---: |
| <img src="https://raw.githubusercontent.com/dblythy/parse-dashboard/7f3d0faad0f555c66bd7e4a8e2bfae3c7991cb55/.github/pr-assets/1459/before.png" width="420"> | <img src="https://raw.githubusercontent.com/dblythy/parse-dashboard/7f3d0faad0f555c66bd7e4a8e2bfae3c7991cb55/.github/pr-assets/1459/after.png" width="420"> |

Reproduced by mocking the `scriptlog` response with an object `message`. Covered by a new unit test (`LogViewEntry.test.js`) that renders both a string and an object message.
