### PR TITLE
refactor: Bump ws from 8.20.0 to 8.21.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,7 @@
         "typescript": "6.0.2",
         "webpack": "5.105.1",
         "webpack-cli": "7.0.2",
-        "ws": "8.20.0",
+        "ws": "8.21.0",
         "yaml": "2.8.3"
       },
       "engines": {
@@ -25241,6 +25241,28 @@
         "node": ">=10"
       }
     },
+    "node_modules/parse-server/node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/parse/node_modules/@babel/runtime": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
@@ -31636,9 +31658,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "typescript": "6.0.2",
     "webpack": "5.105.1",
     "webpack-cli": "7.0.2",
-    "ws": "8.20.0",
+    "ws": "8.21.0",
     "yaml": "2.8.3"
   },
   "scripts": {


### PR DESCRIPTION
Bumps the direct `ws` devDependency from 8.20.0 to 8.21.0.

Replacement for #3373, recreated off the current `alpha` branch so it includes the lockfile-stability fix (#3400). Version is pinned exact, consistent with the repo's dependency pinning convention.

Closes #3373