### PR TITLE
feat: Add dashboard user to job schedule execution description

### DIFF
--- a/src/lib/ParseApp.js
+++ b/src/lib/ParseApp.js
@@ -585,12 +585,22 @@ export default class ParseApp {
     });
   }
 
-  runJob(job) {
+  async runJob(job) {
+    let description = 'Executing from job schedule web console.';
+    try {
+      const response = await fetch(window.PARSE_DASHBOARD_PATH || '/');
+      const dashboardUser = response.headers.get('username');
+      if (dashboardUser) {
+        description = `Executing from job schedule web console by ${dashboardUser}.`;
+      }
+    } catch {
+      // If the dashboard user cannot be determined, fall back to the default description.
+    }
     return Parse._request(
       'POST',
       'jobs',
       {
-        description: 'Executing from job schedule web console.',
+        description,
         input: JSON.parse(job.params || '{}'),
         jobName: job.jobName,
         when: 0,

--- a/src/lib/tests/ParseApp.test.js
+++ b/src/lib/tests/ParseApp.test.js
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment jsdom
+ */
+/*
+ * Copyright (c) 2016-present, Parse, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+jest.dontMock('../ParseApp');
+
+const Parse = require('parse');
+const ParseApp = require('../ParseApp').default;
+
+function newApp() {
+  return new ParseApp({
+    appName: 'test',
+    appId: 'appId',
+    supportedPushLocales: [],
+  });
+}
+
+function mockFetchWithUser(username) {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      headers: { get: header => (header === 'username' ? username : null) },
+    })
+  );
+}
+
+describe('ParseApp.runJob', () => {
+  beforeEach(() => {
+    Parse._request = jest.fn(() => Promise.resolve({}));
+    window.PARSE_DASHBOARD_PATH = '/';
+  });
+
+  it('includes the dashboard user in the description when available', async () => {
+    mockFetchWithUser('alice');
+    await newApp().runJob({ jobName: 'myJob', params: '{}' });
+    expect(Parse._request.mock.calls[0][2].description).toBe(
+      'Executing from job schedule web console by alice.'
+    );
+  });
+
+  it('falls back to the default description when no dashboard user is set', async () => {
+    mockFetchWithUser(null);
+    await newApp().runJob({ jobName: 'myJob', params: '{}' });
+    expect(Parse._request.mock.calls[0][2].description).toBe(
+      'Executing from job schedule web console.'
+    );
+  });
+
+  it('falls back to the default description when the user lookup fails', async () => {
+    global.fetch = jest.fn(() => Promise.reject(new Error('network error')));
+    await newApp().runJob({ jobName: 'myJob', params: '{}' });
+    expect(Parse._request.mock.calls[0][2].description).toBe(
+      'Executing from job schedule web console.'
+    );
+  });
+});


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-dashboard/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-dashboard/blob/alpha/LICENSE).

## Issue

There is currently no way to tell **who** triggered a Cloud Code job from the dashboard. When a job is run manually via *Jobs → Run now*, the resulting `_JobStatus` entry always has the same generic description:

> `Executing from job schedule web console.`

On a dashboard instance shared by several users (dashboard authentication with multiple `users` configured), this makes it impossible to audit which dashboard operator started a given job run.

Closes: <!-- link the issue number if one exists, otherwise remove this line -->

## Approach

Include the currently logged-in **Parse Dashboard** user (the dashboard authentication user, *not* a Parse `_User` of the app) in the job execution description, so the `_JobStatus` record reads:

> `Executing from job schedule web console by <dashboard-user>.`

This provides a simple, built-in level of auditability of job executions triggered from the dashboard.

Implementation details:

- The dashboard user is already exposed by the server as the `username` HTTP response header on the main dashboard route (`Parse-Dashboard/app.js`, `res.append('username', req.user.matchingUsername)`), and is consumed the same way by the sidebar (`src/components/Sidebar/Sidebar.react.js`).
- `ParseApp.runJob` now reads that header and, when present, appends `by <user>` to the job description before posting the job.
- **Backward compatible / safe fallback:** if the dashboard has no authentication configured (no `username` header) or the lookup fails for any reason, the original description `Executing from job schedule web console.` is used unchanged.

## Tasks

- [x] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)

<sub>Note: no user-facing docs describe this internal job description string, so no documentation change is required. The `CHANGELOG` is generated automatically by semantic-release from the commit message, so no manual changelog entry is added.</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Job submissions now include the dashboard username in the job description when available, making submitted jobs easier to identify.
* **Bug Fixes**
  * If the username can’t be read, job submissions now fall back to the standard default description.
  * Improved reliability of job submission behavior when dashboard lookup requests fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->