### PR TITLE
refactor: Bump globals from 17.3.0 to 17.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
         "eslint-plugin-jest": "29.15.1",
         "eslint-plugin-react": "7.37.5",
         "get-port": "7.2.0",
-        "globals": "17.3.0",
+        "globals": "17.5.0",
         "http-server": "14.1.1",
         "husky": "9.1.7",
         "jest": "30.0.4",
@@ -17517,9 +17517,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.3.0.tgz",
-      "integrity": "sha512-yMqGUQVVCkD4tqjOJf3TnrvaaHDMYp4VlUSObbkIiuCPe/ofdMBFIAcBbCSRFWOnos6qRiTVStDwqPLUclaxIw==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
+      "integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "eslint-plugin-jest": "29.15.1",
     "eslint-plugin-react": "7.37.5",
     "get-port": "7.2.0",
-    "globals": "17.3.0",
+    "globals": "17.5.0",
     "http-server": "14.1.1",
     "husky": "9.1.7",
     "jest": "30.0.4",


### PR DESCRIPTION
Replaces #3343.

Bumps [globals](https://github.com/sindresorhus/globals) from 17.3.0 to 17.5.0.

### Changes

- **17.4.0**: Updated globals data (sindresorhus/globals#338)
- **17.5.0**: Updated globals data (sindresorhus/globals#342)

### Breaking Changes

None

### Code Changes Required

None — drop-in devDependency data update (list of global identifiers used by ESLint config).

Closes #3343
