### PR TITLE
feat: Add contains-substring filter for String fields

### DIFF
--- a/src/lib/Filters.js
+++ b/src/lib/Filters.js
@@ -64,6 +64,12 @@ export const Constraints = {
     composable: true,
     comparable: true,
   },
+  contains: {
+    name: 'contains substring',
+    field: 'String',
+    composable: true,
+    comparable: true,
+  },
   before: {
     name: 'is before',
     field: 'Date',
@@ -185,7 +191,18 @@ export const FieldConstraints = {
   Pointer: ['exists', 'dne', 'eq', 'neq', 'starts', 'containedIn', 'unique'],
   Boolean: ['exists', 'dne', 'eq', 'neq', 'containedIn', 'unique'],
   Number: ['exists', 'dne', 'eq', 'neq', 'lt', 'lte', 'gt', 'gte', 'containedIn', 'unique'],
-  String: ['exists', 'dne', 'eq', 'neq', 'starts', 'ends', 'matches', 'containedIn', 'unique'],
+  String: [
+    'exists',
+    'dne',
+    'eq',
+    'neq',
+    'starts',
+    'ends',
+    'matches',
+    'contains',
+    'containedIn',
+    'unique',
+  ],
   Date: [
     'exists',
     'dne',

--- a/src/lib/queryFromFilters.js
+++ b/src/lib/queryFromFilters.js
@@ -232,6 +232,9 @@ export function addConstraintFromValues(query, field, constraint, compareTo, mod
     case 'matches':
       query.matches(field, String(compareTo), modifiers);
       break;
+    case 'contains':
+      query.contains(field, String(compareTo));
+      break;
     case 'keyExists':
       query.exists(field + '.' + compareTo);
       break;

--- a/src/lib/tests/queryFromFilters.test.js
+++ b/src/lib/tests/queryFromFilters.test.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2016-present, Parse, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+jest.dontMock('../queryFromFilters');
+
+const { addConstraintFromValues } = require('../queryFromFilters');
+const Parse = require('parse');
+
+function whereFor(field, constraint, compareTo, modifiers) {
+  const query = new Parse.Query('Test');
+  addConstraintFromValues(query, field, constraint, compareTo, modifiers);
+  return query.toJSON().where;
+}
+
+describe('addConstraintFromValues contains constraint', () => {
+  it('matches a plain substring literally', () => {
+    expect(whereFor('name', 'contains', 'foo')).toEqual({
+      name: { $regex: '\\Qfoo\\E' },
+    });
+  });
+
+  it('escapes regex metacharacters so they match literally', () => {
+    expect(whereFor('name', 'contains', 'a.b(c)')).toEqual({
+      name: { $regex: '\\Qa.b(c)\\E' },
+    });
+  });
+
+  it('keeps matches as a raw, unescaped regex with modifiers', () => {
+    expect(whereFor('name', 'matches', 'a.b(c)', 'i')).toEqual({
+      name: { $regex: 'a.b(c)', $options: 'i' },
+    });
+  });
+});


### PR DESCRIPTION
Closes #2153

### Problem

For a String column, the only substring-style filter is **matches regex**, which passes the input to `Parse.Query#matches` verbatim as a regular expression. Regex metacharacters therefore have special meaning: `.` matches any character, and metacharacters like `(` are invalid on their own, so a plain literal search either returns the wrong rows or fails with a server error. There is no way to do a simple literal substring search.

### Fix

Add a separate **contains substring** operator for String fields, backed by the SDK's `Parse.Query#contains`, which wraps the input in `\Q...\E` so the whole value is matched literally (the same quoting `startsWith` / `endsWith` already use). The existing **matches regex** operator is unchanged, so raw regex remains available.

The "rename the confusing operator" half of the issue was already handled in #2991 (the old mislabelled entry was replaced by the explicit **matches regex**), so this PR only adds the new safe operator. This does not touch the Array-field labels discussed in #2052.

Unit test added in `src/lib/tests/queryFromFilters.test.js` covering literal substring matching, metacharacter escaping, and a contrast asserting `matches` stays a raw regex.

### The new operator

The String field condition list now offers **contains substring** below **matches regex**:

![new option](https://raw.githubusercontent.com/dblythy/parse-dashboard/qa-assets-2153/qa/2153/after-dropdown-new-option.png)

### Literal `.` (data: `a(b`, `c.d`, `hello`, `world`)

**matches regex** treats `.` as a wildcard and returns every row:

![matches regex dot](https://raw.githubusercontent.com/dblythy/parse-dashboard/qa-assets-2153/qa/2153/contrast-matches-regex-dot.png)

**contains substring** matches `.` literally and returns only `c.d`:

![contains dot](https://raw.githubusercontent.com/dblythy/parse-dashboard/qa-assets-2153/qa/2153/after-contains-dot-literal.png)

### Literal `a(b`

**matches regex** with `a(b` is an invalid regular expression, so the query fails (500) and nothing is shown:

![matches regex paren](https://raw.githubusercontent.com/dblythy/parse-dashboard/qa-assets-2153/qa/2153/contrast-matches-paren-error.png)

**contains substring** with `a(b` matches the parenthesis literally and returns the correct row:

![contains paren](https://raw.githubusercontent.com/dblythy/parse-dashboard/qa-assets-2153/qa/2153/after-contains-paren-result.png)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new string filter option, allowing substring matching in queries.
  * Expanded the available string constraint list to include the new option.

* **Bug Fixes**
  * Query filtering now correctly applies substring matching when this new constraint is used.
  * Added test coverage to ensure substring and regex-based filters behave as expected, including literal handling of special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->