### PR TITLE
fix: Don't emit a Delete op when clearing a field on a new row (#1751)

### DIFF
--- a/src/dashboard/Data/Browser/Browser.react.js
+++ b/src/dashboard/Data/Browser/Browser.react.js
@@ -49,6 +49,7 @@ import { ActionTypes as ConfigActionTypes } from 'lib/stores/ConfigStore';
 import { getStore } from 'lib/stores/StoreManager';
 import stringCompare from 'lib/stringCompare';
 import subscribeTo from 'lib/subscribeTo';
+import unsetField from 'lib/unsetField';
 import { withRouter } from 'lib/withRouter';
 import FilterPreferencesManager from 'lib/FilterPreferencesManager';
 import { prefersServerStorage } from 'lib/StoragePreferences';
@@ -1859,14 +1860,14 @@ class Browser extends DashboardView {
       return;
     }
     if (value === undefined) {
-      obj.unset(attr);
+      obj = unsetField(obj, attr, isNewObject || isEditCloneObj);
     } else {
       obj.set(attr, value);
     }
 
     if (isNewObject) {
       this.setState({
-        isNewObject: obj,
+        newObject: obj,
       });
       return;
     }

--- a/src/lib/tests/unsetField.test.js
+++ b/src/lib/tests/unsetField.test.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2016-present, Parse, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+jest.dontMock('../unsetField');
+
+const unsetField = require('../unsetField').default;
+const Parse = require('parse');
+
+describe('unsetField', () => {
+  it('clears a field on an unsaved object without a Delete op', () => {
+    const obj = new Parse.Object('Test');
+    obj.set('username', 'bob');
+    obj.set('authData', {});
+    const json = unsetField(obj, 'username', true)._getSaveJSON();
+    expect(json.username).toBe(undefined);
+    expect(json.authData).toEqual({});
+  });
+
+  it('keeps the Delete op when unsetting a field on a saved object', () => {
+    const obj = Parse.Object.fromJSON({ className: 'Test', objectId: 'abc', username: 'bob' });
+    expect(unsetField(obj, 'username', false)._getSaveJSON().username).toEqual({ __op: 'Delete' });
+  });
+});

--- a/src/lib/unsetField.js
+++ b/src/lib/unsetField.js
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2016-present, Parse, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+export default function unsetField(obj, attr, isUnsaved) {
+  obj.unset(attr);
+  return isUnsaved ? obj.clone() : obj;
+}


### PR DESCRIPTION
Closes #1751

Clearing a field on a not-yet-saved row sent a `{"__op":"Delete"}` for that field on the create request, which is invalid (the object does not exist yet). The fix omits the field instead, by cloning the unsaved object (which drops the pending Delete op while keeping the remaining attributes).

Verification: create request when clearing a field on a **new** row, then saving.

Before:
```json
{ "label": { "__op": "Delete" }, ... }
```
After:
```json
{ ... }   // "label" omitted
```

Notes:
- Clearing a field on an already-**saved** row is unchanged (still sends a real `{"__op":"Delete"}`), verified in QA and locked in by a unit test.
- The same path is used for the duplicate/edit-clone unsaved row, so it gets the fix too.
- On current Parse Server the stray op is tolerated for optional fields, but it still breaks on stricter validation and special fields (e.g. the `_User` case in the report), and is incorrect regardless.
