### PR TITLE
refactor: Pin filing-cabinet typescript to stabilize lockfile regeneration

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,9 @@
   "overrides": {
     "madge": {
       "typescript": "$typescript"
+    },
+    "filing-cabinet": {
+      "typescript": "5.9.3"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
Every open Dependabot PR on this repo currently fails CI at `npm ci` with `Missing: typescript@5.9.3 from lock file` on Node 20/22 and Docker, so none of them can be merged.

### Root cause

The `madge:circular` dev tool pulls this chain: `madge@8.0.0` → `dependency-tree@11` → `filing-cabinet@5.0.3`, and `filing-cabinet` has a hard dependency on `typescript@^5.7.3`. Because the project pins top-level `typescript@6.0.2` (which does not satisfy `^5.7.3`), npm must install a **nested** `filing-cabinet/node_modules/typescript@5.9.3`.

That nested pin is non-deterministic: when Dependabot regenerates `package-lock.json` for any bump, its npm version drops the nested `typescript@5.9.3`, leaving a lock that no longer satisfies `filing-cabinet` — so `npm ci` fails. (`madge@8.0.0` is the latest release and still uses `filing-cabinet@5`; only `filing-cabinet@6`/`dependency-tree@12` accept typescript 6, and no `madge` release ships them yet, so upgrading is not an option.)

### Fix

Pin `filing-cabinet`'s typescript to the exact `5.9.3` it already resolves to, via npm `overrides`, so the nested resolution is deterministic and survives any lock regeneration:

```json
"overrides": {
  "madge": { "typescript": "$typescript" },
  "filing-cabinet": { "typescript": "5.9.3" }
}
```

This is a **package.json-only** change (3 lines) — `package-lock.json` is unchanged, because the base lock already resolves to `5.9.3`; the override just fixes that resolution in place.

### Verification (local, Node 22)

- `npm ci` — passes (the previously-failing command)
- `npm run madge:circular` — `✔ No circular dependency found!`
- No production/runtime dependency is affected (filing-cabinet is dev-only tooling under `madge`)

Once merged, the ~23 stuck Dependabot PRs on this repo can be re-run and merged normally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency constraint to improve consistency and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->