### PR TITLE
refactor: Bump typescript from 6.0.2 to 6.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
         "semantic-release": "25.0.3",
         "semver": "7.7.4",
         "style-loader": "3.3.1",
-        "typescript": "6.0.2",
+        "typescript": "6.0.3",
         "webpack": "5.105.1",
         "webpack-cli": "7.0.2",
         "ws": "8.20.0",
@@ -30572,9 +30572,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "semantic-release": "25.0.3",
     "semver": "7.7.4",
     "style-loader": "3.3.1",
-    "typescript": "6.0.2",
+    "typescript": "6.0.3",
     "webpack": "5.105.1",
     "webpack-cli": "7.0.2",
     "ws": "8.20.0",


### PR DESCRIPTION
Bumps the direct `typescript` devDependency from 6.0.2 to 6.0.3.

Replacement for #3344, recreated off the current `alpha` branch so it includes the lockfile-stability fix (#3400). Version is pinned exact, consistent with the repo's dependency pinning convention.

Closes #3344