### PR TITLE
refactor: Bump webpack-cli from 7.0.2 to 7.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -102,7 +102,7 @@
         "style-loader": "3.3.1",
         "typescript": "6.0.3",
         "webpack": "5.106.2",
-        "webpack-cli": "7.0.2",
+        "webpack-cli": "7.2.1",
         "ws": "8.21.0",
         "yaml": "2.8.3"
       },
@@ -2601,9 +2601,9 @@
       }
     },
     "node_modules/@discoveryjs/json-ext": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-1.0.0.tgz",
-      "integrity": "sha512-dDlz3W405VMFO4w5kIP9DOmELBcvFQGmLoKSdIRstBDubKFYwaNHV1NnlzMCQpXQFGWVALmeMORAuiLx18AvZQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-1.1.0.tgz",
+      "integrity": "sha512-Xc3VhU02wqZ1HvHRJUwL09HkZSTvidqY5Ya0NXBSYOxAp+Ln9dcJr9fySI+CkONzP3PekQo9WdzCv0PGER/mOA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15479,9 +15479,9 @@
       }
     },
     "node_modules/envinfo": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.14.0.tgz",
-      "integrity": "sha512-CO40UI41xDQzhLB1hWyqUKgFhs250pNcGbyGKe1l/e4FSaI/+YE4IMG76GDt0In67WLPACIITC+sOi08x4wIvg==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.21.0.tgz",
+      "integrity": "sha512-Lw7I8Zp5YKHFCXL7+Dz95g4CcbMEpgvqZNNq3AmlT5XAV6CgAAk6gyAMqn2zjw08K9BHfcNuKrMiCPLByGafow==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -16845,15 +16845,6 @@
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
-      }
-    },
-    "node_modules/fastest-levenshtein": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
-      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4.9.1"
       }
     },
     "node_modules/fastq": {
@@ -31903,18 +31894,17 @@
       }
     },
     "node_modules/webpack-cli": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-7.0.2.tgz",
-      "integrity": "sha512-dB0R4T+C/8YuvM+fabdvil6QE44/ChDXikV5lOOkrUeCkW5hTJv2pGLE3keh+D5hjYw8icBaJkZzpFoaHV4T+g==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-7.2.1.tgz",
+      "integrity": "sha512-YwSGbcZdfz12DM8JIseVPr3oBb09IgVCVc4vY3oDvZnI/mALTGPAP1QiqOi4/bBLSJrRHaqDIXeHcNA0+G38aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@discoveryjs/json-ext": "^1.0.0",
+        "@discoveryjs/json-ext": "^1.1.0",
         "commander": "^14.0.3",
         "cross-spawn": "^7.0.6",
-        "envinfo": "^7.14.0",
-        "fastest-levenshtein": "^1.0.12",
-        "import-local": "^3.0.2",
+        "envinfo": "^7.21.0",
+        "import-local": "^3.2.0",
         "interpret": "^3.1.1",
         "rechoir": "^0.8.0",
         "webpack-merge": "^6.0.1"
@@ -31930,11 +31920,23 @@
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
+        "js-yaml": "^4.0.0 || ^5.0.0",
+        "json5": "^2.2.3",
+        "toml": "^3.0.0 || ^4.0.0",
         "webpack": "^5.101.0",
         "webpack-bundle-analyzer": "^4.0.0 || ^5.0.0",
-        "webpack-dev-server": "^5.0.0"
+        "webpack-dev-server": "^5.0.0 || ^6.0.0"
       },
       "peerDependenciesMeta": {
+        "js-yaml": {
+          "optional": true
+        },
+        "json5": {
+          "optional": true
+        },
+        "toml": {
+          "optional": true
+        },
         "webpack-bundle-analyzer": {
           "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "style-loader": "3.3.1",
     "typescript": "6.0.3",
     "webpack": "5.106.2",
-    "webpack-cli": "7.0.2",
+    "webpack-cli": "7.2.1",
     "ws": "8.21.0",
     "yaml": "2.8.3"
   },


### PR DESCRIPTION
Closes #3413

## Summary

Bumps the direct devDependency `webpack-cli` from `7.0.2` to `7.2.1`.

## Changes

- `webpack-cli` 7.0.2 -> 7.2.1 (`package.json` + `package-lock.json`).
- Transitive updates confined to the webpack-cli subtree: `@discoveryjs/json-ext` 1.0.0 -> 1.1.0, `envinfo` 7.14.0 -> 7.21.0, and removal of `fastest-levenshtein` (replaced by an in-tree implementation upstream).

## Notes

- Patch/minor release line; no breaking changes reported in the webpack-cli changelog for this range.
- Replacement PR for the Dependabot bump, opened from a fork branch against `alpha`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the webpack command-line tooling to a newer version.
  * Refreshed related build-tool packages and compatibility settings.
  * Removed an unused package from the dependency lockfile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->