### PR TITLE
refactor: Bump semver from 7.7.4 to 7.8.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
         "sass": "1.99.0",
         "sass-loader": "16.0.7",
         "semantic-release": "25.0.3",
-        "semver": "7.7.4",
+        "semver": "7.8.5",
         "style-loader": "3.3.1",
         "typescript": "6.0.3",
         "webpack": "5.106.2",
@@ -25888,6 +25888,19 @@
         "node": ">=20.19.0 <21 || >=22.13.0 <23 || >=24.1.0 <25"
       }
     },
+    "node_modules/parse-server/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/parse-server/node_modules/ws": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
@@ -29239,9 +29252,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "sass": "1.99.0",
     "sass-loader": "16.0.7",
     "semantic-release": "25.0.3",
-    "semver": "7.7.4",
+    "semver": "7.8.5",
     "style-loader": "3.3.1",
     "typescript": "6.0.3",
     "webpack": "5.106.2",


### PR DESCRIPTION
Closes #3415

## Summary

Bumps [semver](https://github.com/npm/node-semver) from `7.7.4` to `7.8.5`. This replaces the Dependabot PR #3415 with a fork-based branch so CI can run against the upstream workflows.

- **Dependency type:** `devDependency`
- **Update type:** minor (routine)
- **Pin:** exact version (`7.8.5`)

## Changes

- `package.json` — bump `semver` devDependency `7.7.4` → `7.8.5`
- `package-lock.json` — corresponding lockfile update (semver subtree only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development tooling’s semantic versioning dependency to a newer release.
  * Refreshed dependency metadata to keep installed packages consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->