### PR TITLE
refactor: Bump react-router from 7.18.1 to 7.18.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "react-popper-tooltip": "4.4.2",
         "react-resizable": "4.0.2",
         "react-rnd": "10.5.3",
-        "react-router": "7.18.1",
+        "react-router": "7.18.2",
         "regenerator-runtime": "0.14.1"
       },
       "bin": {
@@ -27676,9 +27676,9 @@
       "license": "0BSD"
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "react-popper-tooltip": "4.4.2",
     "react-resizable": "4.0.2",
     "react-rnd": "10.5.3",
-    "react-router": "7.18.1",
+    "react-router": "7.18.2",
     "regenerator-runtime": "0.14.1"
   },
   "overrides": {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-dashboard/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-dashboard/blob/alpha/LICENSE).

## Issue

Closes #3428

This is a replacement for the Dependabot pull request #3428. Dependabot branches live in the upstream repository and cannot be modified directly, so the same bump is submitted here from a fork to allow the commit message and PR description to follow the repository conventions.

## Approach

Bumps the `react-router` dependency from `7.18.1` to `7.18.2`.

`react-router` is a production dependency of Parse Dashboard and provides the client-side routing for the dashboard UI (route definitions, navigation and URL handling between the dashboard views).

Upstream changes in `react-router` 7.18.2 (patch release, 2026-07-28):

- Hardens the CSRF code paths of the React Server Components (RSC) implementation (remix-run/react-router#15353, backport of the fix for remix-run/react-router#15348).
- No other changes are documented for this release; it contains no features, deprecations or breaking changes.

Parse Dashboard does not use the RSC integration, so this is a routine patch-level upgrade that keeps the dependency current rather than a fix for a dashboard-facing defect.

Scope of the diff:

- Only `package.json` and `package-lock.json` are modified (5 additions / 5 deletions across 2 files).
- The lockfile churn is confined to the `react-router` subtree: the pinned version in the root dependency list plus the `node_modules/react-router` entry (`version`, `resolved`, `integrity`). No transitive dependency versions are added, removed or changed.
- No application source code, configuration or build setup is touched.

## Tasks

- [x] Verified the upstream changelog and release notes for `react-router` 7.18.2

No new tests and no documentation changes are required, as this is a routine dependency version bump that adds no new behavior or public API to Parse Dashboard; the existing test suite covers the affected routing code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated React Router to version 7.18.2.
  * Refreshed locked dependency metadata for consistent installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
