### PR TITLE
feat: Add option `otpAutoSubmit` to control auto-submitting the login form after entering a one-time password

### DIFF
--- a/Parse-Dashboard/app.js
+++ b/Parse-Dashboard/app.js
@@ -1213,6 +1213,7 @@ You have direct access to the Parse database through function calls, so you can 
           <base href="${mountPath}"/>
           <script>
             PARSE_DASHBOARD_PATH = "${mountPath}";
+            PARSE_DASHBOARD_OTP_AUTO_SUBMIT = ${config.otpAutoSubmit === false ? 'false' : 'true'};
           </script>
           <title>Parse Dashboard</title>
         </head>

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ This section provides a comprehensive reference for all Parse Dashboard configur
 | `iconsFolder` | String | No | - | - | - | `"icons"` | Folder for app icons (relative or absolute path) | - |
 | `agent` | Object | No | - | - | `PARSE_DASHBOARD_AGENT` (JSON) | `{...}` | AI agent configuration | [AI Agent Configuration](#ai-agent) |
 | `enableResourceCache` | Boolean | No | `false` | - | - | `true` | Enable browser caching of dashboard resources | - |
+| `otpAutoSubmit` | Boolean | No | `true` | - | - | `false` | Automatically submit the login form once a complete one-time password has been entered | [Multi-Factor Authentication](#multi-factor-authentication-one-time-password) |
 
 
 ##### App Options
@@ -778,6 +779,16 @@ If you create a new user by running `parse-dashboard --createUser`, you will be 
 ```
 
  Parse Dashboard follows the industry standard and supports the common OTP algorithm `SHA-1` by default, to be compatible with most authenticator apps. If you have specific security requirements regarding TOTP characteristics (algorithm, digit length, time period) you can customize them by using the guided configuration mentioned above.
+
+By default, the login form is submitted automatically as soon as a one-time password of the expected length has been entered, so the user does not have to click the login button. If you prefer the user to review the entered one-time password and submit the form manually, set the `otpAutoSubmit` option to `false`:
+
+```json
+{
+  "apps": [{"...": "..."}],
+  "otpAutoSubmit": false,
+  "users": [{"...": "..."}]
+}
+```
 
 ### Running Multiple Dashboard Replicas
 

--- a/src/lib/tests/OtpAutoSubmit.test.js
+++ b/src/lib/tests/OtpAutoSubmit.test.js
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2016-present, Parse, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+jest.dontMock('../../../Parse-Dashboard/Authentication.js');
+jest.dontMock('../../../Parse-Dashboard/app.js');
+
+const express = require('express');
+const http = require('http');
+
+const SESSION_SECRET = 'test-secret';
+
+/**
+ * Fetch the login page, which is the only page that carries the OTP
+ * auto-submit flag.
+ */
+function getLoginPage(port) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { hostname: '127.0.0.1', port, path: '/login', method: 'GET' },
+      res => {
+        let data = '';
+        res.on('data', chunk => (data += chunk));
+        res.on('end', () => resolve({ status: res.statusCode, raw: data }));
+      }
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+/**
+ * Build a dashboard config with users, since the login page is only served
+ * when users are configured.
+ */
+function configWithUsers(overrides = {}) {
+  return {
+    apps: [
+      {
+        serverURL: 'http://localhost:1337/parse',
+        appId: 'testAppId',
+        masterKey: 'testMasterKey',
+        appName: 'TestApp',
+      },
+    ],
+    users: [{ user: 'admin', pass: 'admin' }],
+    ...overrides,
+  };
+}
+
+function startDashboard(config) {
+  return new Promise(resolve => {
+    const parseDashboard = require('../../../Parse-Dashboard/app.js');
+    const parentApp = express();
+    parentApp.use('/', parseDashboard(config, { cookieSessionSecret: SESSION_SECRET }));
+
+    const server = parentApp.listen(0, () => resolve({ server, port: server.address().port }));
+  });
+}
+
+function stopDashboard(server) {
+  return new Promise(resolve => (server ? server.close(resolve) : resolve()));
+}
+
+describe('OTP auto-submit option', () => {
+  let server;
+
+  afterEach(async () => {
+    await stopDashboard(server);
+    server = undefined;
+  });
+
+  it('enables auto-submit when the option is not set', async () => {
+    let port;
+    ({ server, port } = await startDashboard(configWithUsers()));
+
+    const res = await getLoginPage(port);
+
+    expect(res.status).toBe(200);
+    expect(res.raw).toContain('PARSE_DASHBOARD_OTP_AUTO_SUBMIT = true;');
+  });
+
+  it('enables auto-submit when the option is set to true', async () => {
+    let port;
+    ({ server, port } = await startDashboard(configWithUsers({ otpAutoSubmit: true })));
+
+    const res = await getLoginPage(port);
+
+    expect(res.raw).toContain('PARSE_DASHBOARD_OTP_AUTO_SUBMIT = true;');
+  });
+
+  it('disables auto-submit when the option is set to false', async () => {
+    let port;
+    ({ server, port } = await startDashboard(configWithUsers({ otpAutoSubmit: false })));
+
+    const res = await getLoginPage(port);
+
+    expect(res.raw).toContain('PARSE_DASHBOARD_OTP_AUTO_SUBMIT = false;');
+  });
+});

--- a/src/login/Login.js
+++ b/src/login/Login.js
@@ -42,6 +42,10 @@ export default class Login extends React.Component {
     this.inputRefPass = React.createRef();
     this.inputRefMfa = React.createRef();
     this.otpLength = otpLength;
+    // Auto-submitting the login form once the full one-time password has been
+    // entered is enabled by default and can be turned off via the
+    // `otpAutoSubmit` dashboard option.
+    this.otpAutoSubmit = window.PARSE_DASHBOARD_OTP_AUTO_SUBMIT !== false;
   }
 
   componentDidMount() {
@@ -65,7 +69,7 @@ export default class Login extends React.Component {
     const { path } = this.props;
     const updateField = (field, e) => {
       this.setState({ [field]: e.target.value });
-      if (field === 'otp' && e.target.value.length >= this.otpLength) {
+      if (this.otpAutoSubmit && field === 'otp' && e.target.value.length >= this.otpLength) {
         const input = document.querySelectorAll('input');
         for (const field of input) {
           if (field.type === 'submit') {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/parse-dashboard/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/parse-dashboard/blob/alpha/LICENSE).

## Issue

When a user has MFA enabled, the login form is submitted automatically as soon as the entered one-time password reaches the expected length. This was introduced in e5287054 (#2257) and is currently hardcoded with no way to opt out.

That is convenient in the common case, but there is no way to disable it, and the behavior is problematic in a few situations:

- A single mistyped digit submits immediately; the user cannot review or correct the code before submitting.
- The failed attempt causes a full page reload, so the user has to re-enter the one-time password from scratch — and by then the TOTP window may have advanced.
- Assistive technology and password managers that fill the field progressively can trigger a submit mid-fill.

There is currently no configuration option to turn this off.

## Approach

Adds a new root-level dashboard option `otpAutoSubmit` (Boolean, default `true`) that controls whether the login form is auto-submitted once a complete one-time password has been entered.

- **`true` / omitted** — current behavior, unchanged. This is fully backwards compatible; existing installations are not affected.
- **`false`** — the one-time password field no longer triggers a submit; the user submits the form manually.

The option is plumbed to the login page following the existing `enableResourceCache` pattern, which is the established way this repository passes configuration to frontend code:

1. `Parse-Dashboard/app.js` — the `/login` route injects `PARSE_DASHBOARD_OTP_AUTO_SUBMIT` into the page shell, next to the existing `PARSE_DASHBOARD_PATH` global. The check is `config.otpAutoSubmit === false` rather than a truthy test, so that only an explicit `false` disables the feature and any other value (including an absent key) keeps the current default.
2. `src/login/Login.js` — reads the global once in the constructor as `window.PARSE_DASHBOARD_OTP_AUTO_SUBMIT !== false` and adds it to the existing auto-submit guard in `updateField`. Defaulting to `true` when the global is `undefined` keeps the component behaving correctly if it is ever mounted outside the server-rendered shell.

The auto-submit mechanism itself is deliberately left untouched to keep the diff minimal and easy to review; this PR only gates it.

Because the option is a plain root-level config key, it works across all integration styles with no extra plumbing — the Express middleware (`new ParseDashboard({ otpAutoSubmit: false, ... })`), a `--config` file, and the `PARSE_DASHBOARD_CONFIG` environment variable. No new CLI flag or environment variable is introduced.

Example configuration:

```json
{
  "apps": [{ "...": "..." }],
  "otpAutoSubmit": false,
  "users": [
    {
      "user": "user1",
      "pass": "pass",
      "mfa": "lmvmOIZGMTQklhOIhveqkumss"
    }
  ]
}
```

## Tasks

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)

### Tests

`src/lib/tests/OtpAutoSubmit.test.js` mounts the dashboard over a real HTTP server and asserts the value rendered into the login page for all three states — option omitted, `true`, and `false`. It follows the existing `src/lib/tests/RemoteAccess.test.js` pattern.

Note that Jest `roots` is limited to `src/lib` and no jsdom environment is configured for this suite, so the flag is verified at the server-rendered boundary rather than by rendering the React component.

### Documentation

- Added `otpAutoSubmit` to the Root Options table in `README.md`.
- Added a paragraph with an example to the *Multi-Factor Authentication (One-Time Password)* section describing the current auto-submit behavior and how to disable it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `otpAutoSubmit` login configuration option, enabled by default.
  * Administrators can disable automatic form submission after a complete one-time password is entered.

* **Documentation**
  * Documented the new OTP login setting and configuration example.

* **Tests**
  * Added coverage for enabled, disabled, and default OTP auto-submit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
