### PR TITLE
fix: Prepend mount path to new-window links so they work under a subpath

### DIFF
--- a/src/components/AggregationPanel/AggregationPanelComponents.js
+++ b/src/components/AggregationPanel/AggregationPanelComponents.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import copy from 'copy-to-clipboard';
 import Icon from 'components/Icon/Icon.react';
+import generatePath from 'lib/generatePath';
 import styles from './AggregationPanel.scss';
 
 // Text Element Component
@@ -26,7 +27,11 @@ export const KeyValueElement = ({ item, appName, style, showNote }) => {
   const renderValue = ({ value, url, isRelativeUrl }) => {
     if (url) {
       return (
-        <a href={isRelativeUrl ? `apps/${appName}/${url}` : url} target="_blank" rel="noreferrer">
+        <a
+          href={isRelativeUrl ? generatePath({ slug: appName }, url, true) : url}
+          target="_blank"
+          rel="noreferrer"
+        >
           {value}
         </a>
       );

--- a/src/components/PermissionsDialog/PermissionsDialog.react.js
+++ b/src/components/PermissionsDialog/PermissionsDialog.react.js
@@ -955,7 +955,8 @@ export default class PermissionsDialog extends React.Component {
     ]);
     return generatePath(
       this.context,
-      `browser/${className}?filters=${encodeURIComponent(filters)}`
+      `browser/${className}?filters=${encodeURIComponent(filters)}`,
+      true
     );
   }
 

--- a/src/dashboard/Data/Views/Views.react.js
+++ b/src/dashboard/Data/Views/Views.react.js
@@ -447,10 +447,9 @@ class Views extends TableView {
               url.match(/<script/i)
             ) {
               url = '#';
-            } else {
-              url = value.isRelativeUrl
-                ? `apps/${this.context.slug}/${url}${value.urlQuery ? `?${new URLSearchParams(value.urlQuery).toString()}` : ''}`
-                : url;
+            } else if (value.isRelativeUrl) {
+              const query = value.urlQuery ? `?${new URLSearchParams(value.urlQuery).toString()}` : '';
+              url = generatePath(this.context, `${url}${query}`, true);
             }
             // Sanitize text
             let text = value.text;

--- a/src/lib/tests/generatePath.test.js
+++ b/src/lib/tests/generatePath.test.js
@@ -1,0 +1,43 @@
+/**
+ * @jest-environment jsdom
+ */
+/*
+ * Copyright (c) 2016-present, Parse, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+jest.dontMock('../generatePath');
+
+function loadGeneratePath(mountPath) {
+  if (mountPath === undefined) {
+    delete window.PARSE_DASHBOARD_PATH;
+  } else {
+    window.PARSE_DASHBOARD_PATH = mountPath;
+  }
+  let generatePath;
+  jest.isolateModules(() => {
+    generatePath = require('../generatePath').default;
+  });
+  return generatePath;
+}
+
+const app = { slug: 'myApp' };
+
+describe('generatePath', () => {
+  it('returns a root-relative path by default, regardless of mount path', () => {
+    const generatePath = loadGeneratePath('/dashboard/');
+    expect(generatePath(app, 'browser/_User')).toBe('/apps/myApp/browser/_User');
+  });
+
+  it('prepends the mount path when prependMountPath is true and a mount path is set', () => {
+    const generatePath = loadGeneratePath('/dashboard/');
+    expect(generatePath(app, 'browser/_User', true)).toBe('/dashboard/apps/myApp/browser/_User');
+  });
+
+  it('falls back to a root-relative path when prependMountPath is true but no mount path is set', () => {
+    const generatePath = loadGeneratePath(undefined);
+    expect(generatePath(app, 'browser/_User', true)).toBe('/apps/myApp/browser/_User');
+  });
+});


### PR DESCRIPTION
Closes #2441

## Problem

When the dashboard is mounted under a subpath (e.g. `/parse` or `/dashboard`), links that open in a **new browser tab/window** point at `origin + /apps/<slug>/...` and drop the mount path, so the new tab lands on a "Cannot GET" / wrong page. Same-window navigation is fine because it goes through react-router, whose `<BrowserRouter basename={window.PARSE_DASHBOARD_PATH}>` prepends the mount path automatically. New-window links (`window.open`, `<a target="_blank">`) bypass react-router and need the mount path applied explicitly.

`generatePath()` already gained a `prependMountPath` flag in #2527, and the data-browser pointer cmd-click already passes it. This PR fixes the remaining new-window links that still omit it:

- `PermissionsDialog.urlForKey` (ACL/CLP user & role links; the exact regression introduced by #2436).
- `AggregationPanelComponents` info-panel relative links.
- `Views` custom-view "Link" column.

## Fix

Route each of those new-window links through the existing mount-path-aware helper `generatePath(app, path, true)`, which prefixes `window.PARSE_DASHBOARD_PATH` (and falls back to a root-relative path when the dashboard is mounted at `/`).

## Verification

Local stack with the dashboard mounted at `/dashboard`. In the data browser: open a class, then Security → Class Level Permissions, add a user, and click the user link (opens a new tab).

The permissions dialog link (identical before and after; only the underlying `href` differs):

![Class Level Permissions dialog with the user link](https://raw.githubusercontent.com/dblythy/parse-dashboard/qa-assets-2441/qa/2441/after-01-dialog-link.png)

**Before:** the link `href` is `/apps/QA2441/browser/_User?...` (no mount path), so the new tab fails:

![Before: Cannot GET /apps/QA2441/browser/_User](https://raw.githubusercontent.com/dblythy/parse-dashboard/qa-assets-2441/qa/2441/before-02-newtab-404.png)

**After:** the link `href` is `/dashboard/apps/QA2441/browser/_User?...`, so the new tab opens the correct filtered browser:

![After: the _User browser correctly filtered to the user](https://raw.githubusercontent.com/dblythy/parse-dashboard/qa-assets-2441/qa/2441/after-02-newtab-correct.png)

Same-window navigation (sidebar class links, normal pointer click) continues to work under the subpath. Added `src/lib/tests/generatePath.test.js` covering the helper contract (default returns a root-relative path; `prependMountPath=true` prepends the mount path, falling back to root-relative when unset).
