### PR TITLE
fix: Whitelist app config fields sent to the client

### DIFF
--- a/Parse-Dashboard/app.js
+++ b/Parse-Dashboard/app.js
@@ -10,6 +10,50 @@ const Parse = require('parse/node');
 
 let newFeaturesInLatestVersion = [];
 
+const CLIENT_APP_FIELDS = [
+  'appId',
+  'appName',
+  'appNameForURL',
+  'dashboardURL',
+  'created_at',
+  'clientKey',
+  'javascriptKey',
+  'masterKey',
+  'maintenanceKey',
+  'restKey',
+  'windowsKey',
+  'webhookKey',
+  'apiKey',
+  'fileKey',
+  'serverURL',
+  'serverInfo',
+  'production',
+  'iconName',
+  'primaryBackgroundColor',
+  'secondaryBackgroundColor',
+  'supportedPushLocales',
+  'preventSchemaEdits',
+  'preventDataExport',
+  'graphQLServerURL',
+  'columnPreference',
+  'classPreference',
+  'scripts',
+  'enableSecurityChecks',
+  'cloudConfigHistoryLimit',
+  'config',
+  'infoPanel',
+];
+
+function sanitizeAppForClient(app) {
+  const sanitized = {};
+  for (const field of CLIENT_APP_FIELDS) {
+    if (field in app) {
+      sanitized[field] = app[field];
+    }
+  }
+  return sanitized;
+}
+
 /**
  * Gets the new features in the latest version of Parse Dashboard.
  */
@@ -189,7 +233,7 @@ module.exports = function(config, options) {
           response.apps = processedApps.filter((app) => app !== null);
         }
         // They provided correct auth
-        return res.json(response);
+        return res.json({ ...response, apps: response.apps.map(sanitizeAppForClient) });
       }
 
       if (users) {
@@ -209,7 +253,7 @@ module.exports = function(config, options) {
           })
         );
 
-        return res.json(response);
+        return res.json({ ...response, apps: response.apps.map(sanitizeAppForClient) });
       }
       //We shouldn't get here. Fail closed.
       res.send({ success: false, error: 'Something went wrong.' });

--- a/src/lib/tests/dashboardConfig.test.js
+++ b/src/lib/tests/dashboardConfig.test.js
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2016-present, Parse, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+jest.dontMock('../../../Parse-Dashboard/Authentication.js');
+jest.dontMock('../../../Parse-Dashboard/app.js');
+
+const express = require('express');
+const http = require('http');
+
+function getConfig(port) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { hostname: '127.0.0.1', port, path: '/parse-dashboard-config.json', method: 'GET' },
+      res => {
+        let data = '';
+        res.on('data', chunk => (data += chunk));
+        res.on('end', () => {
+          let body = null;
+          try {
+            body = JSON.parse(data);
+          } catch {
+            body = data;
+          }
+          resolve({ status: res.statusCode, body });
+        });
+      }
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+describe('/parse-dashboard-config.json app field whitelist', () => {
+  let server;
+  let port;
+
+  // A circular object, as produced by a real filesAdapter instance (e.g. a Mongo topology).
+  const filesAdapter = {};
+  filesAdapter.self = filesAdapter;
+
+  const dashboardConfig = {
+    apps: [
+      {
+        appId: 'testAppId',
+        appName: 'TestApp',
+        masterKey: 'testMasterKey',
+        serverURL: 'http://localhost:1337/parse',
+        infoPanel: [{ title: 'Panel', classes: ['_User'], cloudCodeFunction: 'fn' }],
+        config: { className: '_User' },
+        // Server-only fields a user may have pasted from their Parse Server config:
+        readOnlyMasterKey: 'testReadOnlyMasterKey',
+        masterKeyTtl: 3600,
+        databaseURI: 'mongodb://localhost:27017/dev',
+        filesAdapter,
+      },
+    ],
+  };
+
+  beforeAll(done => {
+    const parseDashboard = require('../../../Parse-Dashboard/app.js');
+    const dashboardApp = parseDashboard(dashboardConfig, {
+      cookieSessionSecret: 'test-secret',
+      dev: true,
+    });
+    const parentApp = express();
+    parentApp.use('/', dashboardApp);
+    server = parentApp.listen(0, () => {
+      port = server.address().port;
+      done();
+    });
+  });
+
+  afterAll(done => {
+    if (server) {
+      server.close(done);
+    } else {
+      done();
+    }
+  });
+
+  it('responds without crashing when an app config contains a circular filesAdapter', async () => {
+    const res = await getConfig(port);
+    expect(res.status).toBe(200);
+  });
+
+  it('sends the whitelisted client fields', async () => {
+    const { body } = await getConfig(port);
+    const app = body.apps[0];
+    expect(app.appId).toBe('testAppId');
+    expect(app.appName).toBe('TestApp');
+    expect(app.masterKey).toBe('testMasterKey');
+    expect(app.serverURL).toBe('http://localhost:1337/parse');
+    expect(app.infoPanel).toEqual([
+      { title: 'Panel', classes: ['_User'], cloudCodeFunction: 'fn' },
+    ]);
+    expect(app.config).toEqual({ className: '_User' });
+  });
+
+  it('strips server-only fields from the response', async () => {
+    const { body } = await getConfig(port);
+    const app = body.apps[0];
+    expect(app).not.toHaveProperty('filesAdapter');
+    expect(app).not.toHaveProperty('databaseURI');
+    expect(app).not.toHaveProperty('readOnlyMasterKey');
+    expect(app).not.toHaveProperty('masterKeyTtl');
+  });
+});


### PR DESCRIPTION
Closes #1517

## Problem

`/parse-dashboard-config.json` (`Parse-Dashboard/app.js`) sends a shallow copy of each app object to the browser:

```js
const apps = config.apps.map((app) => Object.assign({}, app)); // make a copy
```

Many users reuse their Parse Server config as the dashboard app config, so `apps[]` often carries server-only fields. This has two consequences:

1. **Crash:** a `filesAdapter` instance holds circular references (e.g. a Mongo topology), so `res.json` throws `TypeError: Converting circular structure to JSON` and the whole dashboard fails to load with a "Server Error".
2. **Leak:** every server-only field the user pasted (including `readOnlyMasterKey`, `databaseURI`) is shipped to the browser even though the client never reads them.

## Fix

Send only a whitelist of the per-app fields the client actually consumes. The whitelist is the union of what `src/lib/ParseApp.js` destructures, the raw `infoPanel` read directly in `Browser.react.js`, and the documented app options in the README. The projection is applied at send time (after the existing read-only `masterKey` resolution, which still needs `readOnlyMasterKey`/`masterKeyTtl`), so those server-only fields are used for shaping but never sent.

This fixes the circular-JSON crash and stops leaking server-only fields. `readOnlyMasterKey` and `masterKeyTtl` are now stripped from the payload (intentional tightening; the client never read them).

Note: the whitelist includes both `apiKey` and `fileKey` because the README documents the option as `fileKey` while `ParseApp.js` destructures `apiKey`. That naming mismatch is pre-existing and left as-is here.

## Verification

Added `src/lib/tests/dashboardConfig.test.js` (red→green against the real `app.js` server): with a circular `filesAdapter` in the config, it asserts the endpoint responds `200`, includes the whitelisted client fields, and omits `filesAdapter`/`databaseURI`/`readOnlyMasterKey`/`masterKeyTtl`.

Runtime, same app config with a circular `filesAdapter`:

**Before:** `GET /parse-dashboard-config.json` returns `500` (`Converting circular structure to JSON`), and the dashboard fails to load:

![Before: Server Error](https://raw.githubusercontent.com/dblythy/parse-dashboard/qa-assets-1517/qa/1517/before-dashboard-broken.png)

**After:** the endpoint returns `200` with only whitelisted fields, and the dashboard loads:

![After: dashboard loads the app](https://raw.githubusercontent.com/dblythy/parse-dashboard/qa-assets-1517/qa/1517/after-dashboard-loads.png)

(The "Server not reachable" note in the after image is only because no Parse Server backend was running for this QA; it is unrelated to the config fix, which is what loaded the app.)
