### PR TITLE
fix: Creating a push audience crashes the dashboard with a blank page

### DIFF
--- a/src/components/PushAudienceDialog/PushAudienceDialog.react.js
+++ b/src/components/PushAudienceDialog/PushAudienceDialog.react.js
@@ -103,7 +103,9 @@ export default class PushAudienceDialog extends React.Component {
     const field = Object.keys(available)[0];
     this.setState(
       ({ filters }) => ({
-        filters: filters.push(new Map({ field: field, constraint: available[field][0] })),
+        filters: filters.push(
+          new Map({ class: '_Installation', field: field, constraint: available[field][0] })
+        ),
       }),
       this.fetchAudienceSize.bind(this)
     );
@@ -284,7 +286,9 @@ export default class PushAudienceDialog extends React.Component {
         />
         <div className={styles.filter}>
           <Filter
-            schema={this.props.schema}
+            className="_Installation"
+            schema={{ _Installation: this.props.schema }}
+            allClasses={{ _Installation: this.props.schema }}
             filters={this.state.filters}
             onChange={filters => {
               this.setState({ filters }, this.fetchAudienceSize.bind(this));

--- a/src/components/PushAudienceDialog/PushAudienceDialog.react.js
+++ b/src/components/PushAudienceDialog/PushAudienceDialog.react.js
@@ -72,7 +72,9 @@ export default class PushAudienceDialog extends React.Component {
         stateSettings.platforms = deviceType.$in || [];
       }
       if (audienceInfo.filters) {
-        stateSettings.filters = audienceInfo.filters;
+        stateSettings.filters = audienceInfo.filters.map(filter =>
+          filter.get('class') ? filter : filter.set('class', '_Installation')
+        );
       }
       if (audienceInfo.name) {
         stateSettings.audienceName = audienceInfo.name;

--- a/src/lib/Filters.js
+++ b/src/lib/Filters.js
@@ -260,6 +260,9 @@ export function availableFilters(schema, currentFilters, blacklist) {
 
 export function findRelatedClasses(referClass, allClasses, blacklist, currentFilters) {
   const relatedClasses = {};
+  if (!allClasses) {
+    return relatedClasses;
+  }
   if (allClasses[referClass]) {
     const availableForRefer = availableFilters(allClasses[referClass], currentFilters, blacklist);
     if (Object.keys(availableForRefer).length > 0) {

--- a/src/lib/tests/Filters.findRelatedClasses.test.js
+++ b/src/lib/tests/Filters.findRelatedClasses.test.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2016-present, Parse, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+const { findRelatedClasses } = require('../Filters');
+
+describe('findRelatedClasses', () => {
+  it('does not throw and returns an empty object when allClasses is undefined', () => {
+    expect(() => findRelatedClasses(undefined, undefined)).not.toThrow();
+    expect(findRelatedClasses(undefined, undefined, [], undefined)).toEqual({});
+  });
+
+  it('returns the available filters for the referenced class', () => {
+    const allClasses = { _Installation: { deviceType: { type: 'String' } } };
+    const result = findRelatedClasses('_Installation', allClasses, [], undefined);
+    expect(result._Installation).toBeDefined();
+    expect(result._Installation.deviceType).toContain('exists');
+  });
+});

--- a/src/lib/tests/Filters.findRelatedClasses.test.js
+++ b/src/lib/tests/Filters.findRelatedClasses.test.js
@@ -9,8 +9,8 @@ const { findRelatedClasses } = require('../Filters');
 
 describe('findRelatedClasses', () => {
   it('does not throw and returns an empty object when allClasses is undefined', () => {
-    expect(() => findRelatedClasses(undefined, undefined)).not.toThrow();
-    expect(findRelatedClasses(undefined, undefined, [], undefined)).toEqual({});
+    expect(() => findRelatedClasses('_Installation', undefined)).not.toThrow();
+    expect(findRelatedClasses('_Installation', undefined, [], undefined)).toEqual({});
   });
 
   it('returns the available filters for the referenced class', () => {


### PR DESCRIPTION
## Issue

Opening the **Create an audience** dialog blanks the entire dashboard page. It reproduces 100% on any app, from both entry points — `…/push/new` ("Create an audience") and `…/push/audiences` ("Create your first audience") — which mount the same `PushAudienceDialog`, so there is no in-dashboard workaround. (No existing issue found; discovered on 9.2.0.)

The dialog throws at mount, and the uncaught error unmounts the React tree → blank page:

```
TypeError: Cannot read properties of undefined (reading 'undefined')
    at findRelatedClasses  (src/lib/Filters.js:263)   // if (allClasses[referClass])
    at Filter              (src/components/Filter/Filter.react.js)
  in Filter (created by PushAudienceDialog)
```

## Approach

Root cause: the relational-filter refactor (#2576) changed `Filter` to call `findRelatedClasses(className, allClasses, …)` and migrated the data-browser caller (`BrowserFilter`) to pass `className` + `allClasses`, but `PushAudienceDialog` was not updated — it still renders `<Filter schema={…} />` only. With `className` and `allClasses` both `undefined`, `findRelatedClasses` evaluates `allClasses[referClass]` → `undefined[undefined]` → throws.

This PR:

- Passes `className="_Installation"` and an `_Installation`-keyed `schema`/`allClasses` map from `PushAudienceDialog` to `<Filter>` (the audience dialog filters a single class).
- Tags conditions added via **Add a condition** with `class: '_Installation'`, so the condition row's `schema[class][field]` lookup and the audience-size query resolve the field type.
- Guards `findRelatedClasses` against an undefined `allClasses` (defensive; also protects any future single-class caller), with a regression test.

Verified locally against a live Parse Server: the dialog now opens, **Add a condition** produces a working field/constraint row, and AUDIENCE SIZE updates.

## Tasks

- [x] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved push audience filtering by ensuring installation conditions include the correct class identifier and schema, aligning the condition editor with audience size calculations.
  * Prevented audience filter screens from failing when related class information is unavailable.
  * Increased reliability when calculating audience sizes for filtered conditions.
* **Tests**
  * Added Jest coverage for `findRelatedClasses` behavior when class metadata is missing, and for correct related-class resolution when provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->