### PR TITLE
fix: Render Cloud Config Date params as dates after refresh

### DIFF
--- a/src/dashboard/Data/Config/Config.react.js
+++ b/src/dashboard/Data/Config/Config.react.js
@@ -13,6 +13,7 @@ import AddArrayEntryDialog from 'dashboard/Data/Config/AddArrayEntryDialog.react
 import RemoveArrayEntryDialog from 'dashboard/Data/Config/RemoveArrayEntryDialog.react';
 import EmptyState from 'components/EmptyState/EmptyState.react';
 import Icon from 'components/Icon/Icon.react';
+import decodeConfigValue from 'lib/decodeConfigValue';
 import { isDate } from 'lib/DateUtils';
 import Parse from 'parse';
 import React from 'react';
@@ -365,7 +366,7 @@ class Config extends TableView {
 
       // Get latest param values
       const fetchedParams = this.props.config.data.get('params');
-      const fetchedValue = fetchedParams.get(this.state.modalParam);
+      const fetchedValue = decodeConfigValue(fetchedParams.get(this.state.modalParam));
       const fetchedMasterKeyOnly =
         this.props.config.data.get('masterKeyOnly')?.get(this.state.modalParam) || false;
 
@@ -482,15 +483,9 @@ class Config extends TableView {
         data = [];
         params.forEach((value, param) => {
           const masterKeyOnly = masterKeyOnlyParams.get(param) || false;
-          const type = typeof value;
-          if (type === 'object' && value.__type == 'File') {
-            value = Parse.File.fromJSON(value);
-          } else if (type === 'object' && value.__type == 'GeoPoint') {
-            value = new Parse.GeoPoint(value);
-          }
           data.push({
             param: param,
-            value: value,
+            value: decodeConfigValue(value),
             masterKeyOnly: masterKeyOnly,
           });
         });

--- a/src/lib/decodeConfigValue.js
+++ b/src/lib/decodeConfigValue.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2016-present, Parse, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+import Parse from 'parse';
+
+export default function decodeConfigValue(value) {
+  if (value && typeof value === 'object') {
+    if (value.__type === 'File') {
+      return Parse.File.fromJSON(value);
+    }
+    if (value.__type === 'GeoPoint') {
+      return new Parse.GeoPoint(value);
+    }
+    if (value.__type === 'Date') {
+      return new Date(value.iso);
+    }
+  }
+  return value;
+}

--- a/src/lib/tests/decodeConfigValue.test.js
+++ b/src/lib/tests/decodeConfigValue.test.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2016-present, Parse, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+jest.dontMock('../decodeConfigValue');
+
+const decodeConfigValue = require('../decodeConfigValue').default;
+const Parse = require('parse');
+
+describe('decodeConfigValue', () => {
+  it('rehydrates a wire-format Date into a Date instance', () => {
+    const result = decodeConfigValue({ __type: 'Date', iso: '2024-05-05T00:36:00.000Z' });
+    expect(result instanceof Date).toBe(true);
+    expect(result.toISOString()).toBe('2024-05-05T00:36:00.000Z');
+  });
+
+  it('passes a real Date through unchanged', () => {
+    const d = new Date('2024-05-05T00:36:00.000Z');
+    expect(decodeConfigValue(d)).toBe(d);
+  });
+
+  it('rehydrates a File wire object', () => {
+    const result = decodeConfigValue({ __type: 'File', name: 'f.png', url: 'https://x/f.png' });
+    expect(result instanceof Parse.File).toBe(true);
+  });
+
+  it('rehydrates a GeoPoint wire object', () => {
+    const result = decodeConfigValue({ __type: 'GeoPoint', latitude: 1, longitude: 2 });
+    expect(result instanceof Parse.GeoPoint).toBe(true);
+  });
+
+  it('passes primitives through', () => {
+    expect(decodeConfigValue('x')).toBe('x');
+    expect(decodeConfigValue(42)).toBe(42);
+  });
+});


### PR DESCRIPTION
Closes #2566

A Cloud Config parameter of type `Date` renders correctly right after it is created, but after a page refresh it shows the raw wire object `{"__type":"Date","iso":"..."}` instead of a date.

Cause: config values are fetched via `GET /config` and stored without decoding, so a Date arrives as `{__type:'Date', iso}`. `Config#tableData` rehydrated `File` and `GeoPoint` wire objects back into real instances but had no branch for `Date`, so the value failed the `isDate` check and fell through to `JSON.stringify`. It looked correct before a refresh only because the local store keeps the original `Date` until the next fetch.

Fix: a small `lib/decodeConfigValue` helper rehydrates `File`/`GeoPoint`/`Date` wire objects, applied both in `tableData` (table render) and in the edit-modal refetch path (which read the raw value and would otherwise feed a non-Date into the date picker).

### Before
Refresh shows the Date param as an `Object`.

![before](https://raw.githubusercontent.com/dblythy/parse-dashboard/qa-assets-2566/qa/2566/before-config-table.png)

### After
Refresh shows the Date param as a date.

![after](https://raw.githubusercontent.com/dblythy/parse-dashboard/qa-assets-2566/qa/2566/after-config-table.png)

Opening the editor shows a populated date picker (this path is also fixed by decoding the refetched value):

![edit modal](https://raw.githubusercontent.com/dblythy/parse-dashboard/qa-assets-2566/qa/2566/after-edit-modal.png)

Regression: File/GeoPoint/String/Number render and edit unchanged (GeoPoint editor shown):

![geopoint regression](https://raw.githubusercontent.com/dblythy/parse-dashboard/qa-assets-2566/qa/2566/after-geopoint-modal-regression.png)

Covered by a unit test (`src/lib/tests/decodeConfigValue.test.js`). The broader date-input UX ideas from the issue (unified text input, optional calendar picker, ISO placeholder) are left as a follow-up.
