### PR TITLE
fix: Advertise localhost instead of 0.0.0.0 in the dashboard startup message

### DIFF
--- a/Parse-Dashboard/server.js
+++ b/Parse-Dashboard/server.js
@@ -191,11 +191,18 @@ module.exports = (options) => {
   // Mount parseDashboard with authentication
   app.use(mountPath, parseDashboard(config.data, dashboardOptions));
 
+  // 0.0.0.0 (IPv4) and :: (IPv6) are bind-all addresses: they are not directly
+  // navigable and browsers do not treat them as a secure context, which breaks
+  // Web APIs the dashboard relies on (e.g. crypto.randomUUID used by the Parse
+  // SDK). Advertise localhost instead so the printed URL actually works.
+  const displayHost = address =>
+    address === '0.0.0.0' || address === '::' ? 'localhost' : address;
+
   let server;
   if(!configSSLKey || !configSSLCert){
     // Start the server.
     server = app.listen(port, host, function () {
-      console.log(`The dashboard is now available at http://${server.address().address}:${server.address().port}${mountPath}`);
+      console.log(`The dashboard is now available at http://${displayHost(server.address().address)}:${server.address().port}${mountPath}`);
 
       // Initialize browser control WebSocket if enabled
       if (browserControlSetup) {
@@ -211,7 +218,7 @@ module.exports = (options) => {
       key: privateKey,
       cert: certificate
     }, app).listen(port, host, function () {
-      console.log(`The dashboard is now available at https://${server.address().address}:${server.address().port}${mountPath}`);
+      console.log(`The dashboard is now available at https://${displayHost(server.address().address)}:${server.address().port}${mountPath}`);
 
       // Initialize browser control WebSocket if enabled
       if (browserControlSetup) {

--- a/src/lib/tests/e2e/dashboard.e2e.test.js
+++ b/src/lib/tests/e2e/dashboard.e2e.test.js
@@ -54,7 +54,7 @@ describe('dashboard e2e', () => {
 describe('Config options', () => {
   it('should start with port option', async () => {
     const result = await startParseDashboardAndGetOutput(['--port', '4041']);
-    expect(result).toContain('The dashboard is now available at http://0.0.0.0:4041/');
+    expect(result).toContain('The dashboard is now available at http://localhost:4041/');
   });
 
   it('should reject to start if config and other options are combined', async () => {


### PR DESCRIPTION
## Summary

The dev server binds to `0.0.0.0` (all interfaces) and prints:

> The dashboard is now available at http://0.0.0.0:4040/

But `0.0.0.0` is not directly navigable and browsers do not treat it as a **secure context** (`window.isSecureContext === false`). That disables Web APIs the dashboard relies on — notably `crypto.randomUUID()`, which the Parse JS SDK uses to generate its `installationId`. So opening the advertised URL fails on the first Parse request with:

> Error: Server not reachable: `crypto.randomUUID is not a function`

## Fix

Map the bind-all addresses (`0.0.0.0` / `::`) to `localhost` when printing the startup URL, so the advertised address works in a browser (`localhost` and `127.0.0.1` are secure contexts). The actual `listen`/bind address is unchanged, so remote reachability is unaffected.

## Verification

| origin | `isSecureContext` | `crypto.randomUUID` |
| --- | --- | --- |
| `http://0.0.0.0:4040` | false | undefined |
| `http://localhost:4040` | true | function |

Updated the existing startup-message e2e assertion accordingly; it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard startup messages now display `localhost` instead of bind-all addresses, making the provided HTTP and HTTPS links clearer and safer to use.
  * Updated dashboard startup validation to reflect the corrected URL display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->