### PR TITLE
refactor: Bump globals from 17.5.0 to 17.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
         "eslint-plugin-jest": "29.15.1",
         "eslint-plugin-react": "7.37.5",
         "get-port": "7.2.0",
-        "globals": "17.5.0",
+        "globals": "17.7.0",
         "http-server": "14.1.1",
         "husky": "9.1.7",
         "jest": "30.0.4",
@@ -18035,9 +18035,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.5.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
-      "integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "eslint-plugin-jest": "29.15.1",
     "eslint-plugin-react": "7.37.5",
     "get-port": "7.2.0",
-    "globals": "17.5.0",
+    "globals": "17.7.0",
     "http-server": "14.1.1",
     "husky": "9.1.7",
     "jest": "30.0.4",


### PR DESCRIPTION
Closes #3420

## Changes
Bumps the `globals` devDependency from 17.5.0 to 17.7.0. `globals` provides metadata about global identifiers for various JS environments, used by ESLint tooling.

## Breaking Changes
None. This is a patch/minor bump to a dev-only dependency that adds/updates global definitions; no runtime or public API impact.

## Code Changes
None required. Only `package.json` and `package-lock.json` are updated to pin the new version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development tooling dependency to a newer version.
  * Refreshed the project’s locked dependency metadata for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->