### PR TITLE
fix: Render Date value in non-Date column instead of crashing (#1927)

### DIFF
--- a/src/components/BrowserCell/BrowserCell.react.js
+++ b/src/components/BrowserCell/BrowserCell.react.js
@@ -148,12 +148,13 @@ export default class BrowserCell extends Component {
         this.copyableValue = content = JSON.stringify(this.props.value);
       }
     } else if (this.props.type === 'Date') {
-      if (typeof value === 'object' && this.props.value.__type) {
-        this.props.value = new Date(this.props.value.iso);
-      } else if (typeof value === 'string') {
-        this.props.value = new Date(this.props.value);
+      let dateValue = this.props.value;
+      if (typeof dateValue === 'object' && dateValue.__type) {
+        dateValue = new Date(dateValue.iso);
+      } else if (typeof dateValue === 'string') {
+        dateValue = new Date(dateValue);
       }
-      this.copyableValue = content = dateStringUTC(this.props.value);
+      this.copyableValue = content = dateStringUTC(dateValue);
     } else if (this.props.type === 'Boolean') {
       this.copyableValue = content = this.props.value ? 'True' : 'False';
     } else if (this.props.type === 'Object' || this.props.type === 'Bytes') {
@@ -206,6 +207,8 @@ export default class BrowserCell extends Component {
         'Relation'
       );
       this.copyableValue = undefined;
+    } else if (this.props.value instanceof Date) {
+      this.copyableValue = content = dateStringUTC(this.props.value);
     }
     this.onContextMenu = this.onContextMenu.bind(this);
 

--- a/src/lib/tests/BrowserCell.test.js
+++ b/src/lib/tests/BrowserCell.test.js
@@ -49,4 +49,26 @@ describe('BrowserCell', () => {
       expect(component.props.className).toContain('required');
     });
   });
+
+  describe('Date value in a non-Date column (issue #1927)', () => {
+    it('should render a Date value as a string instead of crashing', () => {
+      let component;
+      expect(() => {
+        component = renderer
+          .create(<BrowserCell type="String" value={new Date('2001-01-01T00:00:00Z')} row={0} />)
+          .toJSON();
+      }).not.toThrow();
+      expect(typeof component.children[0]).toBe('string');
+    });
+
+    it('should render a Date-typed column given a date string without crashing', () => {
+      let component;
+      expect(() => {
+        component = renderer
+          .create(<BrowserCell type="Date" value="2001-01-01" row={0} />)
+          .toJSON();
+      }).not.toThrow();
+      expect(typeof component.children[0]).toBe('string');
+    });
+  });
 });


### PR DESCRIPTION
Closes #1927

## Problem

If a column named `expiresAt` is added to a class with a type other than Date (e.g. String) and given a value, the data browser renders a blank/white page. The console shows:

```
Minified React error #31 … args[]=Sun Dec 31 2000 16:00:00 GMT-0800 (Pacific Standard Time)
```

React error #31 is "Objects are not valid as a React child": a `Date` object is being rendered directly into JSX.

## Root cause

`expiresAt` is a reserved Parse field name. Parse Server coerces it to a Date on read regardless of the column type the schema declares:

```
GET /parse/classes/TestClass
→ "expiresAt": { "__type": "Date", "iso": "2001-01-01T00:00:00.000Z" }   // schema says String
```

The Parse JS SDK decodes that into a real `Date` instance, so the data browser receives `value = <Date>` while the cell's `type` prop is `String`. `BrowserCell.renderCellContent()` keys its whole if/else chain off `this.props.type` and has no default branch, so for `type === 'String'` nothing matches and the raw `Date` object is set as the cell content and rendered as a JSX child, crashing the tree.

## Fix

`src/components/BrowserCell/BrowserCell.react.js`:

1. Render a `Date` value as a formatted string (via the existing `dateStringUTC` helper) even when the declared column type is not `Date`, so a Date reaching a non-Date column no longer crashes.
2. While here, fix a latent bug in the `type === 'Date'` branch: its guards tested an out-of-scope `value` variable (always `undefined`), so the `{__type:'Date', iso}` / string conversions were dead code and mutated the read-only `this.props.value`. It now uses a local variable, so a Date-typed column given a `{__type}`/string value is handled instead of throwing.

## Verification

Added `src/lib/tests/BrowserCell.test.js` cases (red→green): a Date value in a non-Date column renders as a string without throwing, and a Date-typed column given a date string renders without throwing.

Runtime, class with a String `expiresAt` column and value `"2001-01-01"`:

**Before:** opening the class blanks the whole page; console logs `Objects are not valid as a React child (found: Mon Jan 01 2001 …)`:

![Before: blank page](https://raw.githubusercontent.com/dblythy/parse-dashboard/qa-assets-1927/qa/1927/before-crash.png)

**After:** the browser loads and the `expiresAt` cell shows the formatted date; no console errors:

![After: dashboard loads, expiresAt cell renders](https://raw.githubusercontent.com/dblythy/parse-dashboard/qa-assets-1927/qa/1927/after-fixed.png)
