### PR TITLE
fix: Add delete control for file fields in the edit dialog (#1832)

### DIFF
--- a/src/components/FileEditor/FileEditor.react.js
+++ b/src/components/FileEditor/FileEditor.react.js
@@ -20,9 +20,7 @@ export default class FileEditor extends React.Component {
 
     this.checkExternalClick = this.checkExternalClick.bind(this);
     this.handleKey = this.handleKey.bind(this);
-    this.removeFile = this.removeFile.bind(this);
     this.inputRef = React.createRef();
-    this.fileInputRef = React.createRef();
   }
 
   componentDidMount() {
@@ -62,11 +60,6 @@ export default class FileEditor extends React.Component {
     });
   }
 
-  removeFile() {
-    this.fileInputRef.current.value = '';
-    this.props.onCommit(undefined);
-  }
-
   async handleChange(e) {
     const file = e.target.files[0];
     if (file) {
@@ -84,12 +77,7 @@ export default class FileEditor extends React.Component {
         className={styles.editor}
       >
         <a className={styles.upload}>
-          <input
-            ref={this.fileInputRef}
-            id="fileInput"
-            type="file"
-            onChange={this.handleChange.bind(this)}
-          />
+          <input id="fileInput" type="file" onChange={this.handleChange.bind(this)} />
           <span>{file ? 'Replace file' : 'Upload file'}</span>
         </a>
       </div>

--- a/src/dashboard/Data/Browser/EditRowDialog.react.js
+++ b/src/dashboard/Data/Browser/EditRowDialog.react.js
@@ -354,6 +354,9 @@ export default class EditRowDialog extends React.Component {
                   value={file ? 'Change file' : 'Select file'}
                   onClick={() => this.openFileEditor(name)}
                 />
+                {file && (
+                  <Pill value="Delete file" onClick={() => this.handleChange(undefined, name)} />
+                )}
                 {this.state.showFileEditor === name && (
                   <FileEditor
                     value={file}

--- a/src/lib/tests/EditRowDialog.test.js
+++ b/src/lib/tests/EditRowDialog.test.js
@@ -1,0 +1,76 @@
+/**
+ * @jest-environment jsdom
+ */
+/*
+ * Copyright (c) 2016-present, Parse, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+jest.dontMock('../../dashboard/Data/Browser/EditRowDialog.react');
+jest.mock('../../dashboard/Data/Browser/ObjectPickerDialog.react', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+import React from 'react';
+import ShallowRenderer from 'react-test-renderer/shallow';
+const EditRowDialog = require('../../dashboard/Data/Browser/EditRowDialog.react').default;
+
+function findElements(node, predicate, found = []) {
+  if (Array.isArray(node)) {
+    node.forEach(child => findElements(child, predicate, found));
+    return found;
+  }
+  if (!node || typeof node !== 'object' || !node.props) {
+    return found;
+  }
+  if (predicate(node)) {
+    found.push(node);
+  }
+  Object.keys(node.props).forEach(key => {
+    findElements(node.props[key], predicate, found);
+  });
+  return found;
+}
+
+function render(selectedObject, updateRow = () => {}) {
+  const renderer = new ShallowRenderer();
+  renderer.render(
+    <EditRowDialog
+      className="TestClass"
+      columns={[{ name: 'photo', type: 'File' }]}
+      schema={{}}
+      useMasterKey={false}
+      selectedObject={selectedObject}
+      updateRow={updateRow}
+      onClose={() => {}}
+    />
+  );
+  return renderer.getRenderOutput();
+}
+
+const fileStub = () => ({ url: () => undefined, name: () => 'photo.png' });
+
+describe('EditRowDialog File field delete control (issue #1832)', () => {
+  it('renders a "Delete file" control when a file is present', () => {
+    const output = render({ row: 0, id: 'abc', photo: fileStub() });
+    const pills = findElements(output, n => n.props.value === 'Delete file');
+    expect(pills.length).toBe(1);
+  });
+
+  it('unsets the file via updateRow when the delete control is clicked', () => {
+    const updateRow = jest.fn();
+    const output = render({ row: 0, id: 'abc', photo: fileStub() }, updateRow);
+    const pill = findElements(output, n => n.props.value === 'Delete file')[0];
+    pill.props.onClick();
+    expect(updateRow).toHaveBeenCalledWith(0, 'photo', undefined);
+  });
+
+  it('does not render a "Delete file" control when there is no file', () => {
+    const output = render({ row: 0, id: 'abc' });
+    const pills = findElements(output, n => n.props.value === 'Delete file');
+    expect(pills.length).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #1832

## Problem

Under the modern UI, a File field in the row **edit modal** can be downloaded and replaced but not
removed with a click. The pre-3.2.0 UI had a Delete button; it was dropped, and the modal offers no
way to unset a file (only the data-browser `Delete` key unsets a field). This matches the issue's
final diagnosis that the modal "behaves differently than the data browser" and needs a per-field
unset affordance.

## Fix

Add a "Delete file" control (a `Pill`, rendered only when a file exists) next to "Change file" in the
`EditRowDialog` File case. It unsets via the existing path: `handleChange(undefined, name)` ->
`updateRow(row, name, undefined)` -> `Parse.Object.unset()` -> save, i.e. exactly the same "unset"
contract the data-browser `Delete` key already uses, so behaviour is consistent.

Also removes the now-superseded dead code in `FileEditor` (`removeFile()` and the `fileInputRef` it
was the sole reader of): that method already did `onCommit(undefined)` but was never wired to
anything, and since `FileEditor` renders `display:none` (it is a headless native-picker trigger),
the delete control belongs in the dialog where the file UI is actually visible.

Scope: the inline data-browser File cell already supports unset via the `Delete` key, so only the
modal needed a click affordance.

## Verification

Added `src/lib/tests/EditRowDialog.test.js` (red->green): asserts the "Delete file" Pill renders only
when a file is present and that clicking it calls `updateRow(row, name, undefined)`.

Runtime, class `TestFiles` with a `photo` File column holding an uploaded file, opened via
Edit > "Edit this row with modal":

**Before:** the File field shows only the download arrow + "Change file"; no way to delete the file.

![Before: no delete control](https://raw.githubusercontent.com/dblythy/parse-dashboard/qa-assets-1832/qa/1832/before-modal-no-delete.png)

**After:** a "Delete file" control appears next to "Change file".

![After: delete control present](https://raw.githubusercontent.com/dblythy/parse-dashboard/qa-assets-1832/qa/1832/after-modal-delete-file.png)

Clicking "Delete file" unsets the field (shows "Select file"; the cell reads "(undefined)" and the
server no longer returns the `photo` key):

![After: file removed](https://raw.githubusercontent.com/dblythy/parse-dashboard/qa-assets-1832/qa/1832/after-deleted-unset.png)
