### PR TITLE
fix: Prevent Config table crash when a parameter value is null

### DIFF
--- a/src/dashboard/Data/Config/Config.react.js
+++ b/src/dashboard/Data/Config/Config.react.js
@@ -28,6 +28,7 @@ import equal from 'fast-deep-equal';
 import Notification from 'dashboard/Data/Browser/Notification.react';
 import ServerConfigStorage from 'lib/ServerConfigStorage';
 import { prefersServerStorage } from 'lib/StoragePreferences';
+import buildConfigTableData from 'lib/ConfigTableData';
 
 @subscribeTo('Config', 'config')
 class Config extends TableView {
@@ -479,24 +480,7 @@ class Config extends TableView {
       const params = this.props.config.data.get('params');
       const masterKeyOnlyParams = this.props.config.data.get('masterKeyOnly') || {};
       if (params) {
-        data = [];
-        params.forEach((value, param) => {
-          const masterKeyOnly = masterKeyOnlyParams.get(param) || false;
-          const type = typeof value;
-          if (type === 'object' && value !== null && value.__type == 'File') {
-            value = Parse.File.fromJSON(value);
-          } else if (type === 'object' && value !== null && value.__type == 'GeoPoint') {
-            value = new Parse.GeoPoint(value);
-          }
-          data.push({
-            param: param,
-            value: value,
-            masterKeyOnly: masterKeyOnly,
-          });
-        });
-        data.sort((object1, object2) => {
-          return object1.param.localeCompare(object2.param);
-        });
+        data = buildConfigTableData(params, masterKeyOnlyParams);
       }
     }
     return data;

--- a/src/dashboard/Data/Config/Config.react.js
+++ b/src/dashboard/Data/Config/Config.react.js
@@ -483,9 +483,9 @@ class Config extends TableView {
         params.forEach((value, param) => {
           const masterKeyOnly = masterKeyOnlyParams.get(param) || false;
           const type = typeof value;
-          if (type === 'object' && value.__type == 'File') {
+          if (type === 'object' && value !== null && value.__type == 'File') {
             value = Parse.File.fromJSON(value);
-          } else if (type === 'object' && value.__type == 'GeoPoint') {
+          } else if (type === 'object' && value !== null && value.__type == 'GeoPoint') {
             value = new Parse.GeoPoint(value);
           }
           data.push({

--- a/src/dashboard/Data/Config/Config.react.js
+++ b/src/dashboard/Data/Config/Config.react.js
@@ -29,6 +29,7 @@ import Notification from 'dashboard/Data/Browser/Notification.react';
 import ServerConfigStorage from 'lib/ServerConfigStorage';
 import { prefersServerStorage } from 'lib/StoragePreferences';
 import buildConfigTableData from 'lib/ConfigTableData';
+import { Map } from 'immutable';
 
 @subscribeTo('Config', 'config')
 class Config extends TableView {
@@ -478,7 +479,7 @@ class Config extends TableView {
     let data = undefined;
     if (this.props.config.data) {
       const params = this.props.config.data.get('params');
-      const masterKeyOnlyParams = this.props.config.data.get('masterKeyOnly') || {};
+      const masterKeyOnlyParams = this.props.config.data.get('masterKeyOnly') || Map();
       if (params) {
         data = buildConfigTableData(params, masterKeyOnlyParams);
       }

--- a/src/lib/ConfigTableData.js
+++ b/src/lib/ConfigTableData.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2016-present, Parse, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+import Parse from 'parse';
+
+export default function buildConfigTableData(params, masterKeyOnlyParams) {
+  const data = [];
+  params.forEach((value, param) => {
+    const masterKeyOnly = masterKeyOnlyParams.get(param) || false;
+    const type = typeof value;
+    if (type === 'object' && value !== null && value.__type == 'File') {
+      value = Parse.File.fromJSON(value);
+    } else if (type === 'object' && value !== null && value.__type == 'GeoPoint') {
+      value = new Parse.GeoPoint(value);
+    }
+    data.push({
+      param: param,
+      value: value,
+      masterKeyOnly: masterKeyOnly,
+    });
+  });
+  data.sort((object1, object2) => {
+    return object1.param.localeCompare(object2.param);
+  });
+  return data;
+}

--- a/src/lib/ConfigTableData.js
+++ b/src/lib/ConfigTableData.js
@@ -10,7 +10,7 @@ import Parse from 'parse';
 export default function buildConfigTableData(params, masterKeyOnlyParams) {
   const data = [];
   params.forEach((value, param) => {
-    const masterKeyOnly = masterKeyOnlyParams.get(param) || false;
+    const masterKeyOnly = masterKeyOnlyParams?.get?.(param) || false;
     const type = typeof value;
     if (type === 'object' && value !== null && value.__type == 'File') {
       value = Parse.File.fromJSON(value);

--- a/src/lib/tests/Config.tableData.test.js
+++ b/src/lib/tests/Config.tableData.test.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2016-present, Parse, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+jest.mock('../subscribeTo', () => () => Component => Component);
+jest.mock('context/currentApp', () => ({ CurrentApp: {} }), { virtual: true });
+jest.mock('../../dashboard/TableView.react', () => {
+  return class TableView {};
+});
+jest.mock('../../dashboard/Data/Config/ConfigDialog.react', () => () => null);
+jest.mock('../../dashboard/Data/Config/DeleteParameterDialog.react', () => () => null);
+jest.mock('../../dashboard/Data/Config/AddArrayEntryDialog.react', () => () => null);
+jest.mock('../../dashboard/Data/Config/RemoveArrayEntryDialog.react', () => () => null);
+jest.mock('../../dashboard/Data/Browser/Notification.react', () => () => null);
+jest.mock('../../components/Sidebar/SidebarAction', () => {
+  return class SidebarAction {
+    constructor() {}
+  };
+});
+jest.mock('../../components/EmptyState/EmptyState.react', () => () => null);
+jest.mock('../../components/Button/Button.react', () => () => null);
+jest.mock('../../components/Icon/Icon.react', () => () => null);
+jest.mock('../../components/Table/TableHeader.react', () => () => null);
+jest.mock('../../components/Toolbar/Toolbar.react', () => () => null);
+jest.mock('../ServerConfigStorage', () => {
+  return class ServerConfigStorage {};
+});
+jest.mock('../StoragePreferences', () => ({
+  prefersServerStorage: () => false,
+}));
+jest.dontMock('../../dashboard/Data/Config/Config.react');
+
+const { Map } = require('immutable');
+const Config = require('../../dashboard/Data/Config/Config.react').default;
+
+describe('Config.tableData', () => {
+  it('does not throw when a param value is null', () => {
+    const instance = Object.create(Config.prototype);
+    instance.props = {
+      config: {
+        data: Map({
+          params: Map({ nullParam: null, other: 'ok' }),
+          masterKeyOnly: Map(),
+        }),
+      },
+    };
+
+    let data;
+    expect(() => {
+      data = instance.tableData();
+    }).not.toThrow();
+
+    expect(data).toEqual([
+      { param: 'nullParam', value: null, masterKeyOnly: false },
+      { param: 'other', value: 'ok', masterKeyOnly: false },
+    ]);
+  });
+});

--- a/src/lib/tests/Config.tableData.test.js
+++ b/src/lib/tests/Config.tableData.test.js
@@ -23,6 +23,17 @@ describe('buildConfigTableData', () => {
     ]);
   });
 
+  it('tolerates missing masterKeyOnly metadata', () => {
+    const params = Map({ nullParam: null, other: 'ok' });
+
+    expect(() => buildConfigTableData(params, {})).not.toThrow();
+    expect(() => buildConfigTableData(params, undefined)).not.toThrow();
+    expect(buildConfigTableData(params, {})).toEqual([
+      { param: 'nullParam', value: null, masterKeyOnly: false },
+      { param: 'other', value: 'ok', masterKeyOnly: false },
+    ]);
+  });
+
   it('converts serialized File and GeoPoint values', () => {
     const params = Map({
       avatar: {

--- a/src/lib/tests/Config.tableData.test.js
+++ b/src/lib/tests/Config.tableData.test.js
@@ -5,57 +5,50 @@
  * This source code is licensed under the license found in the LICENSE file in
  * the root directory of this source tree.
  */
-jest.mock('../subscribeTo', () => () => Component => Component);
-jest.mock('context/currentApp', () => ({ CurrentApp: {} }), { virtual: true });
-jest.mock('../../dashboard/TableView.react', () => {
-  return class TableView {};
-});
-jest.mock('../../dashboard/Data/Config/ConfigDialog.react', () => () => null);
-jest.mock('../../dashboard/Data/Config/DeleteParameterDialog.react', () => () => null);
-jest.mock('../../dashboard/Data/Config/AddArrayEntryDialog.react', () => () => null);
-jest.mock('../../dashboard/Data/Config/RemoveArrayEntryDialog.react', () => () => null);
-jest.mock('../../dashboard/Data/Browser/Notification.react', () => () => null);
-jest.mock('../../components/Sidebar/SidebarAction', () => {
-  return class SidebarAction {
-    constructor() {}
-  };
-});
-jest.mock('../../components/EmptyState/EmptyState.react', () => () => null);
-jest.mock('../../components/Button/Button.react', () => () => null);
-jest.mock('../../components/Icon/Icon.react', () => () => null);
-jest.mock('../../components/Table/TableHeader.react', () => () => null);
-jest.mock('../../components/Toolbar/Toolbar.react', () => () => null);
-jest.mock('../ServerConfigStorage', () => {
-  return class ServerConfigStorage {};
-});
-jest.mock('../StoragePreferences', () => ({
-  prefersServerStorage: () => false,
-}));
-jest.dontMock('../../dashboard/Data/Config/Config.react');
+jest.dontMock('../ConfigTableData');
 
 const { Map } = require('immutable');
-const Config = require('../../dashboard/Data/Config/Config.react').default;
+const Parse = require('parse');
+const buildConfigTableData = require('../ConfigTableData').default;
 
-describe('Config.tableData', () => {
-  it('does not throw when a param value is null', () => {
-    const instance = Object.create(Config.prototype);
-    instance.props = {
-      config: {
-        data: Map({
-          params: Map({ nullParam: null, other: 'ok' }),
-          masterKeyOnly: Map(),
-        }),
-      },
-    };
+describe('buildConfigTableData', () => {
+  it('keeps null param values without throwing', () => {
+    const params = Map({ nullParam: null, other: 'ok' });
+    const masterKeyOnly = Map();
 
-    let data;
-    expect(() => {
-      data = instance.tableData();
-    }).not.toThrow();
-
-    expect(data).toEqual([
+    expect(() => buildConfigTableData(params, masterKeyOnly)).not.toThrow();
+    expect(buildConfigTableData(params, masterKeyOnly)).toEqual([
       { param: 'nullParam', value: null, masterKeyOnly: false },
       { param: 'other', value: 'ok', masterKeyOnly: false },
     ]);
+  });
+
+  it('converts serialized File and GeoPoint values', () => {
+    const params = Map({
+      avatar: {
+        __type: 'File',
+        name: 'photo.png',
+        url: 'https://example.com/photo.png',
+      },
+      location: {
+        __type: 'GeoPoint',
+        latitude: 40.0,
+        longitude: -30.0,
+      },
+    });
+    const masterKeyOnly = Map({ avatar: true });
+
+    const data = buildConfigTableData(params, masterKeyOnly);
+
+    expect(data).toHaveLength(2);
+    expect(data[0].param).toBe('avatar');
+    expect(data[0].masterKeyOnly).toBe(true);
+    expect(data[0].value).toBeInstanceOf(Parse.File);
+    expect(data[0].value.name()).toBe('photo.png');
+    expect(data[1].param).toBe('location');
+    expect(data[1].masterKeyOnly).toBe(false);
+    expect(data[1].value).toBeInstanceOf(Parse.GeoPoint);
+    expect(data[1].value.latitude).toBe(40.0);
+    expect(data[1].value.longitude).toBe(-30.0);
   });
 });


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-dashboard/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-dashboard/blob/alpha/LICENSE).

## Issue

Cloud Config table crashed when a parameter value was `null`. `typeof null === 'object'`, so `tableData()` accessed `value.__type` and threw before rendering.

## Approach

- Guard File/GeoPoint parsing so null values are skipped (`value !== null` before reading `__type`)
- Extract the table-building logic into a pure `buildConfigTableData` helper so unit tests cover the behavior without React component mocks
- Unit tests cover null, string, File, and GeoPoint parameter values

## Tasks

- [x] Add tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration table rendering to safely handle parameters with `null` values.
  * Correctly converts and displays serialized File and GeoPoint configuration values, preserving `masterKeyOnly` behavior (including defaulting to `false` when metadata is missing).
  * Ensures configuration table entries are consistently ordered by parameter name.
* **Tests**
  * Added Jest coverage for the configuration table data builder, including `null` inputs and proper normalization of File/GeoPoint values and `masterKeyOnly` flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->